### PR TITLE
fix typo on "helpful" header in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ A bunch of stuff!
 * The [WordPress and Vagrant Mailing list](https://groups.google.com/forum/#!forum/wordpress-and-vagrant) is a great place to get started for any related topics.
 * The [VVV Wiki](https://github.com/varying-vagrant-vagrants/vvv/wiki) also contains documentation that may help.
 
-### Helfpul Extensions
+### Helpful Extensions
 
 Supporting init scripts during provisioning allows for some great extensions of VVV core.
 


### PR DESCRIPTION
There was a typo in 'helpful' unless it's some obscure pun. Tiny change but reads better.