### PR TITLE
Symlink ack to ack-grep

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -83,6 +83,9 @@ apt-get install --force-yes -y ${apt_package_list[@]}
 # Clean up apt caches
 apt-get clean
 
+# Make ack respond to its real name
+sudo ln -fs /usr/bin/ack-grep /usr/bin/ack
+
 # PEAR PACKAGES
 #
 # Installation for any required PHP PEAR packages


### PR DESCRIPTION
It would be nice to be able to call ack using just `ack` instead of `ack-grep`.
