### PR TITLE
Adjust and fix some URLs in the readme.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Varying Vagrant Vagrants is an evolving [Vagrant](http://vagrantup.com) configur
 * **Version**: 1.0-working
 * **Latest Stable**: [v0.9](https://github.com/10up/varying-vagrant-vagrants/tree/v0.9)
 * **Contributors**: [@jeremyfelt](http://github.com/jeremyfelt), [@carldanley](http://github.com/carldanley), [@ericmann](http://github.com/ericmann), [@lkwdwrd](http://github.com/lkwdwrd), [@TheLastCicada](http://github.com/TheLastCicada), [@tddewey](http://github.com/tddewey), [@johnpbloch](http://github.com/johnpbloch), [@kadamwhite](http://github.com/kadamwhite), [@scribu](http://github.com/scribu), [@danielbachhuber](http://github.com/danielbachhuber), [@tollmanz](http://github.com/tollmanz), [@mbijon](http://github.com/mbijon), [@markjaquith](http://github.com/markjaquith), [@curtismchale](http://github.com/curtismchale), [@Mamaduka](http://github.com/mamaduka), [@lgedeon](http://github.com/lgedeon), [@pmgarman](http://github.com/pmgarman), [@westonruter](http://github.com/westonruter), [@petemall](http://github.com/petemall), [@cmmarslender](http://github.com/cmmarslender), [@mintindeed](http://github.com/mintindeed), [@mboynes](http://github.com/mboynes), [@aaronjorbin](http://github.com/aaronjorbin), [@tobiasbg](http://github.com/tobiasbg), [@simonwheatley](http://github.com/simonwheatley), [@ocean90](http://github.com/ocean90), [@lvnilesh](http://github.com/lvnilesh), [@alexw23](http://github.com/alexw23), [@zamoose](https://github.com/zamoose), [@leewillis77](https://github.com/leewillis77), [@imichaeli](https://github.com/imichaeli), [@andrezrv](https://github.com/andrezrv), [@cadwell](https://github.com/cadwell), [@cfoellmann](https://github.com/cfoellmann), [@westi](https://github.com/westi), [@ryanduff](https://github.com/ryanduff)
-* **Contributing**: Contributions are more than welcome. Please submit pull requests against the [master branch](https://github.com/10up/varying-vagrant-vagrants/). Thanks!
+* **Contributing**: Contributions are more than welcome. Please submit pull requests against the [master branch](https://github.com/10up/varying-vagrant-vagrants). Thanks!
 
 ## Overview
 
@@ -145,25 +145,25 @@ A bunch of stuff!
 1. [WordPress Trunk](http://core.svn.wordpress.org/trunk/)
 1. [WP-CLI](http://wp-cli.org/)
 1. [nginx](http://nginx.org/) 1.4.x
-1. [mysql](http://www.mysql.com) 5.5.x
-1. [php-fpm](http://php-fpm.org) 5.4.x
-1. [memcached](http://memcached.org) 1.4.13
+1. [mysql](http://www.mysql.com/) 5.5.x
+1. [php-fpm](http://php-fpm.org/) 5.4.x
+1. [memcached](http://memcached.org/) 1.4.13
 1. PHP [memcache extension](http://pecl.php.net/package/memcache/3.0.8/) 3.0.8
 1. PHP [xdebug extension](http://pecl.php.net/package/xdebug/2.2.3/) 2.2.3
 1. PHP [imagick extension](http://pecl.php.net/package/imagick/3.1.0RC2/) 3.1.0RC2
 1. [xdebug](http://xdebug.org/) 2.2.3
 1. [PHPUnit](http://pear.phpunit.de/) 3.7.24
-1. [ack-grep](http://beyondgrep.com) 2.04
+1. [ack-grep](http://beyondgrep.com/) 2.04
 1. [git](http://git-scm.com/) 1.8.5
 1. [subversion](http://subversion.apache.org/) 1.7.9
-1. [ngrep](http://ngrep.sourceforge.net/usage.html/)
+1. [ngrep](http://ngrep.sourceforge.net/usage.html)
 1. [dos2unix](http://dos2unix.sourceforge.net/)
-1. [Composer](https://github.com/composer/composer/)
+1. [Composer](https://github.com/composer/composer)
 1. [phpMemcachedAdmin](https://code.google.com/p/phpmemcacheadmin/) 1.2.2 BETA
 1. [phpMyAdmin](http://www.phpmyadmin.net/) 4.0.10 (multi-language)
-1. [Webgrind](https://github.com/jokkedk/webgrind/)
+1. [Webgrind](https://github.com/jokkedk/webgrind)
 1. [NodeJs](http://nodejs.org/) Current Stable Version
-1. [grunt-cli](https://github.com/gruntjs/grunt-cli/) Current Stable Version
+1. [grunt-cli](https://github.com/gruntjs/grunt-cli) Current Stable Version
 
 ### Need Help?
 


### PR DESCRIPTION
URLs with just a domain should have a trailing slash, URLs with a file name must not. For github.com URLs, the trailing slash is optional, and as github.com doesn’t use them, we should opt to also not use them.
