### PR TITLE
[PR] Bump VirtualBox VM memory allocation to 1024 from 512

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure("2") do |config|
 
   # Configurations from 1.0.x can be placed in Vagrant 1.1.x specs like the following.
   config.vm.provider :virtualbox do |v|
-    v.customize ["modifyvm", :id, "--memory", 512]
+    v.customize ["modifyvm", :id, "--memory", 1024]
     v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
     v.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
   end


### PR DESCRIPTION
1GB seems to be a nicer answer than 512MB by default. A Customfile can be used to reduce or raise the memory footprint to another level.

Fixes #427
