### PR TITLE
Switch from hostsupdater to ghost for hosts

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -106,6 +106,13 @@ Vagrant.configure("2") do |config|
 
     return hosts
   end
+
+  if defined?(VagrantPlugins::Ghost)
+    # Pass the found host names to the Ghost plugin.
+    config.ghost.hosts = get_vvv_hosts
+  elsif defined?(VagrantPlugins::HostsUpdater)
+    config.hostsupdater.aliases = get_vvv_hosts
+    config.hostsupdater.remove_on_suspend = true
   end
 
   # Private Network (default)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -78,17 +78,21 @@ Vagrant.configure("2") do |config|
 
   # Local Machine Hosts
   #
-  # If the Vagrant plugin hostsupdater (https://github.com/cogitatio/vagrant-hostsupdater) is
-  # installed, the following will automatically configure your local machine's hosts file to
-  # be aware of the domains specified below. Watch the provisioning script as you may need to
-  # enter a password for Vagrant to access your hosts file.
+  # If the Vagrant plugins Ghost or HostsUpdater are installed, the following
+  # will automatically configure your local machine's hosts file to
+  # be aware of the domains specified below. Watch the provisioning script as
+  # you may need to enter a password for Vagrant to access your hosts file.
   #
-  # By default, we'll include the domains set up by VVV through the vvv-hosts file
-  # located in the www/ directory.
+  # By default, we'll include the domains set up by VVV through the
+  # vvv-hosts file located in the www/ directory.
   #
-  # Other domains can be automatically added by including a vvv-hosts file containing
-  # individual domains separated by whitespace in subdirectories of www/.
-  if defined?(VagrantPlugins::Ghost)
+  # Other domains can be automatically added by including a vvv-hosts
+  # file containing individual domains separated by whitespace in
+  # subdirectories of www/.
+  #
+  # Download the plugins at https://github.com/10up/vagrant-ghost and
+  # https://github.com/cogitatio/vagrant-hostsupdater.
+
   # Collect the host names of installed sites.
   #
   # @return array An array of host names found in config files.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -89,8 +89,12 @@ Vagrant.configure("2") do |config|
   # Other domains can be automatically added by including a vvv-hosts file containing
   # individual domains separated by whitespace in subdirectories of www/.
   if defined?(VagrantPlugins::Ghost)
+  # Collect the host names of installed sites.
+  #
+  # @return array An array of host names found in config files.
+  def get_vvv_hosts
     # Recursively fetch the paths to all vvv-hosts files under the www/ directory.
-    paths = Dir[File.join(vagrant_dir, 'www', '**', 'vvv-hosts')]
+    paths = Dir[File.join("#vagrant_dir", 'www', '**', 'vvv-hosts')]
 
     # Parse the found vvv-hosts files for host names.
     hosts = paths.map do |path|
@@ -100,8 +104,8 @@ Vagrant.configure("2") do |config|
       lines.grep(/\A[^#]/)
     end.flatten.uniq # Remove duplicate entries
 
-    # Pass the found host names to the Ghost plugin so it can perform magic.
-    config.ghost.hosts = hosts
+    return hosts
+  end
   end
 
   # Private Network (default)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -88,7 +88,7 @@ Vagrant.configure("2") do |config|
   #
   # Other domains can be automatically added by including a vvv-hosts file containing
   # individual domains separated by whitespace in subdirectories of www/.
-  if defined?(VagrantPlugins::HostsUpdater)
+  if defined?(VagrantPlugins::Ghost)
     # Recursively fetch the paths to all vvv-hosts files under the www/ directory.
     paths = Dir[File.join(vagrant_dir, 'www', '**', 'vvv-hosts')]
 
@@ -100,9 +100,8 @@ Vagrant.configure("2") do |config|
       lines.grep(/\A[^#]/)
     end.flatten.uniq # Remove duplicate entries
 
-    # Pass the found host names to the hostsupdater plugin so it can perform magic.
-    config.hostsupdater.aliases = hosts
-    config.hostsupdater.remove_on_suspend = true
+    # Pass the found host names to the Ghost plugin so it can perform magic.
+    config.ghost.hosts = hosts
   end
 
   # Private Network (default)


### PR DESCRIPTION
Based on discussion in #606, and inspired by a (recently fixed)
[bug in vagrant-hostsupdater](https://github.com/cogitatio/vagrant-hostsupdater/commit/8b464369016d880dba4936428424c038042488f7) that removes hosts unexpectedly, I would
like to see vagrant-ghost recommended as the plugin for managing hosts.

The two are slightly different in configuration, but this initial change
can keep the existing logic and simply swap out the config settings names
and remove options that don't exist in ghost.
