### PR TITLE
Don't ignore SVN externals for WordPress /trunk

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -518,7 +518,7 @@ PHP
 	else
 		echo "Updating WordPress trunk..."
 		cd /srv/www/wordpress-trunk
-		svn up --ignore-externals
+		svn up
 	fi
 
 	# Checkout, install and configure WordPress trunk via develop.svn


### PR DESCRIPTION
If a new version of Akismet is shipped let `svn up` grab that latest version for WordPress `/trunk`