### PR TITLE
Add network config info for host local IP address

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -82,6 +82,17 @@ Vagrant.configure("2") do |config|
   # for those as well. This includes other Vagrant boxes.
   config.vm.network :private_network, ip: "192.168.50.4"
 
+  # Use Host Machine IP Address
+  #
+  # This network configuration allows the guest to communicate on the host machine's
+  # local IP address on port 8080, e.g. http://localhost/:8080.
+  # Vagrant does require the # host port to be greater than 1024, however
+  # from the command line on the host machine you can port forward traffic from 80 to 8080
+  # $ echo "rdr pass on lo0 inet proto tcp from any to any port 80 -> 127.0.0.1 port 8080" | sudo pfctl -ef -
+  # when done this port forwarding can be removed with
+  # $ sudo pfctl -F all -f /etc/pf.conf
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
   # Drive mapping
   #
   # The following config.vm.synced_folder settings will map directories in your Vagrant


### PR DESCRIPTION
By default, the guest machine is accessed by the host machine via
192.168.50.4.  Instead, we want to make the guest machine accessible
from the host machine's IP address.  This will allow us to access the
guest machine from other devices on the network (e.g. a smart phone)

I had a lot of issues setting this up and think an example in the config file would be helpful.

However, if others aren't having issues with this setup, adding this information may be overkill.

See #442