### PR TITLE
Fix the HyperV Provider

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -227,7 +227,7 @@ Vagrant.configure("2") do |config|
   config.vm.provider :hyperv do |v, override|
     override.vm.synced_folder "www/", "/srv/www/", :owner => "www-data", :mount_options => ["dir_mode=0775","file_mode=0774","forceuid","noperm","nobrl","mfsymlinks"]
     # Change all the folder to use SMB instead of Virtual Box shares
-    config.vm.synced_folders.each do |id, options|
+    override.vm.synced_folders.each do |id, options|
       if ! options[:type]
         options[:type] = "smb"
       end


### PR DESCRIPTION
Though the SMB config is wrapped in a conditional statement, Vagrant's built-in Ruby interpreter seems to be ignoring scope here. Using `config` in the scope shouldn't be an issue, but apparently is. Instead we'll use the explicitly-scoped `override` version to make sure nothing bubbles out unexpectedly.

Fixes #758