### PR TITLE
Added external ip sample

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -81,6 +81,10 @@ Vagrant.configure("2") do |config|
   # If you are running more than one VM through VirtualBox, different subnets should be used
   # for those as well. This includes other Vagrant boxes.
   config.vm.network :private_network, ip: "192.168.50.4"
+  
+  # if you need to have an external IP, you need to uncomment this line and update the ip and bridge adapter name
+  # you can get both of IP class and the adapter name by running `vboxmanage list bridgedifs` into a a terminal (on host system)
+  # config.vm.network :public_network, :bridge => 'Realtek PCIe GBE Family Controller #2', ip: "192.168.1.82"
 
   # Drive mapping
   #


### PR DESCRIPTION
I had some issues figuring out what's the correct conf to set a box that's accesible from the outside. 

This addresses #191, #239 and #263 which even they are closed (at least first two of them), they doesn't provide a reasonable fix.

After you have a static IP, and your vvv box is visible from your network, you need to make a router port forward.

This, in combination with any dynamic dns providers (i'm using dyndns) will make testing on other devices.
If you don't have a static IP, a dynamic DNS service is preffered to xip.io for the simple reason that the generated URL doesn't have your IP in it (if your host change on every restart, then you need to update your wp config to update host, no?)
