### PR TITLE
[PR] Revert "Fix phpMyAdmin permission issue on VMWare"

### DIFF
--- a/config/phpmyadmin-config/config.inc.php
+++ b/config/phpmyadmin-config/config.inc.php
@@ -141,8 +141,6 @@ $cfg['SaveDir'] = '';
 
 $cfg['AllowUserDropDatabase'] = true;
 
-$cfg['CheckConfigurationPermissions'] = false;
-
 /*
  * Include a custom configuration file for phpMyAdmin if it exists locally.
  */


### PR DESCRIPTION
We now provide a custom config file for phpMyAdmin and should
use that as a way to override settings such as this for other
providers. This is specifically a concern due to possible
security issues on public networks.

This reverts commit b18ca1347453da386733192930497b2c6f286218.

See #657 for conversation.