### PR TITLE
Connect develop.svn with (upcoming) develop.git

### DIFF
--- a/config/homebin/develop_git
+++ b/config/homebin/develop_git
@@ -2,3 +2,33 @@
 #
 # A script to convert the included develop.svn.wordpress.org repository into
 # the git mirror, develop.git.wordpress.org.
+
+set -e
+
+if [[ $USER != 'vagrant' ]]; then
+	echo "Please run inside Vagrant"
+	exit 1
+fi
+
+cd /srv/www/wordpress-develop/
+
+if [[ -e .git ]]; then
+	echo "Repo has already been converted to Git"
+	exit 1
+fi
+
+echo "Converting src.wordpress-develop.dev from SVN to GIT"
+
+echo "Rename .svn to .svn-backup"
+mv .svn .svn-backup
+
+git clone --no-checkout git://develop.git.wordpress.org/ /tmp/wp-git
+cd /tmp/wp-git
+git reset -q .
+cd /srv/www/wordpress-develop/
+
+echo "Moving .git dir to /srv/www/wordpress-develop/"
+mv /tmp/wp-git/.git .git
+git config core.fileMode false
+
+echo "Done"

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -474,7 +474,15 @@ PHP
 	else
 		echo "Updating WordPress develop..."
 		cd /srv/www/wordpress-develop/
-		svn up
+		if [[ -e .svn ]]; then
+			svn up
+		else
+			if [[ $(git rev-parse --abbrev-ref HEAD) == 'master' ]]; then
+				git pull --no-edit git://develop.git.wordpress.org/ master
+			else
+				echo "Skip auto git pull on develop.git.wordpress.org since not on master branch"
+			fi
+		fi
 		npm install &>/dev/null
 	fi
 


### PR DESCRIPTION
While the official WordPress Git repo `develop.git.wordpress.org` is not yet fully [up and operational](https://twitter.com/scribu/status/378254120362057728)—although it now is an actual Git repo—how should we go about making both Git and SVN available in VVV? Can we utilize `git-svn` to add `develop.svn.wordpress.org` as a remote for `develop.git.wordpress.org`?

See #111 and #113
