### PR TITLE
Setup default WordPress domains for multisite subdomain support

### DIFF
--- a/config/nginx-config/sites/default.conf
+++ b/config/nginx-config/sites/default.conf
@@ -75,7 +75,7 @@ server {
 server {
     listen       80;
     listen       443 ssl;
-    server_name  local.wordpress.dev;
+    server_name  local.wordpress.dev *.local.wordpress.dev;
     root         /srv/www/wordpress-default;
     include      /etc/nginx/nginx-wp-common.conf;
 }
@@ -90,7 +90,7 @@ server {
 server {
     listen       80;
     listen       443 ssl;
-    server_name  local.wordpress-trunk.dev;
+    server_name  local.wordpress-trunk.dev *.local.wordpress-trunk.dev;
     root         /srv/www/wordpress-trunk;
     include      /etc/nginx/nginx-wp-common.conf;
 }
@@ -105,7 +105,7 @@ server {
 server {
     listen       80;
     listen       443 ssl;
-    server_name  src.wordpress-develop.dev;
+    server_name  src.wordpress-develop.dev *.src.wordpress-develop.dev;
     root         /srv/www/wordpress-develop/src;
     include      /etc/nginx/nginx-wp-common.conf;
 }
@@ -120,7 +120,7 @@ server {
 server {
     listen       80;
     listen       443 ssl;
-    server_name  build.wordpress-develop.dev;
+    server_name  build.wordpress-develop.dev *.build.wordpress-develop.dev;
     root         /srv/www/wordpress-develop/build;
     include      /etc/nginx/nginx-wp-common.conf;
 }


### PR DESCRIPTION
To enable config flexibility after WordPress has been initially installed through provisioning, we should add `*.src.wordpress-develop.dev`, `*.local.wordpress-trunk.dev`, `*.local.wordpress.dev`, `*.build.wordpress-develop.dev` to the respective sections in our default Nginx site setup so that subdomains are at least handled by Nginx.

Some work will still need to be done on the local machine so that these subdomains are recognized, but we can get some of the hard stuff out of the way.
