### PR TITLE
add php-invoker?

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -203,6 +203,7 @@ if [[ $ping_result == *bytes?from* ]]; then
 		mv composer.phar /usr/local/bin/composer
 
 		COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update phpunit/phpunit:3.7.*
+		COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update phpunit/php-invoker:1.1.*
 		COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update mockery/mockery:0.8.*
 		COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update d11wtq/boris:v1.0.2
 		COMPOSER_HOME=/usr/local/src/composer composer -q global config bin-dir /usr/local/bin


### PR DESCRIPTION
When I provision I see
`phpunit/phpunit suggests installing phpunit/php-invoker (>=1.1.0,<1.2.0)`
should we add it to the standard provision process?
