### PR TITLE
Update documentation to remove version number

### DIFF
--- a/config/nginx-config/sites/default.conf
+++ b/config/nginx-config/sites/default.conf
@@ -65,7 +65,7 @@ server {
 }
 
 ################################################################
-# WordPress 3.5.1 nginx configuration
+# WordPress stable nginx configuration
 #
 # http://local.wordpress.dev - this server configuration is
 # setup to listen on port 80 for any requests coming in to


### PR DESCRIPTION
Instead of specifying a version, let's just note stable vs. trunk in the config.  This way the documentation stays accurate.
