### PR TITLE
Add support for VMWare Workstation

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,6 +51,11 @@ Vagrant.configure("2") do |config|
   config.vm.provider :vmware_fusion do |v, override|
     override.vm.box = "netsensia/ubuntu-trusty64"
   end
+  
+  # VMWare Workstation can use the same package as Fusion
+  config.vm.provider :vmware_workstation do |v, override|
+    override.vm.box = "netsensia/ubuntu-trusty64"
+  end
 
   config.vm.hostname = "vvv"
 


### PR DESCRIPTION
The Vagrant VMWare Workstation plugin (for Windows) is compatible with Fusion images but you still have to specify `--provider=vmware_workstation`. However, the VVV Vagrantfile tries to load the default box in such case, so I added a conditional for the vmware_workstation provider so that it uses the Fusion box. 

Provisioned it, works without issues.