### PR TITLE
Running custom scripts on vagrant up and reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 /provision/github.token
 
 # Ignore custom trigger scripts in config/homebin.
+/config/homebin/vagrant_up_custom
 /config/homebin/vagrant_halt_custom
 /config/homebin/vagrant_suspend_custom
 /config/homebin/vagrant_destroy_custom

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -298,6 +298,15 @@ Vagrant.configure("2") do |config|
   # to create backups of all current databases. This can be overridden with custom
   # scripting. See the individual files in config/homebin/ for details.
   if defined? VagrantPlugins::Triggers
+    config.trigger.after :up, :stdout => true do
+      run "vagrant ssh -c 'vagrant_up'"
+    end
+    config.trigger.before :reload, :stdout => true do
+      run "vagrant ssh -c 'vagrant_halt'"
+    end
+    config.trigger.after :reload, :stdout => true do
+      run "vagrant ssh -c 'vagrant_up'"
+    end
     config.trigger.before :halt, :stdout => true do
       run "vagrant ssh -c 'vagrant_halt'"
     end

--- a/config/homebin/vagrant_up
+++ b/config/homebin/vagrant_up
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# This script is run whenever `vagrant up` is used to power on
+# the virtual machine. To customize this behavior, include a file
+# in your local VVV/config/homebin directory: vagrant_up_custom
+#
+# Look for a custom trigger file. If this exists, we'll assume that
+# all trigger actions should be handled by this custom script. If
+# it does not exist, then we'll handle some basic tasks.
+if [[ -f /home/vagrant/bin/vagrant_up_custom ]]; then
+	vagrant_up_custom
+fi


### PR DESCRIPTION
Hi! This PR implements what was discussed in #778.

I've also added a custom trigger before reload that execute `vagrant_halt` script and after reload that execute `vagrant_up` script. Please let me know if a custom `vagrant_reload_before` and `vagrant_reload_after` might be more adequate for this kind of situation.