### PR TITLE
Update phpunit to 4.8.x

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -273,7 +273,7 @@ tools_install() {
   if [[ -n "$(composer --version --no-ansi | grep 'Composer version')" ]]; then
     echo "Updating Composer..."
     COMPOSER_HOME=/usr/local/src/composer composer self-update
-    COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update phpunit/phpunit:4.3.*
+    COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update phpunit/phpunit:4.8.*
     COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update phpunit/php-invoker:1.1.*
     COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update mockery/mockery:0.9.*
     COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update d11wtq/boris:v1.0.8


### PR DESCRIPTION
The latest version is actually 5.1.x, but it requires PHP 5.6+. Updating to 4.8.x at least gets us to a version that has [available documentation](https://phpunit.de/manual/4.8/en/index.html).

I ran the WordPress test suite with this update and it still completes successfully. I'm not sure what other testing needs to be done to vet this change.