### PR TITLE
MySQL config support & external user

### DIFF
--- a/config/mysql/my.cnf
+++ b/config/mysql/my.cnf
@@ -1,0 +1,127 @@
+#
+# The MySQL database server configuration file.
+#
+# You can copy this to one of:
+# - "/etc/mysql/my.cnf" to set global options,
+# - "~/.my.cnf" to set user-specific options.
+# 
+# One can use all long options that the program supports.
+# Run program with --help to get a list of available options and with
+# --print-defaults to see which it would actually understand and use.
+#
+# For explanations see
+# http://dev.mysql.com/doc/mysql/en/server-system-variables.html
+
+# This will be passed to all mysql clients
+# It has been reported that passwords should be enclosed with ticks/quotes
+# escpecially if they contain "#" chars...
+# Remember to edit /etc/mysql/debian.cnf when changing the socket location.
+[client]
+port		= 3306
+socket		= /var/run/mysqld/mysqld.sock
+
+# Here is entries for some specific programs
+# The following values assume you have at least 32M ram
+
+# This was formally known as [safe_mysqld]. Both versions are currently parsed.
+[mysqld_safe]
+socket		= /var/run/mysqld/mysqld.sock
+nice		= 0
+
+[mysqld]
+#
+# * Basic Settings
+#
+user		= mysql
+pid-file	= /var/run/mysqld/mysqld.pid
+socket		= /var/run/mysqld/mysqld.sock
+port		= 3306
+basedir		= /usr
+datadir		= /var/lib/mysql
+tmpdir		= /tmp
+lc-messages-dir	= /usr/share/mysql
+skip-external-locking
+#
+# Instead of skip-networking the default is now to listen only on
+# localhost which is more compatible and is not less secure.
+bind-address		= 0.0.0.0
+#
+# * Fine Tuning
+#
+key_buffer		= 16M
+max_allowed_packet	= 16M
+thread_stack		= 192K
+thread_cache_size       = 8
+# This replaces the startup script and checks MyISAM tables if needed
+# the first time they are touched
+myisam-recover         = BACKUP
+#max_connections        = 100
+#table_cache            = 64
+#thread_concurrency     = 10
+#
+# * Query Cache Configuration
+#
+query_cache_limit	= 1M
+query_cache_size        = 16M
+#
+# * Logging and Replication
+#
+# Both location gets rotated by the cronjob.
+# Be aware that this log type is a performance killer.
+# As of 5.1 you can enable the log at runtime!
+#general_log_file        = /var/log/mysql/mysql.log
+#general_log             = 1
+#
+# Error log - should be very few entries.
+#
+log_error = /var/log/mysql/error.log
+#
+# Here you can see queries with especially long duration
+#log_slow_queries	= /var/log/mysql/mysql-slow.log
+#long_query_time = 2
+#log-queries-not-using-indexes
+#
+# The following can be used as easy to replay backup logs or for replication.
+# note: if you are setting up a replication slave, see README.Debian about
+#       other settings you may need to change.
+#server-id		= 1
+#log_bin			= /var/log/mysql/mysql-bin.log
+expire_logs_days	= 10
+max_binlog_size         = 100M
+#binlog_do_db		= include_database_name
+#binlog_ignore_db	= include_database_name
+#
+# * InnoDB
+#
+# InnoDB is enabled by default with a 10MB datafile in /var/lib/mysql/.
+# Read the manual for more InnoDB related options. There are many!
+#
+# * Security Features
+#
+# Read the manual, too, if you want chroot!
+# chroot = /var/lib/mysql/
+#
+# For generating SSL certificates I recommend the OpenSSL GUI "tinyca".
+#
+# ssl-ca=/etc/mysql/cacert.pem
+# ssl-cert=/etc/mysql/server-cert.pem
+# ssl-key=/etc/mysql/server-key.pem
+
+
+
+[mysqldump]
+quick
+quote-names
+max_allowed_packet	= 16M
+
+[mysql]
+#no-auto-rehash	# faster start of mysql but no tab completition
+
+[isamchk]
+key_buffer		= 16M
+
+#
+# * IMPORTANT: Additional settings that can override those from this file!
+#   The files must end with '.cnf', otherwise they'll be ignored.
+#
+!includedir /etc/mysql/conf.d/

--- a/config/watchr.script
+++ b/config/watchr.script
@@ -7,3 +7,4 @@
 watch( 'create-dbs.sql' ) {|md| system("mysql -u root -pblank < /srv/database/create-dbs.sql; ./database/import-sql.sh") }
 watch( 'nginx-config/sites/(.*)\.conf' ) {|md| system("sudo service nginx restart | echo nginx restarted with new configuration for #{md[1]}.conf. Press enter for prompt...") }
 watch( 'php5-fpm-config/(php.ini|www.conf)' ) {|md| system("sudo service php5-fpm restart | echo php5-fpm restart with new configuration for #{md[1]}. Press enter for prompt...") }
+watch( 'mysql/my.cnf' ) {|md| system("sudo cp /srv/config/mysql/my.cnf /etc/mysql/my.cnf | sudo service mysql restart | echo mysql restart with new configuration for #{md[1]}. Press enter for prompt...") }

--- a/database/import-sql.sh
+++ b/database/import-sql.sh
@@ -4,7 +4,7 @@ printf "\nStart DB Import"
 for file in $( ls *.sql )
 do
 pre_dot=${file%%.*}
-echo "mysql -u root -pblank $pre_dot < $pre_dot.sql"
-mysql -u root -pblank "$pre_dot" < $pre_dot.sql
+echo "mysql -u root -pblank < $pre_dot.sql"
+mysql -u root -pblank < $pre_dot.sql
 done
 printf "\nDatabases imported - press return for prompt\n"

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -60,6 +60,9 @@ sudo ln -sf /srv/config/php5-fpm-config/www.conf /etc/php5/fpm/pool.d/www.conf |
 sudo ln -sf /srv/config/php5-fpm-config/php.ini /etc/php5/fpm/php.ini | echo "Linked php.ini to /etc/php5/fpm/"
 sudo ln -sf /srv/config/php5-fpm-config/php.xdebug.ini /etc/php5/fpm/php.xdebug.ini | echo "Linked php.xdebug.ini to /etc/php5/fpm/"
 
+# Copy over the mysql configuration file
+sudo cp /srv/config/mysql/my.cnf /etc/mysql/my.cnf | echo "Linked my.cnf to /etc/mysql/"
+
 # Make sure the services we expect to be running are running
 sudo service nginx restart
 sudo service php5-fpm restart


### PR DESCRIPTION
My commit notes mention everything that happened. This commit needs to be tested on Windows still. It enabled me to use PHPStorm 6 database drivers to connect to vagrant, as well as Sequel Pro, without SSH.
