### PR TITLE
Add git workaround for svn issues during provisioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Stuff that pops up locally for me - @jeremyfelt
 *.sublime*
 .DS_Store
+.idea
 
 # Because this really is a working directory, ignore vagrant's files
 .vagrant

--- a/config/wp-cli-custom.php
+++ b/config/wp-cli-custom.php
@@ -1,0 +1,52 @@
+﻿<?php
+
+/**
+ * Custom WP-CLI commands
+ *
+ * Usage (from within a WP directory):
+ * $ wp --require=/path/to/wp-cli-custom.php vvv [function name] [parameters]
+ *
+ * @package wp-cli
+ */
+class VVV_Command extends WP_CLI_Command {
+
+	/**
+	 * Alternate method for setting up the official test suite
+	 * using the current WordPress instance. Uses git instead of svn.
+	 *
+	 * Based on wp-cli 0.9.1
+	 *
+	 * @subcommand init-tests
+	 *
+	 * @synopsis [<path>] --dbname=<name> --dbuser=<user> [--dbpass=<password>]
+	 */
+	function init_tests( $args, $assoc_args ) {
+		if ( isset( $args[0] ) )
+			$tests_dir = trailingslashit( $args[0] );
+		else
+			$tests_dir = ABSPATH . 'unit-tests/';
+
+		//WP_CLI::launch( 'svn co https://unit-test.svn.wordpress.org/trunk/ ' . escapeshellarg( $tests_dir ) );
+		WP_CLI::launch( 'git clone -v https://github.com/kurtpayne/wordpress-unit-tests.git ' . escapeshellarg( $tests_dir ) );
+
+		$config_file = file_get_contents( $tests_dir . 'wp-tests-config-sample.php' );
+
+		$replacements = array(
+			"dirname( __FILE__ ) . '/wordpress/'" => "'" . ABSPATH . "'",
+			"yourdbnamehere" => $assoc_args['dbname'],
+			"yourusernamehere" => $assoc_args['dbuser'],
+			"yourpasswordhere" => isset( $assoc_args['dbpass'] ) ? $assoc_args['dbpass'] : ''
+		);
+
+		$config_file = str_replace( array_keys( $replacements ), array_values( $replacements ), $config_file );
+
+		$config_file_path = $tests_dir . 'wp-tests-config.php';
+
+		file_put_contents( $config_file_path, $config_file );
+
+		WP_CLI::success( "Created $config_file_path" );
+	}
+
+}
+
+WP_CLI::add_command( 'vvv', 'VVV_Command' );

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -232,8 +232,14 @@ if [ ! -f /home/vagrant/flags/disable_wp_trunk ]
 then
 	if [ ! -d /srv/www/wordpress-trunk ]
 	then
-		printf "Checking out WordPress trunk....http://core.svn.wordpress.org/trunk\n"
-		svn checkout http://core.svn.wordpress.org/trunk/ /srv/www/wordpress-trunk
+		if [ ! -f /home/vagrant/flags/use_git_instead ]
+		then
+			printf "Checking out WordPress trunk....http://core.svn.wordpress.org/trunk\n"
+			svn checkout http://core.svn.wordpress.org/trunk/ /srv/www/wordpress-trunk
+		else
+			printf "Cloning WordPress trunk....https://github.com/WordPress/WordPress.git\n"
+			git clone -v https://github.com/WordPress/WordPress.git /srv/www/wordpress-trunk
+		fi
 		cd /srv/www/wordpress-trunk
 		printf "Configuring WordPress trunk...\n"
 		wp core config --dbname=wordpress_trunk --dbuser=wp --dbpass=wp --quiet
@@ -241,7 +247,12 @@ then
 	else
 		printf "Updating WordPress trunk...\n"
 		cd /srv/www/wordpress-trunk
-		svn up --ignore-externals
+		if [ ! -f /home/vagrant/flags/use_git_instead ]
+		then
+			svn up --ignore-externals
+		else
+			git pull -v origin
+		fi
 	fi
 fi
 
@@ -250,14 +261,25 @@ if [ ! -f /home/vagrant/flags/disable_wp_tests ]
 then
 	if [ ! -d /srv/www/wordpress-unit-tests ]
 	then
-		printf "Downloading WordPress Unit Tests.....https://unit-tests.svn.wordpress.org\n"
 		# Must be in a WP directory to run wp
 		cd /srv/www/wordpress-trunk
-		wp core init-tests /srv/www/wordpress-unit-tests --dbname=wordpress_unit_tests --dbuser=wp --dbpass=wp
+		if [ ! -f /home/vagrant/flags/use_git_instead ]
+		then
+			printf "Downloading WordPress Unit Tests.....https://unit-tests.svn.wordpress.org\n"
+			wp core init-tests /srv/www/wordpress-unit-tests --dbname=wordpress_unit_tests --dbuser=wp --dbpass=wp
+		else
+			printf "Downloading WordPress Unit Tests.....https://github.com/kurtpayne/wordpress-unit-tests.git\n"
+			wp --require=/srv/config/wp-cli-custom.php vvv init-tests /srv/www/wordpress-unit-tests --dbname=wordpress_unit_tests --dbuser=wp --dbpass=wp
+		fi
 	else
 		printf "Updating WordPress unit tests...\n"	
 		cd /srv/www/wordpress-unit-tests
-		svn up --ignore-externals
+		if [ ! -f /home/vagrant/flags/use_git_instead ]
+		then
+			svn up --ignore-externals
+		else
+			git pull -v origin
+		fi
 	fi
 fi
 


### PR DESCRIPTION
Some Windows users get errors during provisioning with svn checkout of
WP Trunk and the unit tests. This provides a workaround by adding the
flag use_git_instead.

Addresses https://github.com/10up/varying-vagrant-vagrants/issues/58
