### PR TITLE
Support for Parallels Desktop

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -128,7 +128,7 @@ Vagrant.configure("2") do |config|
     # those are specific to Virtualbox. The folder is therefore overridden with one that
     # uses corresponding Parallels mount options.
     config.vm.provider :parallels do |v, override|
-      override.vm.synced_folder "database/data/", "/var/lib/mysql", :mount_options => [ "share" ]
+      override.vm.synced_folder "database/data/", "/var/lib/mysql", :mount_options => []
     end
   end
 
@@ -161,7 +161,7 @@ Vagrant.configure("2") do |config|
   # those are specific to Virtualbox. The folder is therefore overridden with one that
   # uses corresponding Parallels mount options.
   config.vm.provider :parallels do |v, override|
-    override.vm.synced_folder "www/", "/srv/www/", :owner => "www-data", :mount_options => [ "share" ]
+    override.vm.synced_folder "www/", "/srv/www/", :owner => "www-data", :mount_options => []
   end
 
   # Customfile - POSSIBLY UNSTABLE

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,6 +17,13 @@ Vagrant.configure("2") do |config|
     v.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
   end
 
+  # Configuration options for the Parallels Provider
+  config.vm.provider :parallels do |v|
+    v.update_guest_tools = true
+    v.optimize_power_consumption = false
+    v.memory = 1024
+  end
+
   # Forward Agent
   #
   # Enable agent forwarding on vagrant ssh commands. This allows you to use identities
@@ -29,6 +36,11 @@ Vagrant.configure("2") do |config|
   # box containing the Ubuntu 14.04 Trusty 64 bit release. Once this box is downloaded
   # to your host computer, it is cached for future use under the specified box name.
   config.vm.box = "ubuntu/trusty64"
+
+  # The Parallels Provider uses a different naming scheme.
+  config.vm.provider :parallels do |v, override|
+    override.vm.box = "parallels/ubuntu-14.04"
+  end
 
   config.vm.hostname = "vvv"
 
@@ -111,6 +123,13 @@ Vagrant.configure("2") do |config|
     else
       config.vm.synced_folder "database/data/", "/var/lib/mysql", :extra => 'dmode=777,fmode=777'
     end
+
+    # The Parallels Provider does not understand "dmode"/"fmode" in the "mount_options" as
+    # those are specific to Virtualbox. The folder is therefore overridden with one that
+    # uses corresponding Parallels mount options.
+    config.vm.provider :parallels do |v, override|
+      override.vm.synced_folder "database/data/", "/var/lib/mysql", :mount_options => [ "share" ]
+    end
   end
 
   # /srv/config/
@@ -136,6 +155,13 @@ Vagrant.configure("2") do |config|
     config.vm.synced_folder "www/", "/srv/www/", :owner => "www-data", :mount_options => [ "dmode=775", "fmode=774" ]
   else
     config.vm.synced_folder "www/", "/srv/www/", :owner => "www-data", :extra => 'dmode=775,fmode=774'
+  end
+
+  # The Parallels Provider does not understand "dmode"/"fmode" in the "mount_options" as
+  # those are specific to Virtualbox. The folder is therefore overridden with one that
+  # uses corresponding Parallels mount options.
+  config.vm.provider :parallels do |v, override|
+    override.vm.synced_folder "www/", "/srv/www/", :owner => "www-data", :mount_options => [ "share" ]
   end
 
   # Customfile - POSSIBLY UNSTABLE

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -364,9 +364,11 @@ else
 	echo -e "\nMySQL is not installed. No databases imported."
 fi
 
-# Run wp-cli as vagrant user
+# Run wp-cli, tar, and npm as `vagrant` user instead of `root`
 if (( $EUID == 0 )); then
     wp() { sudo -EH -u vagrant -- wp "$@"; }
+    tar() { sudo -EH -u vagrant -- tar "$@"; }
+    npm() { sudo -EH -u vagrant -- npm "$@"; }
 fi
 
 if [[ $ping_result == *bytes?from* ]]; then


### PR DESCRIPTION
Parallels Desktop offers an official and open-source Vagrant Provider plugin at http://parallels.github.io/vagrant-parallels/ and https://github.com/Parallels/vagrant-parallels.
The only real differences to our Virtualbox configuration that I have spotted after a quick glance are the box name and the way how machine settings are changed. Both of this can be overridden with provider-specific declarations in the Vagrantfile, as far as I can see.

I'll use this as a tracking issue for my experiments with adding support to VVV.