### PR TITLE
Ignore custom config directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@
 # No need to share individual site configs with each other
 /config/nginx-config/sites/*.conf
 
+# Ignore anything in the 'custom' directory in config
+/config/custom/*
+
 # No need to share our mysql data with each other
 /database/data/*
 


### PR DESCRIPTION
It would be nice to have a directory in `/config` that is always ignored entirely. Let's say that could be `/config/custom`. This could be used for things like creating additional custom sources lists to be symlinked to `/etc/apt/sources.list.d`, etc.
