### PR TITLE
Enable STRICT PHP error reporting by default

### DIFF
--- a/config/php5-fpm-config/php.ini
+++ b/config/php5-fpm-config/php.ini
@@ -518,7 +518,7 @@ memory_limit = 128M
 ; Development Value: E_ALL | E_STRICT
 ; Production Value: E_ALL & ~E_DEPRECATED
 ; http://php.net/error-reporting
-error_reporting = E_ALL & ~E_DEPRECATED
+error_reporting = E_ALL | E_STRICT
 
 ; This directive controls whether or not and where PHP will output errors,
 ; notices and warnings too. Error output is very useful during development, but
@@ -640,7 +640,7 @@ html_errors = 1
 ; empty.
 ; http://php.net/error-log
 ; Example:
-;error_log = php_errors.log
+error_log = /tmp/php_errors.log
 ; Log errors to syslog (Event Log on NT, not valid in Windows 95).
 ;error_log = syslog
 


### PR DESCRIPTION
This is a development environment, y'know. It's useful to write errors to `/tmp/php_errors.log` so you can have a window open to see any PHP notices, etc.

One issue I've found: `/tmp/php_error.log` is created as root:root, which means it isn't writable by the webserver. Changing the access permissions fixes this. I think there's some other config declaration I'm missing but I haven't been able to track it down yet.
