### PR TITLE
[PR] Be explicit about defaults in XDebug configuration

### DIFF
--- a/config/php5-fpm-config/xdebug.ini
+++ b/config/php5-fpm-config/xdebug.ini
@@ -4,7 +4,7 @@
 ; Type: boolean, Default value: 0
 ; When this setting is set to on, the tracing of function calls will be enabled just before the
 ; script is run. This makes it possible to trace code in the auto_prepend_file.
-;xdebug.auto_trace = 1
+xdebug.auto_trace = 0
 
 ; xdebug.collect_includes
 ; Type: boolean, Default value: 1
@@ -23,7 +23,7 @@ xdebug.collect_params = 1
 ; Type: boolean, Default value: 0
 ; This setting, defaulting to Off, controls whether Xdebug should write the return value of function
 ; calls to the trace files.
-;xdebug.collect_return = 0
+xdebug.collect_return = 0
 
 ; xdebug.collect_vars
 ; Type: boolean, Default value: Off
@@ -31,14 +31,14 @@ xdebug.collect_params = 1
 ; This analysis can be quite slow as Xdebug has to reverse engineer PHP's opcode arrays. This setting
 ; will not record which values the different variables have, for that use xdebug.collect_params. This
 ; setting needs to be enabled only if you wish to use xdebug_get_declared_vars().
-;xdebug.collect_vars = "Off"
+xdebug.collect_vars = "Off"
 
 ; xdebug.default_enable
 ; Type: boolean, Default value: On
 ; If this setting is On then stacktraces will be shown by default on an error event. You can disable
 ; showing stacktraces from your code with xdebug_disable(). As this is one of the basic functions of
 ; Xdebug, it is advisable to leave this setting set to 'On'.
-;xdebug.default_enable = "On"
+xdebug.default_enable = "On"
 
 ; xdebug.dump.*
 ; Type: string, Default value: Empty
@@ -48,15 +48,13 @@ xdebug.collect_params = 1
 ; spaces in this setting. In order to dump the REMOTE_ADDR and the REQUEST_METHOD when an error
 ; occurs, add this setting:
 ;
-; xdebug.dump.SERVER = REMOTE_ADDR,REQUEST_METHOD
-; xdebug.dump.SERVER = REMOTE_ADDR,REQUEST_METHOD
-;xdebug.dump.COOKIE = ""
-;xdebug.dump.FILES = ""
-;xdebug.dump.GET = ""
-;xdebug.dump.POST = ""
-;xdebug.dump.REQUEST = ""
-;xdebug.dump.SERVER = ""
-;xdebug.dump.SESSION = ""
+xdebug.dump.COOKIE = ""
+xdebug.dump.FILES = ""
+xdebug.dump.GET = ""
+xdebug.dump.POST = ""
+xdebug.dump.REQUEST = ""
+xdebug.dump.SERVER = ""
+xdebug.dump.SESSION = ""
 
 ; xdebug.dump_globals
 ; Type: boolean, Default value: 1
@@ -68,13 +66,13 @@ xdebug.dump_globals = 1
 ; Type: boolean, Default value: 1
 ; Controls whether the values of the superglobals should be dumped on all error situations (set to
 ; Off) or only on the first (set to On).
-;xdebug.dump_once = 1
+xdebug.dump_once = 1
 
 ; xdebug.dump_undefined
 ; Type: boolean, Default value: 0
 ; If you want to dump undefined values from the superglobals you should set this setting to On,
 ; otherwise leave it set to Off.
-;xdebug.dump_undefined = 0
+xdebug.dump_undefined = 0
 
 ; xdebug.extended_info
 ; Type: integer, Default value: 1
@@ -83,7 +81,7 @@ xdebug.dump_globals = 1
 ; generally want to turn off this option as PHP's generated oparrays will increase with about a third
 ; of the size slowing down your scripts. This setting can not be set in your scripts with ini_set(),
 ; but only in php.ini.
-;xdebug.extended_info = 1
+xdebug.extended_info = 1
 
 ; xdebug.file_link_format
 ; Type: string, Default value: *empty string* , Introduced in Xdebug 2.1
@@ -91,7 +89,7 @@ xdebug.dump_globals = 1
 ; This setting determines the format of the links that are made in the display of stack traces where
 ; file names are used. This allows IDEs to set up a link-protocol that makes it possible to go
 ; directly to a line and file by clicking on the filenames that Xdebug shows in stack traces.
-;xdebug.file_link_format = ""
+xdebug.file_link_format = ""
 
 ; xdebug.idekey
 ; Type: string, Default value: *complex*
@@ -105,34 +103,34 @@ xdebug.idekey = "VVVDEBUG"
 ; Type: string, Default value: http://www.php.net
 ; This is the base url for the links from the function traces and error message to the manual pages
 ; of the function from the message. It is advisable to set this setting to use the closest mirror.
-;xdebug.manual_url = "http://www.php.net"
+xdebug.manual_url = "http://www.php.net"
 
 ; xdebug.max_nesting_level
 ; Type: integer, Default value: 100
 ; Controls the protection mechanism for infinite recursion protection. The value of this setting is
 ; the maximum level of nested functions that are allowed before the script will be aborted.
-;xdebug.max_nesting_level = 100
+xdebug.max_nesting_level = 100
 
 ; xdebug.overload_var_dump
 ; Type: boolean, Default value: 1 , Introduced in Xdebug 2.1
 ; By default Xdebug overloads var_dump() with its own improved version for displaying variables when
 ; the html_errors php.ini setting is set to 1. In case you do not want that, you can set this setting
 ; to 0, but check first if it's not smarter to turn off html_errors.
