### PR TITLE
Fixes typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Immediate goals for VVV include:
 
 ## Copyright / License
 
-VVV is copyright (c) 2014, the contributors of the VVV project under the [MIT License](https://github.com/varying-vagrant-vagrants/vvv/blog/master/LICENSE].
+VVV is copyright (c) 2014, the contributors of the VVV project under the [MIT License](https://github.com/varying-vagrant-vagrants/vvv/blog/master/LICENSE).
 
 ## History
 


### PR DESCRIPTION
Fixes link to MIT License under Copyright/License section using malformed Markdown.
