### PR TITLE
Move network configuration up

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -53,6 +53,22 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.hostname = "vvv"
+  
+  # Private Network (default)
+  #
+  # A private network is created by default. This is the IP address through which your
+  # host machine will communicate to the guest. In this default configuration, the virtual
+  # machine will have an IP address of 192.168.50.4 and a virtual network adapter will be
+  # created on your host machine with the IP of 192.168.50.1 as a gateway.
+  #
+  # Access to the guest machine is only available to your local host. To provide access to
+  # other devices, a public network should be configured or port forwarding enabled.
+  #
+  # Note: If your existing network is using the 192.168.50.x subnet, this default IP address
+  # should be changed. If more than one VM is running through VirtualBox, including other
+  # Vagrant machines, different subnets should be used for each.
+  #
+  config.vm.network :private_network, ip: "192.168.50.4"
 
   # Local Machine Hosts
   #
@@ -82,22 +98,6 @@ Vagrant.configure("2") do |config|
     config.hostsupdater.aliases = hosts
     config.hostsupdater.remove_on_suspend = true
   end
-
-  # Private Network (default)
-  #
-  # A private network is created by default. This is the IP address through which your
-  # host machine will communicate to the guest. In this default configuration, the virtual
-  # machine will have an IP address of 192.168.50.4 and a virtual network adapter will be
-  # created on your host machine with the IP of 192.168.50.1 as a gateway.
-  #
-  # Access to the guest machine is only available to your local host. To provide access to
-  # other devices, a public network should be configured or port forwarding enabled.
-  #
-  # Note: If your existing network is using the 192.168.50.x subnet, this default IP address
-  # should be changed. If more than one VM is running through VirtualBox, including other
-  # Vagrant machines, different subnets should be used for each.
-  #
-  config.vm.network :private_network, ip: "192.168.50.4"
 
   # Public Network (disabled)
   #


### PR DESCRIPTION
It seems that vagrant-hostsupdater needs to know private network 
configuration (IP address). At least that sounds logical to me.
I had to change the IP address and found that vagrant-hottsupdater did
not write the new IP into `/etc/hosts`.