### PR TITLE
Fix the ability to generate call graph images with Webgrind and graphviz

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -221,6 +221,14 @@ if [[ $ping_result == *bytes?from* ]]; then
 		npm install -g grunt-sass &>/dev/null
 		npm install -g grunt-cssjanus &>/dev/null
 	fi
+	
+	# graphviz
+	#
+	# Set up a symlink between the graphviz path defined in the default Webgrind
+	# config and the apt-get install path
+	echo "Adding graphviz symlink for Webgrind"
+	ln -sf /usr/bin/dot /usr/local/bin/dot
+	
 else
 	echo -e "\nNo network connection available, skipping package installation"
 fi


### PR DESCRIPTION
Webgrind's default config sets the path for graphviz to `/usr/local/bin/dot`, and during provisioning, apt-get installs graphviz to `/usr/bin/dot`.

So the proposal here is to simply symlink `/usr/local/bin/dot` to `/usr/bin/dot` -- without which you can't currently generate call graphs in Webgrind.
