### PR TITLE
Adding spf13 config for vim

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -68,7 +68,6 @@ apt_package_list=(
 	make
 	ngrep
 	vim
-    runuser
 
 	# memcached
 	memcached
@@ -115,7 +114,7 @@ yes yes | pecl install memcache # Install requires entering 'yes' once. May chan
 yes yes | pecl install xdebug # Install requires entering 'yes' once. May change.
 
 # Install the spf13 config for vim https://github.com/spf13/spf13-vim and make vim awesome
-curl http://j.mp/spf13-vim3 -L > spf13-vim.sh && sudo -u vagrant -i bash -c 'sh spf13-vim.sh 2>&1 /dev/null'
+curl -s http://j.mp/spf13-vim3 -L > spf13-vim.sh && sudo -u vagrant -i bash -c 'sh spf13-vim.sh 2>&1 /dev/null'
 
 # SYMLINK HOST FILES
 printf "\nLink Directories...\n"


### PR DESCRIPTION
This adds the popular spf13 config for vim, which adds a ton of neat features, like mouse support, function definitions, PHP Docblock building commands, etc. Learn more at https://github.com/spf13/spf13-vim.

This probably shouldn't go into master yet, since it uses something called Vundle (a vim installer) to install bundled plugins. This makes the stdout go a bit funky (it starts using half of terminal instead of all of it). Everything works fine though, and you get much better vim.*

\* Much better vim results may vary. I'm planning to test each of the bundled plugins and remove the ones that we may never need.
