### PR TITLE
Move xdebug controls to executable files

### DIFF
--- a/config/bash_aliases
+++ b/config/bash_aliases
@@ -24,14 +24,3 @@ stop_config_monitor() {
     pkill -f "watchr watchr.script"
 }
 
-# If XDebug is enabled, disable it
-xdebug_off() {
-	sudo php5dismod xdebug
-	sudo service php5-fpm restart
-}
-
-# If XDebug is disabled, enable it
-xdebug_on() {
-	sudo php5enmod xdebug
-	sudo service php5-fpm restart
-}

--- a/config/homebin/xdebug_off
+++ b/config/homebin/xdebug_off
@@ -1,0 +1,4 @@
+#!/bin/bash
+sudo php5dismod xdebug
+sudo service php5-fpm restart
+

--- a/config/homebin/xdebug_on
+++ b/config/homebin/xdebug_on
@@ -1,0 +1,4 @@
+#!/bin/bash
+sudo php5enmod xdebug
+sudo service php5-fpm restart
+

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -260,6 +260,9 @@ ln -sf /srv/config/bash_profile /home/vagrant/.bash_profile | echo " * /srv/conf
 # Custom bash_aliases included by vagrant user's .bashrc
 ln -sf /srv/config/bash_aliases /home/vagrant/.bash_aliases | echo " * /srv/config/bash_aleases -> /home/vagrant/.bash_aliases"
 
+# Custom home bin directory
+ln -nsf /srv/config/homebin /home/vagrant/bin | echo " * /srv/config/homebin -> /home/vagrant/bin"
+
 # Custom vim configuration via .vimrc
 ln -sf /srv/config/vimrc /home/vagrant/.vimrc | echo " * /srv/config/vimrc -> /home/vagrant/.vimrc"
 


### PR DESCRIPTION
This makes the files accessible to use outside of an interactive shell environment.

This fixes 10up/varying-vagrant-vagrants#119
