### PR TITLE
Allow external access only when coming from host machine

### DIFF
--- a/database/init.sql
+++ b/database/init.sql
@@ -12,4 +12,4 @@ GRANT ALL PRIVILEGES ON `wordpress_unit_tests`.* TO 'wp'@'localhost' IDENTIFIED 
 
 # Create an external user with privileges on all databases in mysql so
 # that a connection can be made from the local machine without an SSH tunnel
-GRANT ALL PRIVILEGES ON *.* TO 'external'@'192.168.50.4' IDENTIFIED BY 'external';
+GRANT ALL PRIVILEGES ON *.* TO 'external'@'192.168.50.1' IDENTIFIED BY 'external';

--- a/database/init.sql
+++ b/database/init.sql
@@ -12,4 +12,4 @@ GRANT ALL PRIVILEGES ON `wordpress_unit_tests`.* TO 'wp'@'localhost' IDENTIFIED 
 
 # Create an external user with privileges on all databases in mysql so
 # that a connection can be made from the local machine without an SSH tunnel
-GRANT ALL PRIVILEGES ON *.* TO 'external'@'%' IDENTIFIED BY 'external';
+GRANT ALL PRIVILEGES ON *.* TO 'external'@'192.168.50.4' IDENTIFIED BY 'external';


### PR DESCRIPTION
Since the Vagrant host machine has the [IP address of `192.168.50.1` as the gateway](https://github.com/Varying-Vagrant-Vagrants/VVV/blob/8098632e255d05cea2dfc03e512a8a86cffe891f/Vagrantfile#L97-L111), this IP address can be explicitly supplied when creating the `external` user, instead of a wildcard `%`. This seems more secure.