### PR TITLE
Add call to composer update in wp-cli section, to make sure any new depe...

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -320,6 +320,7 @@ then
 		printf "\nUpdating wp-cli....\n"
 		cd /srv/www/wp-cli
 		git pull --rebase origin master
+		composer update
 	fi
 	# Link `wp` to the `/usr/local/bin` directory
 	ln -sf /srv/www/wp-cli/bin/wp /usr/local/bin/wp


### PR DESCRIPTION
...ndencies are added

I just ran into this error message that was caused by a dependency being added to wp-cli, but not being loaded to my preexisting vvv install.

```
PHP Fatal error:  Call to undefined function array_column() in /srv/www/wp-cli/php/WP_CLI/SynopsisValidator.php on line 17
```
