### PR TITLE
Add unique name to virtualbox to avoid collisions.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,11 +10,16 @@ Vagrant.configure("2") do |config|
   # with possible backward compatible issues.
   vagrant_version = Vagrant::VERSION.sub(/^v/, '')
 
+  # Give vm a name
+  config.vm.define "vvv" do |v|
+  end
+
   # Configurations from 1.0.x can be placed in Vagrant 1.1.x specs like the following.
   config.vm.provider :virtualbox do |v|
     v.customize ["modifyvm", :id, "--memory", 1024]
     v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
     v.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+    v.name = "vvv"
   end
 
   # Forward Agent


### PR DESCRIPTION
I ran into problems with box already exists messages. I believe it would be wise to use a vvv box name to provide a unique name for this virtualbox which is unlikely to collide with any other virtualboxes on the machine.

Prior to this it was 'default'.
