### PR TITLE
Use single files per table

### DIFF
--- a/config/mysql-config/my.cnf
+++ b/config/mysql-config/my.cnf
@@ -83,3 +83,6 @@ max_allowed_packet	= 128M
 #   The files must end with '.cnf', otherwise they'll be ignored.
 #
 !includedir /etc/mysql/conf.d/
+
+# Minor performance improvement if you're creating/droping DBs and need to reclaim disk space
+innodb_file_per_table = 1


### PR DESCRIPTION
When adding databases to the engine, MySQL adds them all to
the _same_ file by default (in < 5.6.6). When removing these databases
later, MySQL fails to truncate the file, leading to used disk space that's
not actually being used. By specifying one file per table, end users can
more easily free disk space when projects are archived/removed.

Also note, this is a feature that is on by default in MySQL >= 5.6.6, so
we might as well bake it in now to get the management benefits and get
everyone ready for an eventual version update.

Fixes #537