### PR TITLE
Instruct Curl to follow 302 redirect for Wordpress source files

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -456,7 +456,7 @@ if [[ $ping_result == *bytes?from* ]]; then
 	if [[ ! -d /srv/www/wordpress-default ]]; then
 		echo "Downloading WordPress Stable, see http://wordpress.org/"
 		cd /srv/www/
-		curl -O http://wordpress.org/latest.tar.gz
+		curl -L -O http://wordpress.org/latest.tar.gz
 		tar -xvf latest.tar.gz
 		mv wordpress wordpress-default
 		rm latest.tar.gz


### PR DESCRIPTION
Add a flag to the Curl statement in provision.sh so that it follows the redirect for the Wordpress.org `latest.tar.gz`
