### PR TITLE
[PR] Change to PHPUnit 4.0.x for new provisionings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * PHP: Remove php-apc and apc.ini. Enable built in opcache.
 * PHP: Start tracking custom php5-fpm.conf file.
 * PHP: Start tracking custom opcache.ini file.
+* PHP: Update to PHPUnit 4.0.x
 * VVV Dashboard: Add [Opcache Status](https://github.com/rlerdorf/opcache-status) for opcache monitoring.
 
 ## 1.1

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ A bunch of stuff!
 1. PHP [xdebug extension](http://pecl.php.net/package/xdebug/2.2.3/) 2.2.3
 1. PHP [imagick extension](http://pecl.php.net/package/imagick/3.1.0RC2/) 3.1.0RC2
 1. [xdebug](http://xdebug.org/) 2.2.3
-1. [PHPUnit](http://pear.phpunit.de/) 3.7.24
+1. [PHPUnit](http://pear.phpunit.de/) 4.0.x
 1. [ack-grep](http://beyondgrep.com/) 2.04
 1. [git](http://git-scm.com/) 1.8.5
 1. [subversion](http://subversion.apache.org/) 1.7.9

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -201,7 +201,7 @@ if [[ $ping_result == *bytes?from* ]]; then
 		chmod +x composer.phar
 		mv composer.phar /usr/local/bin/composer
 
-		COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update phpunit/phpunit:3.7.*
+		COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update phpunit/phpunit:4.0.*
 		COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update phpunit/php-invoker:1.1.*
 		COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update mockery/mockery:0.8.*
 		COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update d11wtq/boris:v1.0.2


### PR DESCRIPTION
Ran through the WordPress core unit tests in both single and multisite with no issue. I don't think there should be any trouble upgrading here.

This requires a `vagrant destroy` and `vagrant up` to really work.

Fixes #250 
