### PR TITLE
install ntp service on provision

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -82,6 +82,9 @@ apt_package_check_list=(
 	colordiff
 	postfix
 
+	# ntp service to keep clock current
+	ntp
+
 	# Req'd for i18n tools
 	gettext
 


### PR DESCRIPTION
Issue: VVV system clock gets misaligned -- Working with (REST-)APIs requires a correct system clock or the request will be denied
Why: I "never" shut down my PC. Never power-down my VVV/Vagrant correctly. Host will go into "Hibernation" and power will be shut off

To keep the clock current lets run `ntp`. It takes up next to no processing power.
