### PR TITLE
Allow symlinks in shared folders (in VirtualBox)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,6 +14,7 @@ Vagrant.configure("2") do |config|
     v.customize ["modifyvm", :id, "--memory", 1024]
     v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
     v.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+    v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
   end
 
   # Configuration options for the Parallels provider.


### PR DESCRIPTION
Not allowing symlinks in the first place is a security/stability safety. SInce this is for development it should be possible.

MIght need additional changes for Parallels + Fusion

---

New PR (replaces #592) to change destination branch to `develop`
