### PR TITLE
[PR] Install XDebug via PECL rather than apt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * PHP: Start tracking custom php5-fpm.conf file.
 * PHP: Start tracking custom opcache.ini file.
 * PHP: Update to PHPUnit 4.0.x
+* PHP: Install XDebug PECL extension directly, rather than via apt.
 * phpMyAdmin: Update to 4.1.12
 * WP-Cli: Add support for autocomplete.
 * VVV Dashboard: Add [Opcache Status](https://github.com/rlerdorf/opcache-status) for opcache monitoring.

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ A bunch of stuff!
 1. [php-fpm](http://php-fpm.org/) 5.5.x
 1. [memcached](http://memcached.org/) 1.4.13
 1. PHP [memcache extension](http://pecl.php.net/package/memcache/3.0.8/) 3.0.8
-1. PHP [xdebug extension](http://pecl.php.net/package/xdebug/2.2.3/) 2.2.3
+1. PHP [xdebug extension](http://pecl.php.net/package/xdebug/2.2.5/) 2.2.5
 1. PHP [imagick extension](http://pecl.php.net/package/imagick/3.1.2/) 3.1.2
 1. [PHPUnit](http://pear.phpunit.de/) 4.0.x
 1. [ack-grep](http://beyondgrep.com/) 2.04

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -50,7 +50,6 @@ apt_package_check_list=(
 	# Extra PHP modules that we find useful
 	php5-memcache
 	php5-imagick
-	php5-xdebug
 	php5-mcrypt
 	php5-mysql
 	php5-imap
@@ -165,6 +164,13 @@ if [[ $ping_result == *bytes?from* ]]; then
 		# Clean up apt caches
 		apt-get clean
 	fi
+
+	# xdebug
+	#
+	# XDebug 2.2.3 is provided with the Ubuntu install by default. The PECL
+	# installation allows us to use a later version. Not specifying a version
+	# will load the latest stable.
+	pecl install xdebug
 
 	# ack-grep
 	#


### PR DESCRIPTION
The version of XDebug provided by the Ubuntu repository was 2.2.3,
which (per #317) appears to cause some issues when attempting to
load our default sites on some machines.

Using PECL directly allows us to install the latest stable version,
which is 2.2.5 at this time.
