### PR TITLE
Add box name

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,9 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+dir = Dir.pwd
 vagrant_dir = File.expand_path(File.dirname(__FILE__))
+vagrant_name = File.basename(dir)
 
 Vagrant.configure("2") do |config|
 
@@ -9,11 +11,16 @@ Vagrant.configure("2") do |config|
   # with possible backward compatible issues.
   vagrant_version = Vagrant::VERSION.sub(/^v/, '')
 
-  # Configuration options for the VirtualBox provider.
+  # Give vm a name
+  config.vm.define vagrant_name do |v|
+  end
+
+  # Configurations from 1.0.x can be placed in Vagrant 1.1.x specs like the following.
   config.vm.provider :virtualbox do |v|
     v.customize ["modifyvm", :id, "--memory", 1024]
     v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
     v.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+    v.name = vagrant_name
   end
 
   # Configuration options for the Parallels provider.


### PR DESCRIPTION
This is an improvement upon the original [PR #460](https://github.com/Varying-Vagrant-Vagrants/VVV/pull/460)

This now uses the current directory name for the box name, and this allows you to effectively configure the box name without actually configuring it.