-;xdebug.overload_var_dump = 1
+xdebug.overload_var_dump = 1
 
 ; xdebug.profiler_append
 ; Type: integer, Default value: 0
 ; When this setting is set to 1, profiler files will not be overwritten when a new request would map
 ; to the same file (depnding on the xdebug.profiler_output_name setting. Instead the file will be
 ; appended to with the new profile.
-;xdebug.profiler_append = 0
+xdebug.profiler_append = 0
 
 ; xdebug.profiler_enable
 ; Type: integer, Default value: 0
 ; Enables Xdebug's profiler which creates files in the profile output directory. Those files can be
 ; read by KCacheGrind to visualize your data. This setting can not be set in your script with ini_set
 ; ().
-;xdebug.profiler_enable = 0
+xdebug.profiler_enable = 0
 
 ; xdebug.profiler_enable_trigger
 ; Type: integer, Default value: 0
@@ -145,7 +143,7 @@ xdebug.profiler_enable_trigger = 1
 ; The directory where the profiler output will be written to, make sure that the user who the PHP
 ; will be running as has write permissions to that directory. This setting can not be set in your
 ; script with ini_set().
-;xdebug.profiler_output_dir = "C:\xampp\tmp"
+xdebug.profiler_output_dir = "/tmp"
 
 ; xdebug.profiler_output_name
 ; Type: string, Default value: cachegrind.out.%p
@@ -155,7 +153,6 @@ xdebug.profiler_enable_trigger = 1
 ; several format specifiers that can be used to format the file name.
 ;
 ; See the xdebug.trace_output_name documentation for the supported specifiers.
-;xdebug.profiler_output_name = "xdebug_profile.%R::%u"
 xdebug.profiler_output_name = "cachegrind.out.%t-%s"
 
 ; xdebug.remote_autostart
@@ -177,7 +174,7 @@ xdebug.remote_enable = 1
 ; Can be either 'php3' which selects the old PHP 3 style debugger output, 'gdb' which enables the GDB
 ; like debugger interface or 'dbgp' - the brand new debugger protocol. The DBGp protocol is more
 ; widely supported by clients. See more information in the introduction for Remote Debugging.
-;xdebug.remote_handler = "dbgp"
+xdebug.remote_handler = "dbgp"
 
 ; xdebug.remote_host
 ; Type: string, Default value: localhost
@@ -201,7 +198,7 @@ xdebug.remote_log = /tmp/xdebug-remote.log
 ;     Xdebug will try to connect to the debug client as soon as the script starts.
 ; jit
 ;     Xdebug will only try to connect to the debug client as soon as an error condition occurs.
-;xdebug.remote_mode = "req"
+xdebug.remote_mode = "req"
 
 ; xdebug.remote_port
 ; Type: integer, Default value: 9000
@@ -214,41 +211,41 @@ xdebug.remote_port = 9000
 ; Type: integer, Default value: 0
 ; When this setting is set to 1, Xdebug will show a stack trace whenever an exception is raised -
 ; even if this exception is actually caught.
-;xdebug.show_exception_trace = 0
+xdebug.show_exception_trace = 0
 
 ; xdebug.show_local_vars
 ; Type: integer, Default value: 0
 ; When this setting is set to something != 0 Xdebug's generated stack dumps in error situations will
 ; also show all variables in the top-most scope. Beware that this might generate a lot of
 ; information, and is therefore turned off by default.
-;xdebug.show_local_vars = 0
+xdebug.show_local_vars = 0
 
 ; xdebug.show_mem_delta
 ; Type: integer, Default value: 0
 ; When this setting is set to something != 0 Xdebug's human-readable generated trace files will show
 ; the difference in memory usage between function calls. If Xdebug is configured to generate
 ; computer-readable trace files then they will always show this information.
-;xdebug.show_mem_delta = 0
+xdebug.show_mem_delta = 0
 
 ; xdebug.trace_format
 ; Type: integer, Default value: 0
 ; The format of the trace file.
 ;
 ; See the introduction of Function Traces for a few examples.
-;xdebug.trace_format = 0
+xdebug.trace_format = 0
 
 ; xdebug.trace_options
 ; Type: integer, Default value: 0
 ; When set to '1' the trace files will be appended to, instead of being overwritten in subsequent
 ; requests.
-;xdebug.trace_options = 0
+xdebug.trace_options = 0
 
 ; xdebug.trace_output_dir
 ; Type: string, Default value: /tmp
 ; The directory where the tracing files will be written to, make sure that the user who the PHP will
 ; be running as has write permissions to that directory.
 ; xdebug.trace_output_name
-;xdebug.trace_output_dir = "C:\xampp\tmp"
+xdebug.trace_output_dir = "/tmp"
 
 ; Type: string, Default value: trace.%c
 ;
@@ -256,7 +253,7 @@ xdebug.remote_port = 9000
 ; specifies the format with format specifiers, very similar to sprintf() and strftime(). There are
 ; several format specifiers that can be used to format the file name. The '.xt' extension is always
 ; added automatically.
-;xdebug.trace_output_name = "trace.%c"
+xdebug.trace_output_name = "trace.%c"
 
 ; xdebug.var_display_max_children
 ; Type: integer, Default value: 128


### PR DESCRIPTION
By being more explicit about the defaults currently configured for
XDebug, we can make it easier to submit future pull requests for
changes as only the values of individual configurations will be
changed.