### PR TITLE
Expose additional MySQL logs for peformance and troubleshooting.

### DIFF
--- a/config/mysql-config/my.cnf
+++ b/config/mysql-config/my.cnf
@@ -64,9 +64,9 @@ max_allowed_packet	= 128M
 log_error = /var/log/mysql/error.log
 #
 # Here you can see queries with especially long duration
-#log_slow_queries	= /var/log/mysql/mysql-slow.log
-#long_query_time = 2
-#log-queries-not-using-indexes
+log_slow_queries        = /srv/log/mysql_slow.log
+long_query_time = 2
+log-queries-not-using-indexes
 
 [mysqldump]
 quick

--- a/config/mysql-config/my.cnf
+++ b/config/mysql-config/my.cnf
@@ -61,7 +61,7 @@ max_allowed_packet	= 128M
 #
 # Error log - should be very few entries.
 #
-log_error = /var/log/mysql/error.log
+log_error = /srv/log/mysql_error.log
 #
 # Here you can see queries with especially long duration
 log_slow_queries        = /srv/log/mysql_slow.log


### PR DESCRIPTION
This PR resolves #596

I enabled the error logs and also enabled the performance logging.
Mysql logs will be exposed through the /srv/log folder.