### PR TITLE
Disable IPv6 for Postfix

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -128,6 +128,8 @@ echo mysql-server mysql-server/root_password_again password root | debconf-set-s
 # able to send mail, even with postfix installed.
 echo postfix postfix/main_mailer_type select Internet Site | debconf-set-selections
 echo postfix postfix/mailname string vvv | debconf-set-selections
+# Disable ipv6 as some ISPs/mail servers have problems with it
+echo "inet_protocols = ipv4" >> /etc/postfix/main.cf
 
 # Provide our custom apt sources before running `apt-get update`
 ln -sf /srv/config/apt-source-append.list /etc/apt/sources.list.d/vvv-sources.list


### PR DESCRIPTION
@daveross came across an interesting bug with the default configuration -- since the `inet_protocols` defaults to "all", some network configurations will default to trying IPv6 and then giving up when an MX record won't resolve to it. (Try it yourself -- send to addresses at 10up.com vs. get10up.com). Disabling IPv6 and forcing IPv4 for all smtp connections seems to make this work correctly.
