### PR TITLE
Set the WP_CORE_DIR path so phpunit tests are run against WP trunk

### DIFF
--- a/config/bash_profile
+++ b/config/bash_profile
@@ -29,6 +29,8 @@ fi
 # Set the WP_TESTS_DIR path directory so that we can use phpunit inside
 # plugins almost immediately.
 export WP_TESTS_DIR=/srv/www/wordpress-develop/tests/phpunit/
+# Set the WP_CORE_DIR path so phpunit tests are run against WP trunk
+export WP_CORE_DIR=/srv/www/wordpress-develop/src/
 
 # add autocomplete for grunt
 eval "$(grunt --completion=bash)"


### PR DESCRIPTION
Otherwise, test install scripts will default to using WordPress latest, which is incompatible with WP trunk tests.

From https://github.com/wp-cli/wp-cli/issues/2129#issuecomment-154356360