### PR TITLE
Install nodejs-legacy to provide symlink

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -94,6 +94,12 @@ apt_package_check_list=(
 	g++
 	npm
 	nodejs
+
+	# There is a naming conflict with the node package (Amateur Packet
+	# Radio Node Program), and the nodejs binary has been renamed from node
+	# to nodejs.  We need to install the nodejs-legacy package to put it
+	# back.
+	nodejs-legacy
 )
 
 echo "Check for apt packages to install..."
@@ -112,11 +118,6 @@ for pkg in "${apt_package_check_list[@]}"; do
 		apt_package_install_list+=($pkg)
 	fi
 done
-
-# There is a naming conflict with the node package (Amateur Packet Radio Node
-# Program), and the nodejs binary has been renamed from node to nodejs. We need
-# to symlink to put it back.
-ln -s /usr/bin/nodejs /usr/bin/node
 
 # MySQL
 #


### PR DESCRIPTION
The nodejs-legacy package actually provides a symbolic link to nodejs, so it makes sense to use that. See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=614907 for more context.
