### PR TITLE
Bypassing restrictive proxy for keyserver

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -144,13 +144,10 @@ if [[ $ping_result == *bytes?from* ]]; then
 		# our appended apt source.list
 	
 		# Nginx.org nginx key ABF5BD827BD9BF62
-		# switching to apt-key so that we can use port 80 to get through a restrictive proxy
-		# gpg -q --keyserver keyserver.ubuntu.com --recv-key ABF5BD827BD9BF62
 		apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key ABF5BD827BD9BF62
 		gpg -q -a --export ABF5BD827BD9BF62 | apt-key add -
 
 		# Launchpad nodejs key C7917B12
-		# gpg -q --keyserver keyserver.ubuntu.com --recv-key C7917B12
 		apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C7917B12
 		gpg -q -a --export  C7917B12  | apt-key add -
 


### PR DESCRIPTION
Restrictive proxies on certain networks block access to port 11371 causing the gpg call to the keyserver to fail.  Changing to use apt-key instead of gpg allows alternate ports, in this case using port 80, the same as the web UI for the  Ubuntu Keyserver.
