### PR TITLE
Fixed "not found command" on xdebug_on 

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -293,8 +293,12 @@ if [[ ! -d /home/vagrant/bin ]]; then
 	mkdir /home/vagrant/bin
 fi
 rsync -rvzh --delete /srv/config/homebin/ /home/vagrant/bin/
+
+# Make sure that line endings are UNIX
 sudo sed -i 's/\r//' /home/vagrant/bin/*
-sudo cp /home/vagrant/bin/* /usr/bin/
+sudo sed -i 's/\r//' /home/vagrant/.bash_profile
+sudo sed -i 's/\r//' /home/vagrant/.bash_aliases
+sudo sed -i 's/\r//' /home/vagrant/.vimrc
 
 echo " * /srv/config/bash_profile                      -> /home/vagrant/.bash_profile"
 echo " * /srv/config/bash_aliases                      -> /home/vagrant/.bash_aliases"


### PR DESCRIPTION
Adding homebin to /usr/bin in order to have commands available all the time. This way `xdebug_on` works from any directory and db_backup executes correctly, because dunno about others, but i never was able to get these commands to work with a fresh box.

Also, before coyping these guys, i make sure that line endings are set to `\r` in order to make sure that issues like #307 doesn't pop.
