### PR TITLE
install phpcs via composer

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -463,7 +463,7 @@ if [[ $ping_result == "Connected" ]]; then
 		fi
 	fi
 	# Install the standards in PHPCS
-	sudo /srv/www/phpcs/scripts/phpcs --config-set installed_paths ./CodeSniffer/Standards/WordPress/
+	sudo /srv/www/phpcs/scripts/phpcs --config-set installed_paths /srv/www/phpcs-wordpress/
 	sudo /srv/www/phpcs/scripts/phpcs --config-set default_standard WordPress-Core
 	sudo /srv/www/phpcs/scripts/phpcs -i
 

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -215,6 +215,7 @@ if [[ $ping_result == "Connected" ]]; then
 		COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update phpunit/php-invoker:1.1.*
 		COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update mockery/mockery:0.9.*
 		COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update d11wtq/boris:v1.0.8
+		COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update squizlabs/php_codesniffer:2.*
 		COMPOSER_HOME=/usr/local/src/composer composer -q global config bin-dir /usr/local/bin
 		COMPOSER_HOME=/usr/local/src/composer composer global update
 	fi
@@ -448,26 +449,12 @@ if [[ $ping_result == "Connected" ]]; then
 		git pull --rebase origin master
 	fi
 
-	# PHP_CodeSniffer (for running WordPress-Coding-Standards)
-	if [[ ! -d /srv/www/phpcs ]]; then
-		echo -e "\nDownloading PHP_CodeSniffer (phpcs), see https://github.com/squizlabs/PHP_CodeSniffer"
-		git clone -b master https://github.com/squizlabs/PHP_CodeSniffer.git /srv/www/phpcs
-	else
-		cd /srv/www/phpcs
-		if [[ $(git rev-parse --abbrev-ref HEAD) == 'master' ]]; then
-			echo -e "\nUpdating PHP_CodeSniffer (phpcs)..."
-			git pull --no-edit origin master
-		else
-			echo -e "\nSkipped updating PHP_CodeSniffer since not on master branch"
-		fi
-	fi
-
 	# Sniffs WordPress Coding Standards
-	if [[ ! -d /srv/www/phpcs/CodeSniffer/Standards/WordPress ]]; then
+	if [[ ! -d /srv/www/phpcs-wordpress ]]; then
 		echo -e "\nDownloading WordPress-Coding-Standards, sniffs for PHP_CodeSniffer, see https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards"
-		git clone -b master https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git /srv/www/phpcs/CodeSniffer/Standards/WordPress
+		git clone -b master https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git /srv/www/phpcs-wordpress
 	else
-		cd /srv/www/phpcs/CodeSniffer/Standards/WordPress
+		cd /srv/www/phpcs-wordpress
 		if [[ $(git rev-parse --abbrev-ref HEAD) == 'master' ]]; then
 			echo -e "\nUpdating PHP_CodeSniffer WordPress Coding Standards..."
 			git pull --no-edit origin master
@@ -476,9 +463,9 @@ if [[ $ping_result == "Connected" ]]; then
 		fi
 	fi
 	# Install the standards in PHPCS
-	/srv/www/phpcs/scripts/phpcs --config-set installed_paths ./CodeSniffer/Standards/WordPress/
-	/srv/www/phpcs/scripts/phpcs --config-set default_standard WordPress-Core
-	/srv/www/phpcs/scripts/phpcs -i
+	sudo /srv/www/phpcs/scripts/phpcs --config-set installed_paths ./CodeSniffer/Standards/WordPress/
+	sudo /srv/www/phpcs/scripts/phpcs --config-set default_standard WordPress-Core
+	sudo /srv/www/phpcs/scripts/phpcs -i
 
 	# Install and configure the latest stable version of WordPress
 	if [[ ! -d /srv/www/wordpress-default ]]; then


### PR DESCRIPTION
phpcs needs to be installed via composer to reduce the provision process significantly. My last `vagrant provision` took __7039__ seconds! mostly due to git clones.