### PR TITLE
[PR] Bump max upload size to 1024M in PHP and Nginx

### DIFF
--- a/config/nginx-config/nginx.conf
+++ b/config/nginx-config/nginx.conf
@@ -100,7 +100,7 @@ http {
 
     # Max size of a body to allow. This affects uploads, but can be overwritten at
     # the individual site level
-    client_max_body_size 50M;
+    client_max_body_size 1024M;
 
     # The maximum number and size of large headers to accept from a client
     large_client_header_buffers 4 16k;

--- a/config/nginx-config/sites/default.conf
+++ b/config/nginx-config/sites/default.conf
@@ -46,7 +46,7 @@ server {
     location ~ /\.          { access_log off; log_not_found off; deny all; }
 
     location ~ \.php$ {
-        client_max_body_size 25M;
+        client_max_body_size 1024M;
         try_files      $uri =404;
 
         # Include the fastcgi_params defaults provided by nginx

--- a/config/php5-fpm-config/php-custom.ini
+++ b/config/php5-fpm-config/php-custom.ini
@@ -41,10 +41,10 @@ html_errors = 1
 error_log = /srv/log/php_errors.log
 
 ; Maximum size of POST data that PHP will accept.
-post_max_size = 50M
+post_max_size = 1024M
 
 ; Maximum allowed size for uploaded files.
-upload_max_filesize = 50M
+upload_max_filesize = 1024M
 
 ; Maximum number of files that can be uploaded via a single request
 max_file_uploads = 20


### PR DESCRIPTION
This allows sites in development to support more reasonable upload sizes for 2015. It also allows larger SQL (or .gz) files to be uploaded directly through the phpMyAdmin interface for those who do not use the command line.

See #454, #273.
Fixes #599.