### PR TITLE
/etc/hosts not correctly formed

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -471,7 +471,9 @@ DOMAINS='local.wordpress.dev
          build.wordpress-develop.dev'
 
 if ! grep -q "$DOMAINS" /etc/hosts
-then echo "127.0.0.1 $DOMAINS" >> /etc/hosts
+then
+	DOMAINS=$(echo $DOMAINS)
+	echo "127.0.0.1 $DOMAINS" >> /etc/hosts
 fi
 
 end_seconds=`date +%s`


### PR DESCRIPTION
Commit d9844611834e80395e0f3f9b600d3f3e113272dd seems to break domains - was it intended to loop per new line?

This worked for me:

```
DOMAINS='local.wordpress.dev 
     local.wordpress-trunk.dev
     src.wordpress-develop.dev
     build.wordpress-develop.dev'

if ! grep -q "$DOMAINS" /etc/hosts
then
    DOMAINS=$(echo $DOMAINS)
    echo "127.0.0.1 $DOMAINS" >> /etc/hosts
fi
```
