### PR TITLE
Creating app armor config for mysql perms + updating mysql config to …

### DIFF
--- a/config/mysql-config/my.cnf
+++ b/config/mysql-config/my.cnf
@@ -61,12 +61,12 @@ max_allowed_packet	= 128M
 #
 # Error log - should be very few entries.
 #
-log_error = /var/log/mysql/error.log
+log_error = /srv/log/mysql_error.log
 #
 # Here you can see queries with especially long duration
-#log_slow_queries	= /var/log/mysql/mysql-slow.log
-#long_query_time = 2
-#log-queries-not-using-indexes
+log_slow_queries	=  /srv/log/mysql_slow.log
+long_query_time = 2
+log-queries-not-using-indexes
 
 [mysqldump]
 quick

--- a/config/mysql-config/usr.sbin.mysqld
+++ b/config/mysql-config/usr.sbin.mysqld
@@ -1,0 +1,5 @@
+# Configuration for Apparmor service to allow mysql to write to /srv/log
+# Site-specific additions and overrides for usr.sbin.mysqld.
+# For more details, please see /etc/apparmor.d/local/README.
+/srv/log/ r,
+/srv/log/** rwk,

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -310,18 +310,18 @@ tools_install() {
 nginx_setup() {
   # Create an SSL key and certificate for HTTPS support.
   if [[ ! -e /etc/nginx/server.key ]]; then
-	  echo "Generate Nginx server private key..."
-	  vvvgenrsa="$(openssl genrsa -out /etc/nginx/server.key 2048 2>&1)"
-	  echo "$vvvgenrsa"
+    echo "Generate Nginx server private key..."
+    vvvgenrsa="$(openssl genrsa -out /etc/nginx/server.key 2048 2>&1)"
+    echo "$vvvgenrsa"
   fi
   if [[ ! -e /etc/nginx/server.crt ]]; then
-	  echo "Sign the certificate using the above private key..."
-	  vvvsigncert="$(openssl req -new -x509 \
+    echo "Sign the certificate using the above private key..."
+    vvvsigncert="$(openssl req -new -x509 \
             -key /etc/nginx/server.key \
             -out /etc/nginx/server.crt \
             -days 3650 \
             -subj /CN=*.wordpress-develop.dev/CN=*.wordpress.dev/CN=*.vvv.dev/CN=*.wordpress-trunk.dev 2>&1)"
-	  echo "$vvvsigncert"
+    echo "$vvvsigncert"
   fi
 
   echo -e "\nSetup configuration files..."
@@ -408,6 +408,15 @@ mysql_setup() {
     # users and databases that our vagrant setup relies on.
     mysql -u "root" -p"root" < "/srv/database/init.sql"
     echo "Initial MySQL prep..."
+
+
+    #Setup AppArmor to allow mysql to write log files to srv
+    cp "/srv/config/mysql-config/usr.sbin.mysqld" "/etc/apparmor.d/local/usr.sbin.mysqld"
+    echo " * Copied /srv/config/mysql-config/usr.sbin.mysqld          to /etc/apparmor.d/local/usr.sbin.mysqld"
+
+    #Reload AppArmor with new configuration
+    echo "service apparmor reload"
+    service apparmor reload
 
     # Process each mysqldump SQL file in database/backups to import
     # an initial data set for MySQL.


### PR DESCRIPTION
This commit Fixes issues with permissions for mysql writting to /srv/ log

Ubuntu has a special security service called AppArmor that goes above regular file system permissions to lock down applications. It specifies what part of a file system any given application may have access to. 

You can see the default mysql configuration in this file
`/etc/apparmor.d/usr.sbin.mysqld`

There is an empty file generated for custom mysql configurations
`/etc/apparmor.d/local/usr.sbin.mysqld`

Adding these lines to the configuration and restarting AppArmor fixes the issue.

```
/srv/log/ r,
/srv/log/** rwk,
```

See for more info: https://github.com/Varying-Vagrant-Vagrants/VVV/pull/619
