### PR TITLE
Disable the treatment of 404 by Nginx

### DIFF
--- a/config/nginx-config/nginx-wp-common.conf
+++ b/config/nginx-config/nginx-wp-common.conf
@@ -47,7 +47,7 @@ if (!-e $request_filename) {
 location ~ \.php$ {
     # Try the files specified in order. In our case, try the requested URI and if
     # that fails, try (successfully) to pass a 404 error.
-    try_files      $uri =404;
+    # try_files      $uri =404;
 
     # Include the fastcgi_params defaults provided by nginx
     include        /etc/nginx/fastcgi_params;


### PR DESCRIPTION
By disabling the treatment of 404 by Nginx, it lets Wordpress the charge to manage the error 404 by charging the 404 page of the theme.