### PR TITLE
Fix cron issue in WordPress by updating hosts file

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -26,6 +26,13 @@ cp /srv/server-conf/bash_aliases /home/vagrant/.bash_aliases
 printf "\nUse start_config_monitor to begin monitoring config files for changes"
 printf "Use stop_config_monitor to stop monitoring these config files\n\n"
 
+# Your host IP is set in Vagrantfile, but it's nice to see the interfaces anyway.
+# Enter domains space delimited
+DOMAINS='local.wordpress.dev'
+if ! grep -q "$DOMAINS" /etc/hosts
+then echo "127.0.0.1 $DOMAINS" >> /etc/hosts
+fi
+
 # Your host IP is set in Vagrantfile, but it's nice to see the interfaces anyway
 ifconfig | grep "inet addr"
 


### PR DESCRIPTION
Add commands to set the URL you want to use with this 
Vagrant to be 127.0.0.1 in the /etc/hosts file.  This 
allows the webserver to be self-aware and know to look
locally for this domain.  This allows it to call itself
to run wp-cron.  List the domain names you want to use
in DOMAINS.  It checks if that exact record exists in the 
host file and adds it if it does not. 

Future issue to fix:  if you add a new domain to the string,
it will add a new record and leave the old record.  Need to
change this to update the record, or delete the old record...
....or something.  This works fine for now, multiple records 
should not be any problem. 
