### PR TITLE
'fi' causing problems on Vagrant up

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -179,7 +179,7 @@ Vagrant.configure("2") do |config|
   # (run: "always" support added in 1.6.0)
   if vagrant_version >= "1.6.0"
     config.vm.provision :shell, inline: "sudo service mysql start", run: "always"
-  fi
+  end
 
   # Vagrant Triggers
   #


### PR DESCRIPTION
This made first-time provisioning of a fresh copy of VVV impossible. I believe that this fixes it.
