### PR TITLE
Add zip to apt_package_check_list.

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -72,6 +72,7 @@ apt_package_check_list=(
 	imagemagick
 	subversion
 	git-core
+	zip
 	unzip
 	ngrep
 	curl


### PR DESCRIPTION
It always looked weird to me that, while unzip is included into the list of packages to install, zip is not. Every now and then I end up doing an `apt-get install zip` manually, or creating a `provision-custom.sh` only to add zip to `apt_package_check_list`. I use this tool a lot, and I risk to say that I'm not the only one that can find useful to have it automatically installed.
