### PR TITLE
[PR] Set the box name in VirtualBox to that of the working directory

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,9 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+dir = Dir.pwd
 vagrant_dir = File.expand_path(File.dirname(__FILE__))
+vagrant_name = File.basename(dir)
 
 Vagrant.configure("2") do |config|
 
@@ -9,12 +11,17 @@ Vagrant.configure("2") do |config|
   # with possible backward compatible issues.
   vagrant_version = Vagrant::VERSION.sub(/^v/, '')
 
-  # Configuration options for the VirtualBox provider.
+  # Give vm a name
+  config.vm.define vagrant_name do |v|
+  end
+
+  # Configurations from 1.0.x can be placed in Vagrant 1.1.x specs like the following.
   config.vm.provider :virtualbox do |v|
     v.customize ["modifyvm", :id, "--memory", 1024]
     v.customize ["modifyvm", :id, "--cpus", 1]
     v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
     v.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+    v.name = vagrant_name
   end
 
   # Configuration options for the Parallels provider.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,9 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-dir = Dir.pwd
 vagrant_dir = File.expand_path(File.dirname(__FILE__))
-vagrant_name = File.basename(dir)
 
 Vagrant.configure("2") do |config|
 
@@ -21,7 +19,10 @@ Vagrant.configure("2") do |config|
     v.customize ["modifyvm", :id, "--cpus", 1]
     v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
     v.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
-    v.name = vagrant_name
+
+    # Set the box name in VirtualBox to match the working directory.
+    vvv_pwd = Dir.pwd
+    v.name = File.basename(vvv_pwd)
   end
 
   # Configuration options for the Parallels provider.


### PR DESCRIPTION
This allows you to have multiple VVV instances (with different IP addresses) without name collisions and makes things slightly easier to identify in VirtualBox.

Fixes #512.