### PR TITLE
Test for an empty string with `-z` rather than `-e`

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -589,7 +589,7 @@ find /srv/www/ -maxdepth 5 -name 'vvv-hosts' | \
 while read hostfile; do
 	while IFS='' read -r line || [ -n "$line" ]; do
 		if [[ "#" != ${line:0:1} ]]; then
-			if [[ -e "$(grep -q "^127.0.0.1 $line$" /etc/hosts)" ]]; then
+			if [[ -z "$(grep -q "^127.0.0.1 $line$" /etc/hosts)" ]]; then
 				echo "127.0.0.1 $line # vvv-auto" >> /etc/hosts
 				echo " * Added $line from $hostfile"
 			fi


### PR DESCRIPTION
Fixes the adding of vvv-hosts entries to the virtual machine, which has been broken since b669fd29e4 during an attempt to get better at empty and not empty checking.

`-e` is used to check if a file exists and has nothing to do with string comparison. Our other uses of `-e` throughout `provision.sh` are valid.
