### PR TITLE
Set PHP_CodeSniffer installed_path config for folder restructuring

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -436,7 +436,7 @@ if [[ $ping_result == *bytes?from* ]]; then
 			echo -e "\nSkipped updating PHPCS WordPress Coding Standards since not on master branch"
 		fi
 	fi
-	phpcs --config-set installed_paths CodeSniffer/Standards/WordPress/
+	phpcs --config-set installed_paths ./CodeSniffer/Standards/WordPress/
 
 	# Install and configure the latest stable version of WordPress
 	if [[ ! -d /srv/www/wordpress-default ]]; then


### PR DESCRIPTION
Depends on:
- https://github.com/squizlabs/PHP_CodeSniffer/pull/217 (merged)
- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/194 (merged)

With this change, there will be additional standards available, including:
- `WordPress` (current superset of all sniffs)
- `WordPress-Core` (sniffs that seek to implement, and go no farther than, the official coding standards)
- `WordPress-VIP` (Core sniffs plus sniffs specifically implemented to check against the [VIP coding requirements](http://vip.wordpress.com/documentation/code-review-what-we-look-for/))
- `WordPress-Extra` (Core sniffs plus any extras that are best practices but could be controversial)
