### PR TITLE
502 due to "too big response headers"

### DIFF
--- a/config/nginx-config/nginx-wp-common.conf
+++ b/config/nginx-config/nginx-wp-common.conf
@@ -47,7 +47,9 @@ location ~ \.php$ {
 
     # Include the fastcgi_params defaults provided by nginx
     include        /etc/nginx/fastcgi_params;
-    fastcgi_read_timeout 3600s;
+	fastcgi_read_timeout 3600s;
+	fastcgi_buffer_size 128k;
+	fastcgi_buffers 4 128k;
 
     # SCRIPT_FILENAME is a required parameter for things to work properly,
     # but was missing in the default fastcgi_params on upgrade to nginx 1.4.


### PR DESCRIPTION
I'm seeing a 502 from Nginx when I request from `admin-ajax.php`, the error is:

`2013/08/23 13:58:52 [error] 18860#0: *1 upstream sent too big header while reading response header from upstream, client: 192.168.50.1, server: local.pencil.dev, request: "GET /wp-admin/admin-ajax.php HTTP/1.1", upstream: "fastcgi://unix:/var/run/php5-fpm.sock:"`

Is anyone else seeing this?

After some experimentation with [some suggestions found on Stack Overflow](http://stackoverflow.com/questions/11526674/nginx-big-header-response), the solution seems to be to to increase the `fastcgi_buffers` and `fastcgi_buffer_size` in Nginx.
