### PR TITLE
Resolve relative paths in vvv-nginx.conf since not allowed by Nginx

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -746,6 +746,11 @@ custom_vvv(){
     # while still having an Nginx config which works.
     DIR="$(dirname "$SITE_CONFIG_FILE")"
     sed "s#{vvv_path_to_folder}#$DIR#" "$SITE_CONFIG_FILE" > "/etc/nginx/custom-sites/""$DEST_CONFIG_FILE"
+
+    # Resolve relative paths since not supported in Nginx root.
+    while grep -sqE '/[^/][^/]*/\.\.' "/etc/nginx/custom-sites/""$DEST_CONFIG_FILE"; do
+      sed -i 's#/[^/][^/]*/\.\.##g' "/etc/nginx/custom-sites/""$DEST_CONFIG_FILE"
+    done
   done
 
   # Parse any vvv-hosts file located in www/ or subdirectories of www/


### PR DESCRIPTION
This allows for `vvv-nginx.conf` to be located in a project's subdirectory, like the `private` directory on Pantheon:

```conf
server {
    listen       80;
    listen       443 ssl;
    server_name  vvv.pantheon.example.com
    root         {vvv_path_to_folder}/..;
    include      /etc/nginx/nginx-wp-common.conf;
}
```