### PR TITLE
handling sysmlinks for vvv-hosts

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,7 +47,7 @@ Vagrant.configure("2") do |config|
 
     # Capture the paths to all vvv-hosts files under the www/ directory.
     paths = []
-    Dir.glob(vagrant_dir + '/www/**/vvv-hosts').each do |path|
+    Dir.glob(vagrant_dir + '/www/{,/*/**}/vvv-hosts').each do |path|
       paths << path
     end
 


### PR DESCRIPTION
Hi Guys

I am tring to keep my code out of the VVV tree so I created a symlink from the www folder to my code.

But when I placed a vvvv-hosts file in the root of my code it was not found.

the fix was to change the Dir.glob call a bit

 `Dir.glob(vagrant_dir + '/www/**/vvv-hosts').each do |path|`
to
`Dir.glob(vagrant_dir + '/www/{,/*/**}/vvv-hosts').each do |path|`

and bingo it all works
