### PR TITLE
Fix phpMyAdmin permission issue on VMWare

### DIFF
--- a/config/phpmyadmin-config/config.inc.php
+++ b/config/phpmyadmin-config/config.inc.php
@@ -140,3 +140,5 @@ $cfg['SaveDir'] = '';
  */
 
 $cfg['AllowUserDropDatabase'] = true;
+
+$cfg['CheckConfigurationPermissions'] = false;


### PR DESCRIPTION
On VMWare, the default shared folder permissions are 777, which makes phpMyAdmin uncooperative, giving the following error message when trying to use it:

```
Wrong permissions on configuration file, should not be world writable!
```

This patch will disable permission checking in phpMyAdmin to get around this. The permission checking is a mechanism to avoid security issues on shared hosts, but since VVV is presumed to be a development environment this should cause no issues.