### PR TITLE
Provisioner names

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -258,7 +258,7 @@ Vagrant.configure("2") do |config|
   # should run before the shell commands laid out in provision.sh (or your provision-custom.sh
   # file) should go in this script. If it does not exist, no extra provisioning will run.
   if File.exists?(File.join(vagrant_dir,'provision','provision-pre.sh')) then
-    config.vm.provision "provision-pre", type: "shell", :path => File.join( "provision", "provision-pre.sh" )
+    config.vm.provision "pre", type: "shell", :path => File.join( "provision", "provision-pre.sh" )
   end
 
   # provision.sh or provision-custom.sh
@@ -268,9 +268,9 @@ Vagrant.configure("2") do |config|
   # created, that is run as a replacement. This is an opportunity to replace the entirety
   # of the provisioning provided by default.
   if File.exists?(File.join(vagrant_dir,'provision','provision-custom.sh')) then
-    config.vm.provision "provision-custom", type: "shell", :path => File.join( "provision", "provision-custom.sh" )
+    config.vm.provision "custom", type: "shell", :path => File.join( "provision", "provision-custom.sh" )
   else
-    config.vm.provision "provision", type: "shell", :path => File.join( "provision", "provision.sh" )
+    config.vm.provision "default", type: "shell", :path => File.join( "provision", "provision.sh" )
   end
 
   # provision-post.sh acts as a post-hook to the default provisioning. Anything that should
@@ -278,7 +278,7 @@ Vagrant.configure("2") do |config|
   # put into this file. This provides a good opportunity to install additional packages
   # without having to replace the entire default provisioning script.
   if File.exists?(File.join(vagrant_dir,'provision','provision-post.sh')) then
-    config.vm.provision "provision-post", type: "shell", path: File.join( "provision", "provision-post.sh" )
+    config.vm.provision "post", type: "shell", path: File.join( "provision", "provision-post.sh" )
   end
 
   # Always start MySQL on boot, even when not running the full provisioner

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -258,7 +258,7 @@ Vagrant.configure("2") do |config|
   # should run before the shell commands laid out in provision.sh (or your provision-custom.sh
   # file) should go in this script. If it does not exist, no extra provisioning will run.
   if File.exists?(File.join(vagrant_dir,'provision','provision-pre.sh')) then
-    config.vm.provision "pre", type: "shell", :path => File.join( "provision", "provision-pre.sh" )
+    config.vm.provision "pre", type: "shell", path: File.join( "provision", "provision-pre.sh" )
   end
 
   # provision.sh or provision-custom.sh
@@ -268,9 +268,9 @@ Vagrant.configure("2") do |config|
   # created, that is run as a replacement. This is an opportunity to replace the entirety
   # of the provisioning provided by default.
   if File.exists?(File.join(vagrant_dir,'provision','provision-custom.sh')) then
-    config.vm.provision "custom", type: "shell", :path => File.join( "provision", "provision-custom.sh" )
+    config.vm.provision "custom", type: "shell", path: File.join( "provision", "provision-custom.sh" )
   else
-    config.vm.provision "default", type: "shell", :path => File.join( "provision", "provision.sh" )
+    config.vm.provision "default", type: "shell", path: File.join( "provision", "provision.sh" )
   end
 
   # provision-post.sh acts as a post-hook to the default provisioning. Anything that should

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -258,7 +258,7 @@ Vagrant.configure("2") do |config|
   # should run before the shell commands laid out in provision.sh (or your provision-custom.sh
   # file) should go in this script. If it does not exist, no extra provisioning will run.
   if File.exists?(File.join(vagrant_dir,'provision','provision-pre.sh')) then
-    config.vm.provision :shell, :path => File.join( "provision", "provision-pre.sh" )
+    config.vm.provision "provision-pre", type: "shell", :path => File.join( "provision", "provision-pre.sh" )
   end
 
   # provision.sh or provision-custom.sh
@@ -268,9 +268,9 @@ Vagrant.configure("2") do |config|
   # created, that is run as a replacement. This is an opportunity to replace the entirety
   # of the provisioning provided by default.
   if File.exists?(File.join(vagrant_dir,'provision','provision-custom.sh')) then
-    config.vm.provision :shell, :path => File.join( "provision", "provision-custom.sh" )
+    config.vm.provision "provision-custom", type: "shell", :path => File.join( "provision", "provision-custom.sh" )
   else
-    config.vm.provision :shell, :path => File.join( "provision", "provision.sh" )
+    config.vm.provision "provision", type: "shell", :path => File.join( "provision", "provision.sh" )
   end
 
   # provision-post.sh acts as a post-hook to the default provisioning. Anything that should
@@ -278,7 +278,7 @@ Vagrant.configure("2") do |config|
   # put into this file. This provides a good opportunity to install additional packages
   # without having to replace the entire default provisioning script.
   if File.exists?(File.join(vagrant_dir,'provision','provision-post.sh')) then
-    config.vm.provision :shell, :path => File.join( "provision", "provision-post.sh" )
+    config.vm.provision "provision-post", type: "shell", path: File.join( "provision", "provision-post.sh" )
   end
 
   # Always start MySQL on boot, even when not running the full provisioner


### PR DESCRIPTION
Problem: Working on a **provision-post.sh** script, every time you want to test it, you have to run _all_ the provisioners.

Solution: Use the `--provision-with` switch to specify which provisioner(s) to run. Per the Vagrant [documentation](https://docs.vagrantup.com/v2/cli/provision.html):

> `--provision-with x,y,z` - This will only run the given provisioners. For example, if you have a `:shell` and `:chef_solo` provisioner and run `vagrant provision --provision-with shell`, only the shell provisioner will be run.

Since all of VVV's provisioners are `:shell`, this doesn't help much. However, if each one is named, you can do something like this: `vagrant provision --provision-with post`