### PR TITLE
Adds mailcatcher support.

### DIFF
--- a/config/init/mailcatcher.conf
+++ b/config/init/mailcatcher.conf
@@ -1,0 +1,8 @@
+description "Mailcatcher"
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+respawn
+
+exec /usr/local/rvm/bin/mailcatcher --foreground --http-ip=0.0.0.0

--- a/config/init/vvv-start.conf
+++ b/config/init/vvv-start.conf
@@ -9,4 +9,5 @@ service nginx start
 service php5-fpm start
 service memcached start
 service mysql start
+service mailcatcher start
 end script

--- a/config/php5-fpm-config/mailcatcher.ini
+++ b/config/php5-fpm-config/mailcatcher.ini
@@ -1,0 +1,1 @@
+sendmail_path = "/usr/local/rvm/bin/catchmail -f admin@local.dev"

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -99,6 +99,10 @@ apt_package_check_list=(
 	# nodejs for use by grunt
 	g++
 	nodejs
+
+	#Mailcatcher requirement
+	libsqlite3-dev
+
 )
 
 echo "Check for apt packages to install..."
@@ -330,18 +334,81 @@ if [[ -f /srv/config/bash_prompt ]]; then
 	echo " * Copied /srv/config/bash_prompt                       to /home/vagrant/.bash_prompt"
 fi
 
+# Mailcatcher
+# 
+# Installs mailcatcher using RVM. RVM allows us to install the
+# current version of ruby and all mailcatcher dependencies reliably.
+rvm_version="$(/usr/bin/env rvm --silent --version 2>&1 | grep 'rvm ' | cut -d " " -f 2)"
+if [[ -n "${rvm_version}" ]]; then
+
+	pkg="RVM"
+	space_count="$(expr 20 - "${#pkg}")" #11
+	pack_space_count="$(expr 30 - "${#rvm_version}")"
+	real_space="$(expr ${space_count} + ${pack_space_count} + ${#rvm_version})"
+	printf " * $pkg %${real_space}.${#rvm_version}s ${rvm_version}\n"
+else
+	# RVM key D39DC0E3
+	# Signatures introduced in 1.26.0
+	gpg -q --no-tty --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys D39DC0E3
+	gpg -q --no-tty --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys BF04FF17
+	
+	printf " * RVM [not installed]\n Installing from source"
+	curl --silent -L https://get.rvm.io | sudo bash -s stable --ruby
+	source /usr/local/rvm/scripts/rvm
+fi
+
+mailcatcher_version="$(/usr/bin/env mailcatcher --version 2>&1 | grep 'mailcatcher ' | cut -d " " -f 2)"
+if [[ -n "${mailcatcher_version}" ]]; then
+	pkg="Mailcatcher"
+	space_count="$(expr 20 - "${#pkg}")" #11
+	pack_space_count="$(expr 30 - "${#mailcatcher_version}")"
+	real_space="$(expr ${space_count} + ${pack_space_count} + ${#mailcatcher_version})"
+	printf " * $pkg %${real_space}.${#mailcatcher_version}s ${mailcatcher_version}\n"
+else
+	echo " * Mailcatcher [not installed]"
+	/usr/bin/env rvm default@mailcatcher --create do gem install mailcatcher --no-rdoc --no-ri
+
+
+	/usr/bin/env rvm default@mailcatcher --create do gem install mailcatcher --no-rdoc --no-ri
+	/usr/bin/env rvm wrapper default@mailcatcher --no-prefix mailcatcher catchmail
+	# /usr/bin/env rvm default@mailcatcher do gem install i18n -v 0.6.11
+	# /usr/bin/env rvm default@mailcatcher do gem uninstall i18n -Ix --version '>0.6.11'
+			
+fi
+
+
+if [[ -f /etc/init/mailcatcher.conf ]]; then
+	echo " *" Mailcatcher upstart already configured.
+else
+	cp /srv/config/init/mailcatcher.conf  /etc/init/mailcatcher.conf
+	echo " * Copied /srv/config/init/mailcatcher.conf    to /etc/init/mailcatcher.conf"	
+fi
+
+if [[ -f /etc/php5/mods-available/mailcatcher.ini ]]; then
+	echo " *" Mailcatcher php5 fpm already configured.
+else
+	# cp /srv/config/php5-fpm-config/mailcatcher.ini  /etc/php5/fpm/conf.d/mailcatcher.ini
+	cp /srv/config/php5-fpm-config/mailcatcher.ini /etc/php5/mods-available/mailcatcher.ini
+	echo " * Copied /srv/config/php5-fpm-config/mailcatcher.ini    to /etc/php5/mods-available/mailcatcher.ini"
+fi
+
+
 # RESTART SERVICES
 #
 # Make sure the services we expect to be running are running.
 echo -e "\nRestart services..."
 service nginx restart
 service memcached restart
+service mailcatcher restart
 
 # Disable PHP Xdebug module by default
 php5dismod xdebug
 
 # Enable PHP mcrypt module by default
 php5enmod mcrypt
+
+# Enable PHP mailcatcher sendmail settings by default
+php5enmod mailcatcher
 
 service php5-fpm restart
 

--- a/www/default/index.php
+++ b/www/default/index.php
@@ -24,6 +24,7 @@ if ( file_exists( 'dashboard-custom.php' ) ) {
 	<li><a href="database-admin/">phpMyAdmin</a></li>
 	<li><a href="memcached-admin/">phpMemcachedAdmin</a></li>
 	<li><a href="opcache-status/opcache.php">Opcache Status</a></li>
+	<li><a href="http://vvv.dev:1080">Mailcatcher</a></li>
 	<li><a href="webgrind/">Webgrind</a></li>
 	<li><a href="phpinfo/">PHP Info</a></li>
 </ul>


### PR DESCRIPTION
This PR replaces #464 

This is based off of the `develop` branch and should be used instead.

Includes:
 RVM install
 mailcatcher install
 startup script
 PHP smtp configuration
 dashboard link to port

Later revisions also did the following:
 Fixes issues with signature checks in the RVM installation process.
 Removed the stopgap fix for i18n dependency issues of past.
 Added blank lines per request.