### PR TITLE
Update the grunt module we install to match the updates core grunt scripts

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -241,9 +241,13 @@ then
 	then
 		echo "Updating Grunt CLI"
 		npm update -g grunt-cli &>/dev/null
+		npm update -g grunt-sass &>/dev/null
+		npm update -g grunt-cssjanus &>/dev/null
 	else
 		echo "Installing Grunt CLI"
 		npm install -g grunt-cli &>/dev/null
+		npm install -g grunt-sass &>/dev/null
+		npm install -g grunt-cssjanus &>/dev/null
 	fi
 
 else


### PR DESCRIPTION
The grunt scripts in WordPress core now require both these different modules to run so lets install them and keep them updated.
