### PR TITLE
Force .sh line-endings: Defensive fix for Windows provisioning script error

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto
+
+# Force provisioning script to use LF, even on Windows
+*.sh    eol=lf


### PR DESCRIPTION
This should force .sh scripts to be checked out with LF (instead of CRLF) endings ... which should prevent the failed provisioning & shutdown I reported in issue #56 (https://github.com/10up/varying-vagrant-vagrants/issues/56)
