### PR TITLE
[PR] Allow for a custom phpMyAdmin configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@
 # No need to share individual site configs with each other
 /config/nginx-config/sites/*.conf
 
+# No need to share custom phpMyAdmin config with each other
+/config/phpmyadmin-config/config.inc.custom.php
+
 # Ignore anything in the 'custom' directory in config
 /config/custom/*
 

--- a/.gitignore
+++ b/.gitignore
@@ -22,9 +22,6 @@
 # No need to share individual site configs with each other
 /config/nginx-config/sites/*.conf
 
-# No need to share custom phpMyAdmin config with each other
-/config/phpmyadmin-config/config.inc.custom.php
-
 # Ignore anything in the 'custom' directory in config
 /config/custom/*
 
@@ -58,3 +55,6 @@
 # And a few of our web directories are important to share.
 /www/default/*
 !/www/default/index.php
+
+# But not the custom phpMyAdmin config in the database-admin directory.
+/www/default/database-admin/config.inc.custom.php

--- a/config/phpmyadmin-config/config.inc.php
+++ b/config/phpmyadmin-config/config.inc.php
@@ -62,6 +62,11 @@ $cfg['Servers'][$i]['AllowNoPassword'] = false;
 // $cfg['Servers'][$i]['auth_swekey_config'] = '/etc/swekey-pma.conf';
 
 /*
+ * VVV - Include custom configuration file, if exists.
+ */
+include('config.inc.custom.php');
+
+/*
  * End of servers configuration
  */
 

--- a/config/phpmyadmin-config/config.inc.php
+++ b/config/phpmyadmin-config/config.inc.php
@@ -62,11 +62,6 @@ $cfg['Servers'][$i]['AllowNoPassword'] = false;
 // $cfg['Servers'][$i]['auth_swekey_config'] = '/etc/swekey-pma.conf';
 
 /*
- * VVV - Include custom configuration file, if exists.
- */
-include('config.inc.custom.php');
-
-/*
  * End of servers configuration
  */
 
@@ -147,3 +142,10 @@ $cfg['SaveDir'] = '';
 $cfg['AllowUserDropDatabase'] = true;
 
 $cfg['CheckConfigurationPermissions'] = false;
+
+/*
+ * Include a custom configuration file for phpMyAdmin if it exists locally.
+ */
+if ( file_exists( 'config.inc.custom.php' ) ) {
+	include( 'config.inc.custom.php' );
+}

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -649,7 +649,7 @@ PHP
 
 	# Download phpMyAdmin
 	if [[ ! -d /srv/www/default/database-admin ]]; then
-		echo "Downloading phpMyAdmin 4.2.13.1..."
+		echo "Downloading phpMyAdmin..."
 		cd /srv/www/default
 		wget -q -O phpmyadmin.tar.gz 'https://files.phpmyadmin.net/phpMyAdmin/4.4.10/phpMyAdmin-4.4.10-all-languages.tar.gz'
 		tar -xf phpmyadmin.tar.gz

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -659,6 +659,7 @@ PHP
 		echo "PHPMyAdmin already installed."
 	fi
 	cp /srv/config/phpmyadmin-config/config.inc.php /srv/www/default/database-admin/
+	cp /srv/config/phpmyadmin-config/config.inc.custom.php /srv/www/default/database-admin/
 else
 	echo -e "\nNo network available, skipping network installations"
 fi

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -659,7 +659,6 @@ PHP
 		echo "PHPMyAdmin already installed."
 	fi
 	cp /srv/config/phpmyadmin-config/config.inc.php /srv/www/default/database-admin/
-	cp /srv/config/phpmyadmin-config/config.inc.custom.php /srv/www/default/database-admin/
 else
 	echo -e "\nNo network available, skipping network installations"
 fi


### PR DESCRIPTION
If `config.inc.custom.php` exists in the `www/default/database-admin/` directory alongside the default `config.inc.php` file, it will be included so that our default configuration for phpMyAdmin can be overridden.

Props @grantnorwood for the initial approach in #588.