### PR TITLE
Remove .sh extension from provision script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Some loose organization has grown around milestones and labels. We'll often have
 
 ### Bash Scripting
 
-For any shell scripting that we do in Bash — see `provision.sh` — we try to follow the style provided in Google's [Shell Style Guide](http://google-styleguide.googlecode.com/svn/trunk/shell.xml).
+For any shell scripting that we do in Bash — see `provision/provision` — we try to follow the style provided in Google's [Shell Style Guide](http://google-styleguide.googlecode.com/svn/trunk/shell.xml).
 
 ### PHP
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -154,26 +154,26 @@ Vagrant.configure("2") do |config|
   # Process one or more provisioning scripts depending on the existence of custom files.
   #
   # provison-pre.sh acts as a pre-hook to our default provisioning script. Anything that
-  # should run before the shell commands laid out in provision.sh (or your provision-custom.sh
+  # should run before the shell commands laid out in provision (or your provision-custom.sh
   # file) should go in this script. If it does not exist, no extra provisioning will run.
   if File.exists?(File.join(vagrant_dir,'provision','provision-pre.sh')) then
     config.vm.provision :shell, :path => File.join( "provision", "provision-pre.sh" )
   end
 
-  # provision.sh or provision-custom.sh
+  # provision or provision-custom.sh
   #
-  # By default, Vagrantfile is set to use the provision.sh bash script located in the
+  # By default, Vagrantfile is set to use the provision bash script located in the
   # provision directory. If it is detected that a provision-custom.sh script has been
   # created, that is run as a replacement. This is an opportunity to replace the entirety
   # of the provisioning provided by default.
   if File.exists?(File.join(vagrant_dir,'provision','provision-custom.sh')) then
     config.vm.provision :shell, :path => File.join( "provision", "provision-custom.sh" )
   else
-    config.vm.provision :shell, :path => File.join( "provision", "provision.sh" )
+    config.vm.provision :shell, :path => File.join( "provision", "provision" )
   end
 
   # provision-post.sh acts as a post-hook to the default provisioning. Anything that should
-  # run after the shell commands laid out in provision.sh or provision-custom.sh should be
+  # run after the shell commands laid out in provision or provision-custom.sh should be
   # put into this file. This provides a good opportunity to install additional packages
   # without having to replace the entire default provisioning script.
   if File.exists?(File.join(vagrant_dir,'provision','provision-post.sh')) then

--- a/provision/provision
+++ b/provision/provision
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# provision.sh
+# provision
 #
 # This file is specified in Vagrantfile and is loaded by Vagrant as the primary
 # provisioning script whenever the commands `vagrant up`, `vagrant provision`,

--- a/www/vvv-hosts
+++ b/www/vvv-hosts
@@ -1,7 +1,7 @@
 # This file contains a list of the domains supported by default
-# in Varying Vagrant Vagrants. Both Vagrantfile and provision.sh
-# parse this file for domains to add to both your host and guest
-# machines as the virtual machines boot.
+# in Varying Vagrant Vagrants. Both Vagrantfile and the provision
+# script parse this file for domains to add to both your host and
+# guest machines as the virtual machines boot.
 #
 # In addition to this file, other files named vvv-hosts can
 # be created with additional domain information. These will be


### PR DESCRIPTION
In Contributing.md, it mentions that VVV follows [Google's shell style guide](https://google-styleguide.googlecode.com/svn/trunk/shell.xml#File_Extensions). 

If so, we should remove the `.sh` extension from our scripts, mainly `provision.sh`, as its preferred to keep them without an extension. "Executables should have no extension (strongly preferred)"

This PR renames it, and updates all references to the script as well. I've left database/import-sql.sh for now, and we can also rename that if you want.
