### PR TITLE
possible false positive in package_check

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -159,15 +159,15 @@ package_check() {
   local package_version
 
   for pkg in "${apt_package_check_list[@]}"; do
-    package_version=$(dpkg -s "${pkg}" 2>&1 | grep 'Version:' | cut -d " " -f 2)
-    if [[ -n "${package_version}" ]]; then
+    if [[ -n "$(apt-cache policy ${pkg} | grep 'Installed: (none)')" ]]; then
+      echo " *" $pkg [not installed]
+      apt_package_install_list+=($pkg)
+    else
+      package_version=$(dpkg -s "${pkg}" 2>&1 | grep 'Version:' | cut -d " " -f 2)
       space_count="$(expr 20 - "${#pkg}")" #11
       pack_space_count="$(expr 30 - "${#package_version}")"
       real_space="$(expr ${space_count} + ${pack_space_count} + ${#package_version})"
       printf " * $pkg %${real_space}.${#package_version}s ${package_version}\n"
-    else
-      echo " *" $pkg [not installed]
-      apt_package_install_list+=($pkg)
     fi
   done
 }

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -216,11 +216,11 @@ package_install() {
 
     # Update all of the package references before installing anything
     echo "Running apt-get update..."
-    apt-get update -y
+    apt-get -y update
 
     # Install required packages
     echo "Installing apt-get packages..."
-    apt-get install -y ${apt_package_install_list[@]}
+    apt-get -y install ${apt_package_install_list[@]}
 
     # Clean up apt caches
     apt-get clean

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -152,6 +152,14 @@ profile_setup() {
   fi
 }
 
+not_installed() {
+   if [ "$(dpkg -s ${1} 2>&1 | grep 'Version:')" ]; then
+      [ -n "$(apt-cache policy ${1} | grep 'Installed: (none)')" ] && return 0 || return 1
+   else
+      return 0
+   fi
+}
+
 package_check() {
   # Loop through each of our packages that should be installed on the system. If
   # not yet installed, it should be added to the array of packages to install.
@@ -159,7 +167,7 @@ package_check() {
   local package_version
 
   for pkg in "${apt_package_check_list[@]}"; do
-    if [[ -n "$(apt-cache policy ${pkg} | grep 'Installed: (none)')" ]]; then
+    if not_installed "${pkg}"; then
       echo " *" $pkg [not installed]
       apt_package_install_list+=($pkg)
     else


### PR DESCRIPTION
## Premise: It's better to check if a package doesn't exist, because a false positive here does no harm. 

### commit comment

use apt-cache policy instead of dpkg -s to check if pkg is NOT installed
sometimes dpkg -s will find Version information for packages that have
been removed, resulting in a false positive

### reasoning

1. If we check that a package exists and get a false positive, that package will never get installed.
1. If we check that a package doesn't exist and get a false positive, apt-get will attempt to install it and notice that it is already installed.

### example

#### remove virtualbox-5.0 and check if it still exists
```bash
sudo apt-get remove virtualbox-5.0
dpkg -s virtualbox-5.0 2>&1 | grep 'Version:'
```

This results in a false positive due to 'Version:' being found in several places.

```bash
Version: 5.0.14-105127~Ubuntu~trusty
Config-Version: 5.0.14-105127~Ubuntu~trusty
Python-Version: 2.7
```

#### check with apt-cache policy instead

```bash
apt-cache policy virtualbox-5.0
```

The result is not a false positive.

```bash
virtualbox-5.0:
  Installed: (none)
  Candidate: 5.0.14-105127~Ubuntu~trusty
```