### PR TITLE
Typo in inline docs for jf_cron_request()

### DIFF
--- a/config/wordpress-config/mu-plugins/jf-cron-filter.php
+++ b/config/wordpress-config/mu-plugins/jf-cron-filter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Alter the timeout on cron requests from 0.01 to 0.3. Something about
+ * Alter the timeout on cron requests from 0.01 to 0.5. Something about
  * the Vagrant and/or Ubuntu setup doesn't like these self requests 
  * happening so quickly.
  */


### PR DESCRIPTION
Was changed 6 months ago, see 457bf30d.
