### PR TITLE
Use the appropriately inconsistent package name

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -51,7 +51,7 @@ apt_package_list=(
 	php5-xdebug
 	php5-mcrypt
 	php5-mysql
-	php5-pear
+	php-pear
 	php5-curl
 	php5-gd
 	php-apc


### PR DESCRIPTION
Unlike almost all the other PHP related packages, PEAR omits the PHP version from the first part of its name.
