### PR TITLE
Use `mysql -u root` without a password

### DIFF
--- a/config/mysql-config/user-my.cnf
+++ b/config/mysql-config/user-my.cnf
@@ -1,0 +1,7 @@
+[client]
+user     = root
+password = blank
+
+[mysqladmin] 
+user     = root
+password = blank

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -286,6 +286,7 @@ ln -sf /srv/config/php5-fpm-config/apc.ini /etc/php5/fpm/conf.d/apc.ini | echo "
 
 # Configuration for mysql
 cp /srv/config/mysql-config/my.cnf /etc/mysql/my.cnf | echo " * /srv/config/mysql-config/my.cnf -> /etc/mysql/my.cnf"
+ln -sf /srv/config/mysql-config/user-my.cnf /home/vagrant/.my.cnf | echo " * /srv/config/mysql-config/user-my.cnf -> /home/vagrant/.my.cnf"
 
 # Configuration for memcached
 ln -sf /srv/config/memcached-config/memcached.conf /etc/memcached.conf | echo " * /srv/config/memcached-config/memcached.conf -> /etc/memcached.conf"


### PR DESCRIPTION
Here's one possible solution to #158, add a `my.cnf` file to allow the user to simply type `mysql -u root` and not bother with a password. Also works for `sudo mysql -u root`, if they use that for whatever reason.
