### PR TITLE
Add db_restore command in homebin so one-off restores can be done

### DIFF
--- a/config/homebin/db_restore
+++ b/config/homebin/db_restore
@@ -1,0 +1,4 @@
+#!/bin/bash
+#
+# Restore individual SQL files for each database.
+/srv/database/import-sql.sh


### PR DESCRIPTION
`db_restore` maps to `/srv/database/import-sql.sh` so no duplicate code here, however adding the command to the homebin makes it more easily accessible when doing manual backup/restore, outside of `vagrant halt` or `vagrant provision` (while vagrant is already up and running).