### PR TITLE
Add Mockery's dependency directly to the composer file.

### DIFF
--- a/config/phpunit-composer.json
+++ b/config/phpunit-composer.json
@@ -3,9 +3,28 @@
 	"description": "VVV Global Composer packages",
 	"require": {
 		"phpunit/phpunit": "3.7.*",
-		"mockery/mockery": "dev-master@dev"
+		"mockery/mockery": "dev-master@dev",
+		"hamcrest/hamcrest": "1.1.0"
 	},
 	"config": {
 		"bin-dir": "/usr/local/bin/"
-	}
+	},
+	"repositories": [
+		{
+			"type": "package",
+			"package": {
+				"name": "hamcrest/hamcrest",
+				"version": "1.1.0",
+				"dist": {
+					"type": "zip",
+					"url": "https://hamcrest.googlecode.com/files/hamcrest-php-1.1.0.zip"
+				},
+				"include-path": ["Hamcrest-1.1.0/"],
+				"autoload": {
+					"psr-0": { "Hamcrest_": "Hamcrest-1.1.0/" },
+					"files": ["Hamcrest-1.1.0/Hamcrest/Hamcrest.php"]
+				}
+			}
+		}
+	]
 }


### PR DESCRIPTION
Composer won't load repository definitions that aren't in the main composer.json file, so we need to include it from Mockery's composer.json file
