### PR TITLE
Install the `npm-check-updates` module during provisioning

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -163,8 +163,11 @@ if [[ $ping_result == *bytes?from* ]]; then
 		apt-get clean
 	fi
 
-	# Make sure we have the latest npm version
+	# npm
+	#
+	# Make sure we have the latest npm version and the update checker module
 	npm install -g npm
+	npm install -g npm-check-updates
 
 	# xdebug
 	#


### PR DESCRIPTION
See https://www.npmjs.org/package/npm-check-updates
The module is useful to quickly check for updated Grunt modules in a package.json.

Used by @ocean90 as well: https://core.trac.wordpress.org/ticket/27340#comment:16 :-)