### PR TITLE
Install the mainline version of Nginx

### DIFF
--- a/config/apt-source-append.list
+++ b/config/apt-source-append.list
@@ -1,9 +1,9 @@
 # Additional sources will be added here to help control the
 # versions of various packages that are installed
 
-# Provides Nginx stable
-deb http://nginx.org/packages/ubuntu/ trusty nginx
-deb-src http://nginx.org/packages/ubuntu/ trusty nginx
+# Provides Nginx mainline
+deb http://nginx.org/packages/mainline/ubuntu/ trusty nginx
+deb-src http://nginx.org/packages/mainline/ubuntu/ trusty nginx
 
 # Provides Node.js
 deb http://ppa.launchpad.net/chris-lea/node.js/ubuntu trusty main


### PR DESCRIPTION
In the world of Nginx, mainline can be considered the most feature rich and the most stable. The "stable" release receives only bug updates. A good explanation of this was posted by the nginx project after the initial 1.7.x release from 1.6.x - http://nginx.com/blog/nginx-1-6-1-7-released/

I've used nginx 1.7.x in production since that day and have not had any troubles. I think we should be good to move to mainline as our default provisioning.

The way provisioning works in VVV, this will only be noticed during the initial `vagrant up` and then after running `apt-get update`, `apt-get install nginx` inside the VM. In the future, It would be nice to mark several packages as always updates or provide a script to run to update these when a solid Internet connection is available.
