### PR TITLE
set your GitHub token easily for Composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /provision/provision-custom.sh
 /provision/provision-pre.sh
 /provision/provision-post.sh
+/provision/github.token
 
 # Ignore custom trigger scripts in config/homebin.
 /config/homebin/vagrant_halt_custom

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -206,6 +206,12 @@ if [[ $ping_result == "Connected" ]]; then
 		mv composer.phar /usr/local/bin/composer
 	fi
 
+	if [[ -f /vagrant/provision/github.token ]]; then
+		ghtoken=`cat /vagrant/provision/github.token`
+		composer config --global github-oauth.github.com $ghtoken
+		echo "Your personal GitHub token is set for Composer."
+	fi
+
 	# Update both Composer and any global packages. Updates to Composer are direct from
 	# the master branch on its GitHub repository.
 	if [[ -n "$(composer --version --no-ansi | grep 'Composer version')" ]]; then


### PR DESCRIPTION
Just create a simple text file named `provision/github.token` with only your gh token to automatically set the token for composer