### PR TITLE
[PR] Allow Composer packages to update on `vagrant provision`

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -192,7 +192,6 @@ if [[ $ping_result == *bytes?from* ]]; then
 		curl -sS https://getcomposer.org/installer | php
 		chmod +x composer.phar
 		mv composer.phar /usr/local/bin/composer
-		COMPOSER_HOME=/usr/local/src/composer composer -q global config bin-dir /usr/local/bin
 	fi
 
 	# Update both Composer and any global packages. Updates to Composer are direct from


### PR DESCRIPTION
In the current state, the package versions specified for Composer are only applied on the initial provision. By reworking some of the logic here, we can make it possible to upgrade things like phpunit with a `vagrant provision`.
