### PR TITLE
Adjust another path for the WP core Unit tests

### DIFF
--- a/config/wordpress-config/wp-tests-config.php
+++ b/config/wordpress-config/wp-tests-config.php
@@ -1,7 +1,7 @@
 <?php
 
 /* Path to the WordPress codebase you'd like to test. Add a backslash in the end. */
-define( 'ABSPATH', dirname( dirname( __FILE__ ) ) . '/src/' );
+define( 'ABSPATH', dirname( __FILE__ ) . '/src/' );
 
 // Test with multisite enabled: (previously -m)
 // define( 'WP_TESTS_MULTISITE', true );


### PR DESCRIPTION
Adjust another path for the WP core Unit tests, necessary after http://core.trac.wordpress.org/changeset/25165
