### PR TITLE
Fix synced folders for Vagrant 1.2.x.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -63,7 +63,7 @@ Vagrant.configure("2") do |config|
 
   # Drive mapping
   #
-  # The following config.vm.share_folder settings will map directories in your Vagrant
+  # The following config.vm.synced_folder settings will map directories in your Vagrant
   # virtual machine to directories on your local machine. Once these are mapped, any
   # changes made to the files in these directories will affect both the local and virtual
   # machine versions. Think of it as two different ways to access the same file. When the
@@ -80,7 +80,7 @@ Vagrant.configure("2") do |config|
   if vagrant_version >= "1.3.0"
     config.vm.synced_folder "database/data/", "/var/lib/mysql", :mount_options => [ "dmode=777", "fmode=777" ]
   else
-    config.vm.synced_folder "database/data/", "/var/lib/mysql", :extra => [ "dmode=777", "fmode=777" ]
+    config.vm.synced_folder "database/data/", "/var/lib/mysql", :extra => 'dmode=777,fmode=777'
   end
 
   # /srv/config/
@@ -106,7 +106,7 @@ Vagrant.configure("2") do |config|
   if vagrant_version >= "1.3.0"
     config.vm.synced_folder "www/", "/srv/www/", :owner => "www-data", :mount_options => [ "dmode=775", "fmode=774" ]
   else
-    config.vm.synced_folder "www/", "/srv/www/", :owner => "www-data", :extra => [ "dmode=775", "fmode=774" ]
+    config.vm.synced_folder "www/", "/srv/www/", :owner => "www-data", :extra => 'dmode=775,fmode=774'
   end
 
   # Customfile - POSSIBLY UNSTABLE


### PR DESCRIPTION
On Vagrant 1.2.x, using the latest stable version of VVV, `vagrant up` returns the following error:

```
[default] -- /srv/www
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

mount -t vboxsf -o uid=`id -u www-data`,gid=`id -g vagrant`,["dmode=775", "fmode
=774"] /srv/www /srv/www
```

I get it to work by modifying the block between lines 106 and 110:

```
  if vagrant_version >= "1.3.0"
    config.vm.synced_folder "www/", "/srv/www/", :owner => "www-data", :mount_options => [ "dmode=775", "fmode=774" ]
  else
    config.vm.synced_folder "www/", "/srv/www/", :owner => "www-data", :extra => [ "dmode=775", "fmode=774" ]
  end
```

With this:

```
  if vagrant_version >= "1.3.0"
    config.vm.synced_folder "www/", "/srv/www/", :owner => "www-data", :mount_options => [ "dmode=775", "fmode=774" ]
  else
    config.vm.synced_folder "www/", "/srv/www/", :owner => "www-data", :extra => 'dmode=775,fmode=774'
  end
```

I think that this should be modified to work with 1.2.x versions. I also found this Stackoverflow topic: http://stackoverflow.com/questions/13169154/cannot-change-permissions-of-folders-within-vagrant-home-folder, where this guy comments on how the format  for mount options changed across versions.
