### PR TITLE
Add vvv.dev server_name, use instead of IP address

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,14 @@ Immediate goals for VVV include:
     * `vagrant up` - *omg magic happens*
     * Be patient, this could take a while, especially on the first run.
 1. Add a record to your local machine's hosts file
-    * `192.168.50.4  local.wordpress.dev local.wordpress-trunk.dev src.wordpress-develop.dev build.wordpress-develop.dev`
+    * `192.168.50.4  vvv.dev local.wordpress.dev local.wordpress-trunk.dev src.wordpress-develop.dev build.wordpress-develop.dev`
     * On -nix systems you can use: (note that location of host file after the >> may vary) `sudo sh -c 'echo "192.168.50.4 local.wordpress.dev local.wordpress-trunk.dev src.wordpress-develop.dev build.wordpress-develop.dev" >>/private/etc/hosts'`
 1. Visit any of the following default sites in your browser:
     * [http://local.wordpress.dev](http://local.wordpress.dev/) for WordPress stable
     * [http://local.wordpress-trunk.dev](http://local.wordpress-trunk.dev/) for WordPress trunk
     * [http://src.wordpress-develop.dev](http://src.wordpress-develop.dev/) for trunk WordPress development files
     * [http://build.wordpress-develop.dev](http://build.wordpress-develop.dev/) for version of those development files built with Grunt
-    * [http://192.168.50.4](http://192.168.50.4) for a default dashboard containing several useful tools
+    * [http://vvv.dev](http://vvv.dev) for a default dashboard containing several useful tools
 
 Fancy, yeah?
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,7 +29,7 @@ Vagrant.configure("2") do |config|
   config.vm.box = "precise32"
   config.vm.box_url = "http://files.vagrantup.com/precise32.box"
 
-  config.vm.hostname = "vvv"
+  config.vm.hostname = "vvv.dev"
 
   # Local Machine Hosts
   #
@@ -42,6 +42,7 @@ Vagrant.configure("2") do |config|
   # from a local config file so that they can be more dynamic to your setup.
   if defined? VagrantPlugins::HostsUpdater
     config.hostsupdater.aliases = [
+      "vvv.dev",
       "local.wordpress.dev",
       "local.wordpress-trunk.dev",
       "src.wordpress-develop.dev",

--- a/config/nginx-config/sites/default.conf
+++ b/config/nginx-config/sites/default.conf
@@ -27,6 +27,7 @@ server {
     listen       80 default_server;
     listen       443 ssl;
     root         /srv/www/default;
+    server_name  vvv.dev;
     
     location / {
         index index.php;

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -475,7 +475,8 @@ fi
 
 # Add any custom domains to the virtual machine's hosts file so that it
 # is self aware. Enter domains space delimited as shown with the default.
-DOMAINS='local.wordpress.dev 
+DOMAINS='vvv.dev
+         local.wordpress.dev
          local.wordpress-trunk.dev
          src.wordpress-develop.dev
          build.wordpress-develop.dev'
@@ -495,4 +496,4 @@ then
 else
 	echo "No external network available. Package installation and maintenance skipped."
 fi
-echo "For further setup instructions, visit http://$vvv_ip"
+echo "For further setup instructions, visit http://vvv.dev"


### PR DESCRIPTION
It's not very friendly to send a user to a raw IP address. Why not just add a host name (`vvv.dev`) for the default server and reference that instead of the IP address? This will allow the `README` to remain true, even if they override the `Vagrantfile`'s IP address with in the `Customfile`.
