### PR TITLE
[PR] Update phpMyAdmin to 4.2.13.1

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -566,11 +566,11 @@ PHP
 
 	# Download phpMyAdmin
 	if [[ ! -d /srv/www/default/database-admin ]]; then
-		echo "Downloading phpMyAdmin 4.2.11..."
+		echo "Downloading phpMyAdmin 4.2.13.1..."
 		cd /srv/www/default
-		wget -q -O phpmyadmin.tar.gz 'http://sourceforge.net/projects/phpmyadmin/files/phpMyAdmin/4.2.11/phpMyAdmin-4.2.11-all-languages.tar.gz/download'
+		wget -q -O phpmyadmin.tar.gz 'http://sourceforge.net/projects/phpmyadmin/files/phpMyAdmin/4.2.13.1/phpMyAdmin-4.2.13.1-all-languages.tar.gz/download'
 		tar -xf phpmyadmin.tar.gz
-		mv phpMyAdmin-4.2.11-all-languages database-admin
+		mv phpMyAdmin-4.2.13.1-all-languages database-admin
 		rm phpmyadmin.tar.gz
 	else
 		echo "PHPMyAdmin already installed."


### PR DESCRIPTION
4.3.1 is out, but I haven't done any testing with that. Let's go with 4.2.13.1 and then push to 4.3.1 after we ship.
