### PR TITLE
check for instilation of grunt rather than if the directory exists

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -224,13 +224,13 @@ then
 	#
 	# Install or Update Grunt based on gurrent state.  Updates are direct
 	# from NPM
-	if [ ! -d /usr/lib/node_modules/grunt-cli  ]
+	if grunt --version ;
 	then
-		echo "Installing Grunt CLI"
-		npm install -g grunt-cli
-	else
 		echo "Updating Grunt CLI"
 		npm update -g grunt-cli
+	else
+		echo "Installing Grunt CLI"
+		npm install -g grunt-cli
 	fi
 
 else


### PR DESCRIPTION
This fixes the problem of if the grunt instilation fails it doesn't restart properly discovered in #136.  It doesn't fix all of #136, just this aspect. 
