### PR TITLE
Adding PHP FPM status page

### DIFF
--- a/config/nginx-config/sites/default.conf
+++ b/config/nginx-config/sites/default.conf
@@ -63,6 +63,13 @@ server {
         # And get to serving the file!
         fastcgi_index  index.php;
     }
+
+    # PHP FPM status page that we defined in php5-fpm-config/www.conf
+    location /php-status {
+        include        /etc/nginx/fastcgi_params;
+        fastcgi_param  SCRIPT_FILENAME         $document_root$fastcgi_script_name;
+        fastcgi_pass   php;
+    }
 }
 
 ################################################################

--- a/config/php5-fpm-config/www.conf
+++ b/config/php5-fpm-config/www.conf
@@ -213,7 +213,7 @@ pm.max_requests = 100
 ;       anything, but it may not be a good idea to use the .php extension or it
 ;       may conflict with a real PHP file.
 ; Default Value: not set 
-;pm.status_path = /status
+pm.status_path = /php-status
  
 ; The ping URI to call the monitoring page of FPM. If this value is not set, no
 ; URI will be recognized as a ping page. This could be used to test from outside

--- a/www/default/index.php
+++ b/www/default/index.php
@@ -27,6 +27,7 @@ if ( file_exists( 'dashboard-custom.php' ) ) {
 	<li><a href="http://vvv.dev:1080">Mailcatcher</a></li>
 	<li><a href="webgrind/">Webgrind</a></li>
 	<li><a href="phpinfo/">PHP Info</a></li>
+	<li><a href="php-status?html&amp;full">PHP Status</a></li>
 </ul>
 
 <ul class="nav">


### PR DESCRIPTION
The PHP FPM status page lists active requests, this is useful to debug running wp-crons.
Few people might use it, its requires only these few changes.
I'm using it to track concurrent cronjob workers that re-spawn themselves to process big data in background.