### PR TITLE
Allow unit test DB config to be supplied via environment vars

### DIFF
--- a/config/wordpress-config/wp-tests-config.php
+++ b/config/wordpress-config/wp-tests-config.php
@@ -23,14 +23,22 @@ define( 'WP_DEBUG', true );
 // These tests will DROP ALL TABLES in the database with the prefix named below.
 // DO NOT use a production database or one that is shared with something else.
 
-define( 'DB_NAME', 'wordpress_unit_tests' );
-define( 'DB_USER', 'wp' );
-define( 'DB_PASSWORD', 'wp' );
-if ( file_exists( '/vagrant' ) ) {
+if ( getenv( 'WP_TESTS_DB_HOST' ) ) {
+	define( 'DB_HOST', getenv( 'WP_TESTS_DB_HOST' ) );
+} else if ( file_exists( '/vagrant' ) ) {
 	define( 'DB_HOST', 'localhost' );
 } else {
 	define( 'DB_HOST', '192.168.50.4' );
 }
+define( 'DB_NAME', getenv( 'WP_TESTS_DB_NAME' ) ?: 'wordpress_unit_tests' );
+if ( getenv( 'WP_TESTS_DB_USER' ) ) {
+	define( 'DB_USER', getenv( 'WP_TESTS_DB_USER' ) );
+	define( 'DB_PASSWORD', getenv( 'WP_TESTS_DB_PASSWORD' ) );
+} else {
+	define( 'DB_USER', 'wp' );
+	define( 'DB_PASSWORD', 'wp' );
+}
+
 define( 'DB_CHARSET', 'utf8' );
 define( 'DB_COLLATE', '' );
 


### PR DESCRIPTION
Based on our conversation here: https://twitter.com/jeremyfelt/status/707751217187819521

With this in place, you'd be able to `brew install mysql`, create the `wordpress_unit_tests` database:

```sql
CREATE DATABASE IF NOT EXISTS wordpress_unit_tests CHARACTER SET utf8;
```

And then add the following lines to your host machine's `.bash_profile`:

```php
export WP_TESTS_DB_HOST=localhost
export WP_TESTS_DB_NAME=wordpress_unit_tests
export WP_TESTS_DB_USER=root
export WP_TESTS_DB_PASSWORD=''
```

Assuming you also have PHPUnit installed (`brew install phpunit`), you show now be able to run `phpunit` from a terminal on the host machine and execute the unit tests as fast as possible.