### PR TITLE
Add postfix and default config to provisioning

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -77,6 +77,7 @@ apt_package_check_list=(
 	make
 	vim
 	colordiff
+    postfix
 
 	# Req'd for i18n tools
 	gettext
@@ -122,6 +123,15 @@ done
 # following two lines *is* actually set to the word 'blank' for the root user.
 echo mysql-server mysql-server/root_password password blank | debconf-set-selections
 echo mysql-server mysql-server/root_password_again password blank | debconf-set-selections
+
+# Postfix
+#
+# Use debconf-set-selections to specify the selections in the postfix setup. Set
+# up as an 'Internet Site' with the host name 'vvv'. Note that if your current
+# Internet connection does not allow communication over port 25, you will not be
+# able to send mail, even with postfix installed.
+echo postfix postfix/main_mailer_type select Internet Site | debconf-set-selections
+echo postfix postfix/mailname string vvv | debconf-set-selections
 
 # Provide our custom apt sources before running `apt-get update`
 ln -sf /srv/config/apt-source-append.list /etc/apt/sources.list.d/vvv-sources.list | echo "Linked custom apt sources"


### PR DESCRIPTION
Simply installing postfix with the default configuration allows mail messages to be sent from Vagrant under most circumstances. This adds post fix to the default configuration to try and make debugging email just a little easier.
