### PR TITLE
add tj to list of helpful extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Supporting init scripts during provisioning allows for some great extensions of 
 * [Variable VVV](https://github.com/bradp/vv) automates setting up new sites, setting up deployments, and more.
 * [HHVVVM](https://github.com/johnjamesjacoby/hhvvvm) is an HHVM configuration for VVV.
 * The [WordPress Meta Environment](https://github.com/iandunn/wordpress-meta-environment) is a "collection of scripts that provision the official WordPress.org websites into a Varying Vagrant Vagrants installation."
+* [Theme Juice CLI](https://github.com/ezekg/theme-juice-cli) automates spinning up new sites, manages build tools and dependencies, and handles deployments to multiple stages. Supports vanilla VVV and most forks e.g. [VVV-Apache](https://github.com/ericmann/vvv-apache).
 
 #### Custom Dashboards
 


### PR DESCRIPTION
Adds [`tj`](http://themejuice.it) to the list of helpful extensions. By default, it uses [VVV-Apache](https://github.com/ericmann/vvv-apache), but can be used with vanilla VVV by using a couple flags (described [here](https://github.com/ezekg/theme-juice-cli#can-i-use-the-original-vvv-instead-of-vvv-apache)). It's much like Variable VVV, and was actually created around the same time (funny how that worked out).