### PR TITLE
update deprecated `parallels.optimize_power_consumption = false`

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,7 +24,7 @@ Vagrant.configure("2") do |config|
   # Configuration options for the Parallels provider.
   config.vm.provider :parallels do |v|
     v.update_guest_tools = true
-    v.optimize_power_consumption = false
+    v.customize ["set", :id, "--longer-battery-life", "off"]
     v.memory = 1024
     v.cpus = 1
   end


### PR DESCRIPTION
- use `parallels.customize ["set", :id, "--longer-battery-life", "off"]` in its place