### PR TITLE
Use HTTPS when downloading the latest WordPress package

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -456,7 +456,7 @@ if [[ $ping_result == *bytes?from* ]]; then
 	if [[ ! -d /srv/www/wordpress-default ]]; then
 		echo "Downloading WordPress Stable, see http://wordpress.org/"
 		cd /srv/www/
-		curl -L -O http://wordpress.org/latest.tar.gz
+		curl -L -O https://wordpress.org/latest.tar.gz
 		tar -xvf latest.tar.gz
 		mv wordpress wordpress-default
 		rm latest.tar.gz


### PR DESCRIPTION
See #350

"libcurl performs peer SSL certificate verification by default"
http://curl.haxx.se/docs/sslcerts.html

This is better practice and eliminates the current redirect from
HTTP to HTTPS. We'll leave the `-L` flag, as future redirects are
possible.

Thanks @nacin
