### PR TITLE
Add nvm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Add support for VMWare Workstation as a provider. See [656](https://github.com/Varying-Vagrant-Vagrants/VVV/pull/656).
 * Add MailCatcher to default provisioning. See [#632](https://github.com/Varying-Vagrant-Vagrants/VVV/pull/632).
 
-## Bug fixes and enhancements
+### Bug fixes and enhancements
 * Composer: Set a custom GitHub token for Composer if it exists. See [#575](https://github.com/Varying-Vagrant-Vagrants/VVV/pull/575).
 * Docs: Update inline `Vagrantfile` documentation to better explain various network configurations.
 * MySQL: Enable `innodb_file_per_table`. See [#537](https://github.com/Varying-Vagrant-Vagrants/VVV/issues/537).

--- a/config/bash_profile
+++ b/config/bash_profile
@@ -40,3 +40,7 @@ eval "$(grunt --completion=bash)"
 
 # PHPCS path
 export PATH="$PATH:/srv/www/phpcs/scripts/"
+
+# nvm path
+export NVM_DIR="/srv/config/nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" # This loads nvm

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -228,6 +228,21 @@ package_install() {
 }
 
 tools_install() {
+  # nvm
+  if [[ ! -d "/srv/config/nvm" ]]; then
+    echo -e "\nDownloading nvm, see https://github.com/creationix/nvm"
+    git clone "https://github.com/creationix/nvm.git" "/srv/config/nvm"
+    cd /srv/config/nvm
+    git checkout `git describe --abbrev=0 --tags`
+  else
+    echo -e "\nUpdating nvm..."
+    cd /srv/config/nvm
+    git pull origin master
+    git checkout `git describe --abbrev=0 --tags`
+  fi
+  # Activate nvm
+  source /srv/config/nvm/nvm.sh
+
   # npm
   #
   # Make sure we have the latest npm version and the update checker module


### PR DESCRIPTION
Initial support using nvm to allow alternate NodeJS versions to be installed, 
• https://github.com/creationix/nvm#manual-install

• By default no additional NodeJS versions are installed and the default installed NodeJS `system` version is used, currently this is `0.10.x`, #779 updates this to `0.12.x`.

• To install additional NodeJS versions use `nvm install 4`, or `nvm install 5` for the latest v4.x or v5.x branches respectively, 

• To list installed NodeJS versions use `nvm list`

• To switch to an installed NodeJS version use `nvm use 4`, or `nvm use 5` for the current installed v4.x or v5.x branches respectively

Fixes #562 Use nvm instead of NodeJS, see also:
• #779 Switch to NodeSource for NodeJS packages
• #788 Update NodeJS version to most recent LTS (4.2.x)

