### PR TITLE
Add mu-plugin to fix Nginx permalink issue

### DIFF
--- a/config/wordpress-config/mu-plugins/nginx-permalink-fix.php
+++ b/config/wordpress-config/mu-plugins/nginx-permalink-fix.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Remove `index.php` from permalinks when using Nginx
+ *
+ * If `index.php` is showing up as a level within your permalinks when running
+ * WordPress on Nginx, it can be removed by hooking into 'got_rewrite' and
+ * explicitly forcing WordPress to believe that rewrite is available.
+ *
+ */
+
+function nginx_got_rewrite( $rewrite_available ) {
+    return true;
+}
+add_filter( 'got_rewrite', 'nginx_got_rewrite', 999 );


### PR DESCRIPTION
Because WordPress cannot correctly identify whether rewrite capabilities are enabled on this server setup, "index.php" is getting injected into the top level of the permalink structure (e.g. http://www.mysite.com/index.php/sample-post/). Hooking into WP's `got_rewrite` filter to explicitly specify that rewrites are available removes the issue, as explained in the closing comments for the core Trac ticket 13201 and demonstrated in the code for rtCamp's "Nginx Helper" plugin.

> ![nginx-issue](https://f.cloud.github.com/assets/442115/835934/83a701d0-f2e5-11e2-8b71-bb803d1ad06b.png)
> _the issue_

In the interest of clarify, this plugin uses the simplest possible code (i.e., no plugin Class boilerplate).

References:
- [Trac ticket for Nginx permalink issues](http://core.trac.wordpress.org/ticket/13021#comment:4)
- [Nginx Helper plugin](http://wordpress.org/plugins/nginx-helper/)

Fixes #85
