### PR TITLE
Add php7.0-soap

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -47,6 +47,7 @@ apt_package_check_list=(
   php7.0-curl
   php-pear
   php7.0-gd
+  php7.0-soap
 
   # nginx is installed as the default web server
   nginx


### PR DESCRIPTION
The SOAP module may be common enough to be part of the default install?