### PR TITLE
Fix Composer version check

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -187,7 +187,7 @@ if [[ $ping_result == *bytes?from* ]]; then
 	#
 	# Install or Update Composer based on current state. Updates are direct from
 	# master branch on GitHub repository.
-	if [[ -n "$(composer --version | grep -q 'Composer version')" ]]; then
+	if [[ -n "$(composer --version --no-ansi | grep 'Composer version')" ]]; then
 		echo "Updating Composer..."
 		COMPOSER_HOME=/usr/local/src/composer composer self-update
 		COMPOSER_HOME=/usr/local/src/composer composer global update


### PR DESCRIPTION
I've seen this for a few versions of VVV that in both Ubuntu 12.04 and 14.04 the below line of code would always evaluate to false, and as such, always install Composer instead of checking for an update:

``` bash
if [[ -n "$(composer --version | grep -q 'Composer version')" ]]; then
```

I propose using the following, which seems to evaluate more consistently:

``` bash
if [[ -n "$(composer --version --no-ansi | grep 'Composer version')" ]]; then
```
