### PR TITLE
Update paths in WP Unit Tests integration after recent changes in WP core

### DIFF
--- a/config/bash_profile
+++ b/config/bash_profile
@@ -1,4 +1,4 @@
-# bash_profile 
+# bash_profile
 #
 # Symlinked to the vagrant user's home directory. This loads
 # the default .bashrc provided by the virtual machine, which in
@@ -20,7 +20,7 @@ fi
 
 # Set the WP_TESTS_DIR path directory so that we can use phpunit inside
 # plugins almost immediately.
-export WP_TESTS_DIR=/srv/www/wordpress-develop/tests/
+export WP_TESTS_DIR=/srv/www/wordpress-develop/tests/phpunit/
 
 # add autocomplete for grunt
 eval "$(grunt --completion=bash)"

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -421,7 +421,7 @@ PHP
 define( 'WP_DEBUG', true );
 PHP
 		wp core install --url=src.wordpress-develop.dev --quiet --title="WordPress Develop" --admin_name=admin --admin_email="admin@local.dev" --admin_password="password"
-		cp /srv/config/wordpress-config/wp-tests-config.php /srv/www/wordpress-develop/tests/
+		cp /srv/config/wordpress-config/wp-tests-config.php /srv/www/wordpress-develop/
 	else
 		echo "Updating WordPress trunk..."
 		cd /srv/www/wordpress-develop/


### PR DESCRIPTION
Update paths in WP Unit Tests integration after recent changes in WP core, see http://core.trac.wordpress.org/changeset/25165/
