### PR TITLE
Fix path to WordPress unit tests

### DIFF
--- a/config/bash_profile
+++ b/config/bash_profile
@@ -20,7 +20,7 @@ fi
 
 # Set the WP_TESTS_DIR path directory so that we can use phpunit inside
 # plugins almost immediately.
-export WP_TESTS_DIR=/srv/www/wordpress-unit-tests/
+export WP_TESTS_DIR=/srv/www/wordpress-develop/tests/
 
 # add autocomplete for grunt
 eval "$(grunt --completion=bash)"


### PR DESCRIPTION
Separate checkout of WordPress unit tests was replaced in #113, but this path was not adjusted
