### PR TITLE
Fix composer selfupdate error

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -220,13 +220,13 @@ if [[ $ping_result == "Connected" ]]; then
 	# the master branch on its GitHub repository.
 	if [[ -n "$(composer --version --no-ansi | grep 'Composer version')" ]]; then
 		echo "Updating Composer..."
-		COMPOSER_HOME=/usr/local/src/composer composer self-update
-		COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update phpunit/phpunit:4.3.*
-		COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update phpunit/php-invoker:1.1.*
-		COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update mockery/mockery:0.9.*
-		COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update d11wtq/boris:v1.0.8
-		COMPOSER_HOME=/usr/local/src/composer composer -q global config bin-dir /usr/local/bin
-		COMPOSER_HOME=/usr/local/src/composer composer global update
+		COMPOSER_HOME=/usr/local/src/composer sudo composer self-update
+		COMPOSER_HOME=/usr/local/src/composer sudo composer -q global require --no-update phpunit/phpunit:4.3.*
+		COMPOSER_HOME=/usr/local/src/composer sudo composer -q global require --no-update phpunit/php-invoker:1.1.*
+		COMPOSER_HOME=/usr/local/src/composer sudo composer -q global require --no-update mockery/mockery:0.9.*
+		COMPOSER_HOME=/usr/local/src/composer sudo composer -q global require --no-update d11wtq/boris:v1.0.8
+		COMPOSER_HOME=/usr/local/src/composer sudo composer -q global config bin-dir /usr/local/bin
+		COMPOSER_HOME=/usr/local/src/composer sudo composer global update
 	fi
 
 	# Grunt


### PR DESCRIPTION
The provision script tries to update composer through 'composer self-update' which throws this error:
[Composer\Downloader\FilesystemException]
Filesystem exception:
Composer update failed: the "/usr/local/bin/composer" file could not be written

Fix self update by prefixing all the calls to composer with sudo.

Commit refers to issue https://github.com/Varying-Vagrant-Vagrants/VVV/issues/725