### PR TITLE
[PR] Proxy guest DNS requests through the host machine

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,6 +13,8 @@ Vagrant.configure("2") do |config|
   # Configurations from 1.0.x can be placed in Vagrant 1.1.x specs like the following.
   config.vm.provider :virtualbox do |v|
     v.customize ["modifyvm", :id, "--memory", 512]
+    v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+    v.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
   end
 
   # Forward Agent


### PR DESCRIPTION
Rather than attempting to handle DNS lookups itself, this causes
the virtual machine to proxy any DNS back through the host machine.

This should really help in cases where your DNS changes due to an
unfamiliar network, etc... We'll want to pay attention to how it
handles local host lookups, though I think the hosts file will
still be watched.

See #327 

Note that these are VirtualBox specific settings.
