### PR TITLE
corrected line endings (LF)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-* text=auto
+* text eol=lf
 
 # Force provisioning script to use LF, even on Windows
 *.sh    eol=lf


### PR DESCRIPTION
This changes the line endings (from CR+LF to LF) of files connected to the guest cmd.
There are still some files like my.cnf that have Windows line endings which is not breaking anything but is not good either.

My tests show that this change results in
FIX Close #430 
FIX Close #419
FIX Close #358
Improves #413 
