### PR TITLE
Setup autocompletion for wp-cli

### DIFF
--- a/config/bash_profile
+++ b/config/bash_profile
@@ -24,3 +24,6 @@ export WP_TESTS_DIR=/srv/www/wordpress-develop/tests/phpunit/
 
 # add autocomplete for grunt
 eval "$(grunt --completion=bash)"
+
+# add autocomplete for wp-cli
+. /srv/www/wp-cli/utils/wp-completion.bash


### PR DESCRIPTION
Source `/srv/www/wp-cli/utils/wp-completion.bash` inside `config/bash_profile` to allow for WP-CLI autocompletion
