### PR TITLE
Simplify private network overrides

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -119,7 +119,7 @@ Vagrant.configure("2") do |config|
   # should be changed. If more than one VM is running through VirtualBox, including other
   # Vagrant machines, different subnets should be used for each.
   #
-  config.vm.network :private_network, ip: "192.168.50.4"
+  config.vm.network :private_network, id: "vvv_primary" ip: "192.168.50.4"
 
   # Public Network (disabled)
   #

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -121,6 +121,10 @@ Vagrant.configure("2") do |config|
   #
   config.vm.network :private_network, id: "vvv_primary" ip: "192.168.50.4"
 
+  config.vm.provider :hyperv do |v, override|
+    override.vm.network :private_network, id: "vvv_primary" ip: nil
+  end
+
   # Public Network (disabled)
   #
   # Using a public network rather than the default private network configuration will allow

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -119,7 +119,7 @@ Vagrant.configure("2") do |config|
   # should be changed. If more than one VM is running through VirtualBox, including other
   # Vagrant machines, different subnets should be used for each.
   #
-  config.vm.network :private_network, id: "vvv_primary" ip: "192.168.50.4"
+  config.vm.network :private_network, id: "vvv_primary", ip: "192.168.50.4"
 
   config.vm.provider :hyperv do |v, override|
     override.vm.network :private_network, id: "vvv_primary", ip: nil

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -122,7 +122,7 @@ Vagrant.configure("2") do |config|
   config.vm.network :private_network, id: "vvv_primary" ip: "192.168.50.4"
 
   config.vm.provider :hyperv do |v, override|
-    override.vm.network :private_network, id: "vvv_primary" ip: nil
+    override.vm.network :private_network, id: "vvv_primary", ip: nil
   end
 
   # Public Network (disabled)


### PR DESCRIPTION
This is ostensibly an improvement for hyperv providers, but carries extra benefits for all providers.

Hyper-V does not know how to make private networks, so the extra IP address configured by VVV is not needed (and when used with vagrant ghost, results in duplicate hosts entries that point to a dud address). This unsets the private network for the hyperv provider.

Additionally, this makes it much easier and more forwards-compatible to modify the VM ip address. Currently, if you need to change the vm's network (e.g. because your network is using the 192.168.50.* subnet), you must edit `Vagrantfile` directly. With an id for the network config, the ip can be overridden in the `Customfile` in one line:

```rb
config.vm.network :private_network, id: "vvv_primary", ip: "10.10.10.10"
```