### PR TITLE
fix some ShellCheck code linter warnings

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -163,25 +163,32 @@ not_installed() {
   fi
 }
 
+print_pkg_info() {
+  local pkg="$1"
+  local pkg_version="$2"
+  local space_count
+  local pack_space_count
+  local real_space
+
+  space_count="$(( 20 - ${#pkg} ))" #11
+  pack_space_count="$(( 30 - ${#pkg_version} ))"
+  real_space="$(( space_count + pack_space_count + ${#pkg_version} ))"
+  printf " * $pkg %${real_space}.${#pkg_version}s ${pkg_version}\n"
+}
+
 package_check() {
   # Loop through each of our packages that should be installed on the system. If
   # not yet installed, it should be added to the array of packages to install.
   local pkg
-  local package_version
-  local space_count
-  local pack_space_count
-  local real_space
+  local pkg_version
 
   for pkg in "${apt_package_check_list[@]}"; do
     if not_installed "${pkg}"; then
       echo " *" "$pkg" [not installed]
       apt_package_install_list+=($pkg)
     else
-      package_version=$(dpkg -s "${pkg}" 2>&1 | grep 'Version:' | cut -d " " -f 2)
-      space_count="$(( 20 - ${#pkg} ))" #11
-      pack_space_count="$(( 30 - ${#package_version} ))"
-      real_space="$(( space_count + pack_space_count + ${#package_version} ))"
-      printf " * $pkg %${real_space}.${#package_version}s ${package_version}\n"
+      pkg_version=$(dpkg -s "${pkg}" 2>&1 | grep 'Version:' | cut -d " " -f 2)
+      print_pkg_info "$pkg" "$pkg_version"
     fi
   done
 }
@@ -465,19 +472,13 @@ mailcatcher_setup() {
   # Installs mailcatcher using RVM. RVM allows us to install the
   # current version of ruby and all mailcatcher dependencies reliably.
   local pkg
-  local space_count
-  local pack_space_count
-  local real_space
   local rvm_version
   local mailcatcher_version
 
   rvm_version="$(/usr/bin/env rvm --silent --version 2>&1 | grep 'rvm ' | cut -d " " -f 2)"
   if [[ -n "${rvm_version}" ]]; then
     pkg="RVM"
-    space_count="$(( 20 - ${#pkg} ))" #11
-    pack_space_count="$(( 30 - ${#rvm_version} ))"
-    real_space="$(( space_count + pack_space_count + ${#rvm_version} ))"
-    printf " * $pkg %${real_space}.${#rvm_version}s ${rvm_version}\n"
+    print_pkg_info "$pkg" "$rvm_version"
   else
     # RVM key D39DC0E3
     # Signatures introduced in 1.26.0
@@ -492,10 +493,7 @@ mailcatcher_setup() {
   mailcatcher_version="$(/usr/bin/env mailcatcher --version 2>&1 | grep 'mailcatcher ' | cut -d " " -f 2)"
   if [[ -n "${mailcatcher_version}" ]]; then
     pkg="Mailcatcher"
-    space_count="$(( 20 - ${#pkg} ))" #11
-    pack_space_count="$(( 30 - ${#mailcatcher_version} ))"
-    real_space="$(( space_count + pack_space_count + ${#mailcatcher_version} ))"
-    printf " * $pkg %${real_space}.${#mailcatcher_version}s ${mailcatcher_version}\n"
+    print_pkg_info "$pkg" "$mailcatcher_version"
   else
     echo " * Mailcatcher [not installed]"
     /usr/bin/env rvm default@mailcatcher --create do gem install mailcatcher --no-rdoc --no-ri

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -155,7 +155,7 @@ profile_setup() {
 
 not_installed() {
   dpkg -s "$1" 2>&1 | grep -q 'Version:'
-  if [ "$?" -eq 0 ]; then
+  if [[ "$?" -eq 0 ]]; then
     apt-cache policy "$1" | grep 'Installed: (none)'
     return "$?"
   else


### PR DESCRIPTION
- make code more standard and readable
- insert space around code inside $(( ... ))
- define variables within functions as local

Shell is special, even variables declared inside a function and inside
another block, appearing to have limited scope, will still be available
after the function call. Define as local to avoid potential issues.