### PR TITLE
Remove all unlink statements in provisioning

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -274,21 +274,6 @@ fi
 
 echo -e "\nSetup configuration files..."
 
-# Unlink all previous symlinked config files. This allows us to avoid errors
-# as we proceed to copy over new versions of these config files. It is likely
-# that this section will be removed after everyone has had a fair chance. With
-# a `vagrant destroy`, none of this is necessary.
-unlink /etc/nginx/nginx.conf
-unlink /etc/nginx/nginx-wp-common.conf
-unlink /etc/php5/fpm/pool.d/www.conf
-unlink /etc/php5/fpm/conf.d/php-custom.ini
-unlink /etc/php5/fpm/conf.d/xdebug.ini
-unlink /etc/php5/fpm/conf.d/apc.ini
-unlink /etc/memcached.conf
-unlink /home/vagrant/.bash_profile
-unlink /home/vagrant/.bash_aliases
-unlink /home/vagrant/.vimrc
-
 # Used to to ensure proper services are started on `vagrant up`
 cp /srv/config/init/vvv-start.conf /etc/init/vvv-start.conf
 


### PR DESCRIPTION
In v1.0 of VVV, we made the change to copy a bunch of config files over rather than using symlinks. Because of this we had to unlink all of the previous symlinks before the copies would actually work. The unlinking should be treated as a temporary solution as it is somewhat confusing to run across in the provisioning script.

This commit removes unlinking. If for some reason an upgrade is done from v0.9 directly to v1.1 or master, it is possible that some errors will appear explaining that a file cannot be copied on top of itself. This isn't much of a big deal, but should be treated with a `vagrant destroy` and `vagrant up` to clear things a bit.
