### PR TITLE
Update provision.sh to fix xdebug.ini issue

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -266,6 +266,7 @@ cp /srv/config/php5-fpm-config/php-custom.ini /etc/php5/fpm/conf.d/php-custom.in
 cp /srv/config/php5-fpm-config/opcache.ini /etc/php5/fpm/conf.d/opcache.ini
 cp /srv/config/php5-fpm-config/xdebug.ini /etc/php5/mods-available/xdebug.ini
 
+# Find the path to Xdebug and prepend it to xdebug.ini
 XDEBUG_PATH=$( find /usr -name 'xdebug.so' | head -1 )
 sed -i "1izend_extension=\"$XDEBUG_PATH\"" /etc/php5/mods-available/xdebug.ini
 


### PR DESCRIPTION
The _xdebug_on_ command no longer works, as _php5enmod_ tries to create symlinks in both the _/etc/php5/fpm/conf.d_ and _/etc/php5/cli/conf.d_ directories that point to _/etc/php5/mods-available/xdebug.ini_. This fails with the following message:
`WARNING: Module xdebug ini file doesn't exist under /etc/php5/mods-available`

As it stands, xdebug.ini is placed in _/etc/php5/fpm/conf.d_ and loaded all the time  but xdebug is not active because of the absence of a valid _zend_extension_ path. 

This fix updates provision.sh to place xdebug.ini in the mods-available directory so that _xdebug_on_ can create the needed symlinks in both _/etc/php5/fpm/conf.d_ and _/etc/php5/cli/conf.d_. It also finds the path to xdebug.so and prepends it to xdebug.ini so the the extension can be loaded.

Of note - opcache.ini remains in the fpm/conf.d directory and is always loaded in FPM, alongside mods-available/opcache.ini - this may require similar attention to xdebug.ini
