### PR TITLE
Remove tcp_nodelay directive

### DIFF
--- a/config/nginx-config/nginx.conf
+++ b/config/nginx-config/nginx.conf
@@ -48,9 +48,6 @@ http {
     # Don't send out partial TCP frames
     tcp_nopush          on;
 
-    # Merge smaller TCP packets into one larger packet
-    tcp_nodelay        off;
-
     # How long each connection should stay idle
     keepalive_timeout   5;
 


### PR DESCRIPTION
The reasoning here - https://github.com/h5bp/server-configs-nginx/issues/28 - seems to make sense. When we set `tcp_nodelay` to off, we tell Nginx to use Nagle's algorithm to figure out how packets should be buffered–with a possible 500ms latency if it can't figure things out in time. This 500ms latency is something that even [Nagle says](http://developers.slashdot.org/comments.pl?sid=174457&threshold=1&commentsort=0&mode=thread&cid=14515105) should stay in the 1980s.

Suggesting we remove this directive and leave it to Nginx's default `on` to _not_ use Nagle's algorithm.
