### PR TITLE
[PR] Clean up GPG signing key handling

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -149,9 +149,10 @@ if [[ $ping_result == *bytes?from* ]]; then
 		echo "Applying Nginx signing key..."
 		wget --quiet http://nginx.org/keys/nginx_signing.key -O- | apt-key add -
 
-		# Launchpad nodejs key C7917B12
-		apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C7917B12
-		gpg -q -a --export  C7917B12  | apt-key add -
+		# Apply the nodejs assigning key
+		echo "Applying nodejs signing key..."
+		apt-key adv --quiet --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C7917B12 2>&1 | grep "gpg:"
+		apt-key export C7917B12 | apt-key add -
 
 		# update all of the package references before installing anything
 		echo "Running apt-get update..."


### PR DESCRIPTION
Use the work from @mirmillo as a base to clean up gpg key stuff, see #446.
- We're able to use `hkp` for port 80 requests to work around issues with restrictive proxies.
- We were actually using the wrong signing key for Nginx. This we can grab directly from nginx.org and apply as we go.

Total bonus - no more gpg red. :)
