### PR TITLE
Add Ruby and Sass

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -94,6 +94,9 @@ apt_package_check_list=(
 	g++
 	nodejs
 
+	# Ruby is needed for SASS
+	ruby
+
 )
 
 echo "Check for apt packages to install..."
@@ -245,6 +248,16 @@ then
 		echo "Installing Grunt CLI"
 		npm install -g grunt-cli &>/dev/null
 	fi
+
+	if sass -v;
+	then 
+		echo "updating sass"
+		gem update sass
+	else
+		echo "installing sass"
+		gem install sass --pre
+	fi
+
 
 else
 	echo -e "\nNo network connection available, skipping package installation"


### PR DESCRIPTION
WordPress Develop is going to require SASS, specifically the 3.3 version that includes source maps.  

http://core.trac.wordpress.org/ticket/22862#comment:70
