### PR TITLE
Docker Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,29 @@ A bunch of stuff!
 1. [NodeJs](https://nodejs.org/)
 1. [grunt-cli](https://github.com/gruntjs/grunt-cli)
 1. [Mailcatcher](http://mailcatcher.me/)
+1. [Docker](https://www.docker.com/)
+
+### Dockerized PHP
+
+VVV ships with PHP built-in by default and, with no changes from you, will use that stock version of PHP just fine. But in case you need to test your code with _other_ versions of PHP, we've also added Docker-wrapped installations of all the recent major versions as well:
+* 5.3
+* 5.4
+* 5.5
+* 5.6
+* 7.0 - this is installed normally as well
+
+If you want your site to use a specific PHP backend (read: version), then add `set $default_backend phpXX;` to the `server` block of that site's Nginx config file. The XX in this string stands for the version number you want to use (i.e. 5.3 would be `php53`, 5.5 would be `php55`, 7.0 would be `php70`). Your site will now use _that_ version of PHP by default!
+
+#### Cookie Control
+
+We've also set up a tricky Nginx cookie map so you can swap the back-end powering a site dynamically. Click and drag the following bookmarklet links to your browser's toolbar, and you can click them to dynamically change which version of PHP will deliver the site:
+
+* <a href="javascript:(function() {document.cookie='env='+''+';path=/;';})()">PHP</a> - Resets you back to stock PHP
+* <a href="javascript:(function() {document.cookie='env='+'53'+';path=/;';})()">PHP53</a>
+* <a href="javascript:(function() {document.cookie='env='+'54'+';path=/;';})()">PHP54</a>
+* <a href="javascript:(function() {document.cookie='env='+'55'+';path=/;';})()">PHP55</a>
+* <a href="javascript:(function() {document.cookie='env='+'56'+';path=/;';})()">PHP56</a>
+* <a href="javascript:(function() {document.cookie='env='+'70'+';path=/;';})()">PHP70</a>
 
 ### Need Help?
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -286,6 +286,7 @@ Vagrant.configure("2") do |config|
   if vagrant_version >= "1.6.0"
     config.vm.provision :shell, inline: "sudo service mysql restart", run: "always"
     config.vm.provision :shell, inline: "sudo service nginx restart", run: "always"
+    config.vm.provision :shell, inline: "sudo docker restart php53 php54 php55 php56 php70", run: "always"
   end
 
   # Vagrant Triggers

--- a/config/apt-source-append.list
+++ b/config/apt-source-append.list
@@ -12,3 +12,6 @@ deb-src http://ppa.launchpad.net/chris-lea/node.js/ubuntu trusty main
 # Provides PHP7
 deb http://ppa.launchpad.net/ondrej/php/ubuntu trusty main
 deb-src http://ppa.launchpad.net/ondrej/php/ubuntu trusty main
+
+# Provides Docker
+deb https://apt.dockerproject.org/repo ubuntu-trusty main

--- a/config/nginx-config/nginx-wp-common.conf
+++ b/config/nginx-config/nginx-wp-common.conf
@@ -74,7 +74,7 @@ location ~ \.php$ {
     fastcgi_param   SCRIPT_FILENAME         $document_root$fastcgi_script_name;
 
     # Use the upstream for php7-fpm that we defined in nginx.conf
-    fastcgi_pass   php;
+    fastcgi_pass   $backend;
 
     # And get to serving the file!
     fastcgi_index  index.php;

--- a/config/nginx-config/nginx.conf
+++ b/config/nginx-config/nginx.conf
@@ -90,6 +90,39 @@ http {
         server unix:/var/run/php7-fpm.sock;
     }
 
+    upstream php53 {
+        server localhost:9053;
+    }
+
+    upstream php54 {
+        server localhost:9054;
+    }
+
+    upstream php55 {
+        server localhost:9055;
+    }
+
+    upstream php56 {
+        server localhost:9056;
+    }
+
+    upstream php70 {
+        server localhost:9070;
+    }
+
+    map '' $default_backend {
+        default php;
+    }
+
+    map $cookie_env $backend {
+        default $default_backend;
+        53      php53;
+        54      php54;
+        55      php55;
+        56      php56;
+        70      php70;
+    }
+
     # If the requested body size is more than the buffer size, the entire body is
     # written to a temporary file. Default is 8k or 16k depending on the platform.
     client_body_buffer_size 16k;

--- a/config/nginx-config/nginx.conf
+++ b/config/nginx-config/nginx.conf
@@ -110,17 +110,21 @@ http {
         server localhost:9070;
     }
 
-    map '' $default_backend {
-        default php;
-    }
-
-    map $cookie_env $backend {
-        default $default_backend;
+    map $cookie_env $env_map {
         53      php53;
         54      php54;
         55      php55;
         56      php56;
         70      php70;
+    }
+
+    map '' $default_backend {
+        default php;
+    }
+
+    map $env_map $backend {
+        default  $default_backend;
+        "~php.*" $env_map;
     }
 
     # If the requested body size is more than the buffer size, the entire body is

--- a/config/nginx-config/sites/default.conf
+++ b/config/nginx-config/sites/default.conf
@@ -29,6 +29,9 @@ server {
     root         /srv/www/default;
     server_name  vvv.dev;
 
+    # Set the default backend to stock PHP installed during provisioning.
+    set $default_backend php;
+
     location / {
         index index.php;
         try_files $uri $uri/ /index.php?$args;
@@ -58,7 +61,7 @@ server {
         fastcgi_param   SCRIPT_FILENAME         $document_root$fastcgi_script_name;
 
         # Use the upstream for fastcgi / php5-fpm that we defined in nginx.conf
-        fastcgi_pass   php;
+        fastcgi_pass   $backend;
 
         # And get to serving the file!
         fastcgi_index  index.php;
@@ -83,6 +86,7 @@ server {
     listen       80;
     listen       443 ssl;
     server_name  local.wordpress.dev *.local.wordpress.dev ~^local\.wordpress\.\d+\.\d+\.\d+\.\d+\.xip\.io$;
+    set          $default_backend php;
     root         /srv/www/wordpress-default;
     include      /etc/nginx/nginx-wp-common.conf;
 }
@@ -98,6 +102,7 @@ server {
     listen       80;
     listen       443 ssl;
     server_name  local.wordpress-trunk.dev *.local.wordpress-trunk.dev ~^local\.wordpress-trunk\.\d+\.\d+\.\d+\.\d+\.xip\.io$;
+    set          $default_backend php;
     root         /srv/www/wordpress-trunk;
     include      /etc/nginx/nginx-wp-common.conf;
 }
@@ -113,6 +118,7 @@ server {
     listen       80;
     listen       443 ssl;
     server_name  src.wordpress-develop.dev *.src.wordpress-develop.dev ~^src\.wordpress-develop\.\d+\.\d+\.\d+\.\d+\.xip\.io$;
+    set          $default_backend php;
     root         /srv/www/wordpress-develop/src;
     include      /etc/nginx/nginx-wp-common.conf;
 }
@@ -128,6 +134,7 @@ server {
     listen       80;
     listen       443 ssl;
     server_name  build.wordpress-develop.dev *.build.wordpress-develop.dev ~^build\.wordpress-develop\.\d+\.\d+\.\d+\.\d+\.xip\.io$;
+    set          $default_backend php;
     root         /srv/www/wordpress-develop/build;
     include      /etc/nginx/nginx-wp-common.conf;
 }

--- a/config/nginx-config/sites/local-nginx-example.conf-sample
+++ b/config/nginx-config/sites/local-nginx-example.conf-sample
@@ -36,6 +36,9 @@ server {
     # delimited here. See http://nginx.org/en/docs/http/server_names.html
     server_name  testserver.com;
 
+    # Set the default backend to PHP 7
+    set $default_backend php70;
+
     # Tells nginx which directory the files for this domain are located
     root         /srv/www/wordpress-local;
 

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -91,6 +91,9 @@ apt_package_check_list=(
   #Mailcatcher requirement
   libsqlite3-dev
 
+  #Docker requirement
+  linux-image-extra-$(uname -r)
+  docker-engine
 )
 
 ### FUNCTIONS
@@ -226,6 +229,10 @@ package_install() {
     # Apply the PHP signing key
     apt-key adv --quiet --keyserver "hkp://keyserver.ubuntu.com:80" --recv-key E5267A6C 2>&1 | grep "gpg:"
     apt-key export E5267A6C | apt-key add -
+
+    # Apply the Docker signing key
+    apt-key adv --quiet --keyserver "hkp://p80.pool.sks-keyservers.net:80" --recv-keys 58118E89F3A912897C070ADBF76221572C52609D 2>&1 | grep "gpg:"
+    apt-key export 58118E89F3A912897C070ADBF76221572C52609D | apt-key add -
 
     # Update all of the package references before installing anything
     echo "Running apt-get update..."
@@ -641,6 +648,14 @@ phpmyadmin_setup() {
   cp "/srv/config/phpmyadmin-config/config.inc.php" "/srv/www/default/database-admin/"
 }
 
+docker_setup() {
+  docker run -d --restart=always --net=host -v /srv/www:/srv/www -v /var/log:/var/log --name=php53 10up/php:5.3-fpm || docker restart php53
+  docker run -d --restart=always --net=host -v /srv/www:/srv/www -v /var/log:/var/log --name=php54 10up/php:5.4-fpm || docker restart php54
+  docker run -d --restart=always --net=host -v /srv/www:/srv/www -v /var/log:/var/log --name=php55 10up/php:5.5-fpm || docker restart php55
+  docker run -d --restart=always --net=host -v /srv/www:/srv/www -v /var/log:/var/log --name=php56 10up/php:5.6-fpm || docker restart php56
+  docker run -d --restart=always --net=host -v /srv/www:/srv/www -v /var/log:/var/log --name=php70 10up/php:7.0-fpm || docker restart php70
+}
+
 wordpress_default() {
   # Install and configure the latest stable version of WordPress
   if [[ ! -d "/srv/www/wordpress-default" ]]; then
@@ -652,7 +667,7 @@ wordpress_default() {
     rm latest.tar.gz
     cd /srv/www/wordpress-default
     echo "Configuring WordPress Stable..."
-    noroot wp core config --dbname=wordpress_default --dbuser=wp --dbpass=wp --quiet --extra-php <<PHP
+    noroot wp core config --dbname=wordpress_default --dbuser=wp --dbpass=wp --dbhost=127.0.0.1 --quiet --extra-php <<PHP
 // Match any requests made via xip.io.
 if ( isset( \$_SERVER['HTTP_HOST'] ) && preg_match('/^(local.wordpress.)\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(.xip.io)\z/', \$_SERVER['HTTP_HOST'] ) ) {
 define( 'WP_HOME', 'http://' . \$_SERVER['HTTP_HOST'] );
@@ -689,7 +704,7 @@ wordpress_trunk() {
     svn checkout "https://core.svn.wordpress.org/trunk/" "/srv/www/wordpress-trunk"
     cd /srv/www/wordpress-trunk
     echo "Configuring WordPress trunk..."
-    noroot wp core config --dbname=wordpress_trunk --dbuser=wp --dbpass=wp --quiet --extra-php <<PHP
+    noroot wp core config --dbname=wordpress_trunk --dbuser=wp --dbpass=wp --dbhost=127.0.0.1 --quiet --extra-php <<PHP
 // Match any requests made via xip.io.
 if ( isset( \$_SERVER['HTTP_HOST'] ) && preg_match('/^(local.wordpress-trunk.)\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(.xip.io)\z/', \$_SERVER['HTTP_HOST'] ) ) {
 define( 'WP_HOME', 'http://' . \$_SERVER['HTTP_HOST'] );
@@ -714,7 +729,7 @@ wordpress_develop(){
     svn checkout "https://develop.svn.wordpress.org/trunk/" "/srv/www/wordpress-develop"
     cd /srv/www/wordpress-develop/src/
     echo "Configuring WordPress develop..."
-    noroot wp core config --dbname=wordpress_develop --dbuser=wp --dbpass=wp --quiet --extra-php <<PHP
+    noroot wp core config --dbname=wordpress_develop --dbuser=wp --dbpass=wp --dbhost=127.0.0.1 --quiet --extra-php <<PHP
 // Match any requests made via xip.io.
 if ( isset( \$_SERVER['HTTP_HOST'] ) && preg_match('/^(src|build)(.wordpress-develop.)\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(.xip.io)\z/', \$_SERVER['HTTP_HOST'] ) ) {
 define( 'WP_HOME', 'http://' . \$_SERVER['HTTP_HOST'] );
@@ -831,6 +846,7 @@ mailcatcher_setup
 phpfpm_setup
 services_restart
 mysql_setup
+docker_setup
 
 network_check
 # WP-CLI and debugging tools


### PR DESCRIPTION
This change adds Docker support to VVV and builds in containers for PHP 5.3 through 7.0, pre-configured for WordPress sites (thanks to the amazing work of [10up](http://10up.com)). The containers are each configured to run as distinct PHP back-ends, each listening on a distinct port:
- 5.3 on port 9053
- 5.4 on port 9054
- 5.5 on port 9055
- 5.6 on port 9056
- 7.0 on port 9070

Each is then configured as an available upstream in Nginx (alongside the stock `php` upstream provided during provisioning as well). By default, sites will use the regular php process, but developers can:
1. Define a custom back-end in their config by adding `set $default_backend php54;` (for PHP 5.4) to the site's `server` block.
2. Dynamically select their PHP backend by specifying an environment cookie during the request (the README is updated with bookmarklets that do this for you). The cookie is read by Nginx and will override the default backend specified in the configuration file.

**Note:** There is no PHP 5.2 container as that version pre-dates FPM availability, but the containers provided give broad support for proactive compatibility testing during development.
