### PR TITLE
Agent Forwarding

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,11 @@ Vagrant.configure("2") do |config|
   config.vm.provider :virtualbox do |v|
 	v.customize ["modifyvm", :id, "--memory", 512]
   end
+
+  # Forward Agent
+  #
+  # Enable agent forwarding on vagrant ssh commands
+  config.ssh.forward_agent = true
   
   # Default Ubuntu Box
   #


### PR DESCRIPTION
This by default will enabled agent forwarding, which will allow for things like accessing private GitHub repos the same way you would locally.
