### PR TITLE
Tweaked xdebug

### DIFF
--- a/config/php5-fpm-config/xdebug.ini
+++ b/config/php5-fpm-config/xdebug.ini
@@ -145,7 +145,7 @@ xdebug.profiler_enable_trigger = 1
 ; The directory where the profiler output will be written to, make sure that the user who the PHP
 ; will be running as has write permissions to that directory. This setting can not be set in your
 ; script with ini_set().
-;xdebug.profiler_output_dir = "C:\xampp\tmp"
+xdebug.profiler_output_dir = "/vagrant/tmp"
 
 ; xdebug.profiler_output_name
 ; Type: string, Default value: cachegrind.out.%p
@@ -156,21 +156,22 @@ xdebug.profiler_enable_trigger = 1
 ;
 ; See the xdebug.trace_output_name documentation for the supported specifiers.
 ;xdebug.profiler_output_name = "xdebug_profile.%R::%u"
-xdebug.profiler_output_name = "cachegrind.out.%t-%s"
+; xdebug.profiler_output_name = "cachegrind.out.%t-%s"
+xdebug.profiler_output_name = "profile-%t-%s.cachegrind"
 
 ; xdebug.remote_autostart
 ; Type: boolean, Default value: 0, VVV Default value: 1
 ; Normally you need to use a specific HTTP GET/POST variable to start remote debugging (see Remote
 ; Debugging). When this setting is set to 'On' Xdebug will always attempt to start a remote debugging
 ; session and try to connect to a client, even if the GET/POST/COOKIE variable was not present.
-xdebug.remote_autostart = 1
+xdebug.remote_autostart = 0
 
 ; xdebug.remote_enable
 ; Type: boolean, Default value: 0
 ; This switch controls whether Xdebug should try to contact a debug client which is listening on the
 ; host and port as set with the settings xdebug.remote_host and xdebug.remote_port. If a connection
 ; can not be established the script will just continue as if this setting was Off.
-xdebug.remote_enable = 1
+xdebug.remote_enable = 0
 
 ; xdebug.remote_handler
 ; Type: string, Default value: dbgp
@@ -190,7 +191,7 @@ xdebug.remote_host = "192.168.50.1"
 ; If set to a value, it is used as filename to a file to which all remote debugger communications are
 ; logged. The file is always opened in append-mode, and will therefore not be overwritten by default.
 ; There is no concurrency protection available.
-xdebug.remote_log = /tmp/xdebug-remote.log
+xdebug.remote_log = /vagrant/tmp/xdebug-remote.log
 
 ; xdebug.remote_mode
 ; Type: string, Default value: req
@@ -201,7 +202,7 @@ xdebug.remote_log = /tmp/xdebug-remote.log
 ;     Xdebug will try to connect to the debug client as soon as the script starts.
 ; jit
 ;     Xdebug will only try to connect to the debug client as soon as an error condition occurs.
-;xdebug.remote_mode = "req"
+xdebug.remote_mode = "jit"
 
 ; xdebug.remote_port
 ; Type: integer, Default value: 9000
@@ -248,7 +249,7 @@ xdebug.remote_port = 9000
 ; The directory where the tracing files will be written to, make sure that the user who the PHP will
 ; be running as has write permissions to that directory.
 ; xdebug.trace_output_name
-;xdebug.trace_output_dir = "C:\xampp\tmp"
+xdebug.trace_output_dir = "/vagrant/tmp"
 
 ; Type: string, Default value: trace.%c
 ;


### PR DESCRIPTION
Tweaked Xdebug to play nice: 

- added correct paths
- added JIT as remote mode 
- turned off autostart; instead, you need to pass `XDEBUG_PROFILE=1` as a GET or set a cookie