### PR TITLE
[PR] Use Unix line endings on conf files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 
 # Force provisioning script to use LF, even on Windows
 *.sh    eol=lf
+*.conf  eol=lf


### PR DESCRIPTION
This is specifically directed to #287, in which these line endings
may be causing issues when starting the MySQL service after a
restart of the VM.
