### PR TITLE
Disable Nginx 404 handler for static assets

### DIFF
--- a/config/nginx-config/nginx-wp-common.conf
+++ b/config/nginx-config/nginx-wp-common.conf
@@ -20,13 +20,6 @@ gzip off;
 # Add trailing slash to */wp-admin requests.
 rewrite /wp-admin$ $scheme://$host$uri/ permanent;
 
-# Handle all static assets by serving the file directly. Add directives 
-# to send expires headers and turn off 404 error logging.
-location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
-    expires 24h;
-    log_not_found off;
-}
-
 # this prevents hidden files (beginning with a period) from being served
 location ~ /\. {
 	access_log off;


### PR DESCRIPTION
This extra production-minded rule prevents some useful plugins from working properly, such as [Dependency Minification](https://github.com/x-team/wp-dependency-minification) and [Media Placeholders](https://github.com/x-team/wp-media-placeholders), since they rely on the WordPress handling requests to JS, CSS, and images. The Nginx config goes above-and-beyond the default equivalent `.htaccess` that WordPress generates, and I think @TheLastCicada was in agreement today at WCPDX that this can be removed.
