### PR TITLE
wp-cli support for local machine

### DIFF
--- a/config/wp-cli/local.php
+++ b/config/wp-cli/local.php
@@ -1,0 +1,8 @@
+<?php
+
+define('DB_HOST', 'vvv.dev:3306');
+
+define('DB_USER', 'external');
+define('DB_PASSWORD', 'external');
+
+

--- a/config/wp-cli/quiet.php
+++ b/config/wp-cli/quiet.php
@@ -1,0 +1,4 @@
+<?php 
+error_reporting(0);
+@ini_set('display_errors', 0);
+define( 'WP_DEBUG', false );

--- a/wp-cli.yml
+++ b/wp-cli.yml
@@ -1,0 +1,3 @@
+require:
+  - config/wp-cli/local.php
+  - config/wp-cli/quiet.php


### PR DESCRIPTION
Closes #563 

This defines a custom `wp-cli.yml` for external use on the host machine. 

If you have `wp-cli` installed locally and wanted to use it there instead of through vagrant ssh or other methods this should do it. 

It accomplishes this by requiring a few php files to silence uneccessary warnings and to redefine the database for connecting from outside the VM. 

So far in all local testing it has worked great.