### PR TITLE
query_cache_* entries should be under [mysqld]

### DIFF
--- a/config/mysql-config/my.cnf
+++ b/config/mysql-config/my.cnf
@@ -67,6 +67,9 @@ log_error = /var/log/mysql/error.log
 #log_slow_queries	= /var/log/mysql/mysql-slow.log
 #long_query_time = 2
 #log-queries-not-using-indexes
+query_cache_size = 104857600
+query_cache_type = 1
+query_cache_limit = 1048576
 
 [mysqldump]
 quick
@@ -75,9 +78,6 @@ max_allowed_packet	= 128M
 
 [mysql]
 #no-auto-rehash	# faster start of mysql but no tab completion
-query_cache_size = 104857600
-query_cache_type = 1
-query_cache_limit = 1048576
 
 [isamchk]
 


### PR DESCRIPTION
query_cache_* entries should be under [mysqld] not under [mysql]. the current way is throwing errors on provision