### PR TITLE
Turn on html errors

### DIFF
--- a/config/php5-fpm-config/php.ini
+++ b/config/php5-fpm-config/php.ini
@@ -608,7 +608,7 @@ track_errors = Off
 ; Development Value: On
 ; Production value: Off
 ; http://php.net/html-errors
-html_errors = Off
+html_errors = 1
 
 ; If html_errors is set On PHP produces clickable error messages that direct
 ; to a page describing the error or function causing the error in detail.


### PR DESCRIPTION
Turns on html_errors in php.ini, which is required for xdebug's prettified output.
