### PR TITLE
provision.sh skipped network installation when executed in a private network behind organizational Proxy server

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -33,9 +33,8 @@ if [[ $ping_result != *bytes?from* ]]; then
             "Darwin" ) dgw=`netstat -nr | grep default | awk {'print $2'}` ;;
             # MINGW32* )  ?
         esac
-        echo $dgw
         ping_result="$(ping -c 2 $dgw 2>&1)"
-        echo $ping_result
+        
         if [[ $ping_result != *bytes?from* ]]; then
             # Windows CJK users will inevitably come down here.
             # Can you abandon VVV? Too good to miss!


### PR DESCRIPTION
I tried "vagrant up" and "vagrant provision" in a private network of my work, which is connected to the Internet only via HTTP proxy server. I found a message "No external network available. Package installation and maintenance skipped". Reading the provision/provision.sh code told me that it tries to ping public DNS servers to check external network connectivity. In my private network with proxy, ping command can reach none of the public DNS servers, it mistakenly find No network connectivity available even though HTTP messages can come and go. I think the connectivity test should be more robust. It thing one idea could be pinging IP of the platform's default gateway. Pinging the default gateway wil save the case where the platform is behind the Proxy.
