### PR TITLE
Add wildcard Nginx rules to load default VVV domains via xip.io

### DIFF
--- a/config/nginx-config/sites/default.conf
+++ b/config/nginx-config/sites/default.conf
@@ -75,7 +75,7 @@ server {
 server {
     listen       80;
     listen       443 ssl;
-    server_name  local.wordpress.dev *.local.wordpress.dev;
+    server_name  local.wordpress.dev *.local.wordpress.dev ~^local\.wordpress\.\d+\.\d+\.\d+\.\d+\.xip\.io$;
     root         /srv/www/wordpress-default;
     include      /etc/nginx/nginx-wp-common.conf;
 }
@@ -90,7 +90,7 @@ server {
 server {
     listen       80;
     listen       443 ssl;
-    server_name  local.wordpress-trunk.dev *.local.wordpress-trunk.dev;
+    server_name  local.wordpress-trunk.dev *.local.wordpress-trunk.dev ~^local\.wordpress-trunk\.\d+\.\d+\.\d+\.\d+\.xip\.io$;
     root         /srv/www/wordpress-trunk;
     include      /etc/nginx/nginx-wp-common.conf;
 }
@@ -105,7 +105,7 @@ server {
 server {
     listen       80;
     listen       443 ssl;
-    server_name  src.wordpress-develop.dev *.src.wordpress-develop.dev;
+    server_name  src.wordpress-develop.dev *.src.wordpress-develop.dev ~^src\.wordpress-develop\.\d+\.\d+\.\d+\.\d+\.xip\.io$;
     root         /srv/www/wordpress-develop/src;
     include      /etc/nginx/nginx-wp-common.conf;
 }
@@ -120,7 +120,7 @@ server {
 server {
     listen       80;
     listen       443 ssl;
-    server_name  build.wordpress-develop.dev *.build.wordpress-develop.dev;
+    server_name  build.wordpress-develop.dev *.build.wordpress-develop.dev ~^build\.wordpress-develop\.\d+\.\d+\.\d+\.\d+\.xip\.io$;
     root         /srv/www/wordpress-develop/build;
     include      /etc/nginx/nginx-wp-common.conf;
 }


### PR DESCRIPTION
local.wordpress._.xip.io
local.wordpress-trunk._.xip.io
src.wordpress-develop._.xip.io
build.wordpress-develop._.xip.io
where \* represents an IP address

The goal of these rules is to allow other devices on your network to
load these websites using URLs like the following
local.wordpress.192.168.1.10.xip.io
local.wordpress.10.0.1.20.xip.io

See #263

Fixes #448
