### PR TITLE
Grunt build task should run after both after initialization AND update

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -542,6 +542,8 @@ PHP
 		cd /srv/www/wordpress-develop/
 		echo "Running npm install for the first time, this may take several minutes..."
 		npm install &>/dev/null
+		echo "Running grunt for the first time, this may take a minute..."
+		grunt
 	else
 		echo "Updating WordPress develop..."
 		cd /srv/www/wordpress-develop/
@@ -556,11 +558,7 @@ PHP
 		fi
 		echo "Updating npm packages..."
 		npm install &>/dev/null
-	fi
-
-	if [[ ! -d /srv/www/wordpress-develop/build ]]; then
-		echo "Initializing grunt in WordPress develop... This may take a few moments."
-		cd /srv/www/wordpress-develop/
+		echo "Updating WordPress develop /build folder with grunt... This may take a minute."
 		grunt
 	fi
 


### PR DESCRIPTION
Previously the Grunt build task `grunt` (Alias of `grunt build`) would only run if the `/build` folder did not exist, `grunt build` should be performed after initial initilaztion of the WordPress develop repo AND after updating the repo.