### PR TITLE
Rename default config to always come first

### DIFF
--- a/config/nginx-config/sites/default.conf
+++ b/config/nginx-config/sites/default.conf
@@ -24,7 +24,7 @@
 # placed in the /srv/www/default directory are accessible through this IP. It is
 # not intended to run WordPress through this directory.
 server {
-    listen       80;
+    listen       80 default_server;
     listen       443 ssl;
     root         /srv/www/default;
     


### PR DESCRIPTION
If a custom config file is added that starts with a number or A-C, it will be the first server defined in Nginx. That means the ip address by itself will not point to the default server, but rather whatever server is defined first.
