### PR TITLE
Add Elasticsearch 2.3.4

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -148,6 +148,7 @@ Vagrant.configure("2") do |config|
   # Please see VVV and Vagrant documentation for additional details.
   #
   # config.vm.network "forwarded_port", guest: 80, host: 8080
+  config.vm.network "forwarded_port", guest: 9200, host: 9200
 
   # Drive mapping
   #

--- a/config/elasticsearch/elasticsearch.yml
+++ b/config/elasticsearch/elasticsearch.yml
@@ -1,0 +1,96 @@
+# ======================== Elasticsearch Configuration =========================
+#
+# NOTE: Elasticsearch comes with reasonable defaults for most settings.
+#       Before you set out to tweak and tune the configuration, make sure you
+#       understand what are you trying to accomplish and the consequences.
+#
+# The primary way of configuring a node is via this file. This template lists
+# the most important settings you may want to configure for a production cluster.
+#
+# Please see the documentation for further information on configuration options:
+# <http://www.elastic.co/guide/en/elasticsearch/reference/current/setup-configuration.html>
+#
+# ---------------------------------- Cluster -----------------------------------
+#
+# Use a descriptive name for your cluster:
+#
+# cluster.name: my-application
+#
+# ------------------------------------ Node ------------------------------------
+#
+# Use a descriptive name for the node:
+#
+# node.name: node-1
+#
+# Add custom attributes to the node:
+#
+# node.rack: r1
+#
+# ----------------------------------- Paths ------------------------------------
+#
+# Path to directory where to store the data (separate multiple locations by comma):
+#
+# path.data: /path/to/data
+#
+# Path to log files:
+#
+# path.logs: /path/to/logs
+#
+# ----------------------------------- Memory -----------------------------------
+#
+# Lock the memory on startup:
+#
+# bootstrap.mlockall: true
+#
+# Make sure that the `ES_HEAP_SIZE` environment variable is set to about half the memory
+# available on the system and that the owner of the process is allowed to use this limit.
+#
+# Elasticsearch performs poorly when the system is swapping the memory.
+#
+# ---------------------------------- Network -----------------------------------
+#
+# Set the bind address to a specific IP (IPv4 or IPv6):
+#
+# network.host: 192.168.0.1
+#
+# Set a custom port for HTTP:
+#
+# http.port: 9200
+#
+# For more information, see the documentation at:
+# <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html>
+#
+# --------------------------------- Discovery ----------------------------------
+#
+# Pass an initial list of hosts to perform discovery when new node is started:
+# The default list of hosts is ["127.0.0.1", "[::1]"]
+#
+# discovery.zen.ping.unicast.hosts: ["host1", "host2"]
+#
+# Prevent the "split brain" by configuring the majority of nodes (total number of nodes / 2 + 1):
+#
+# discovery.zen.minimum_master_nodes: 3
+#
+# For more information, see the documentation at:
+# <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery.html>
+#
+# ---------------------------------- Gateway -----------------------------------
+#
+# Block initial recovery after a full cluster restart until N nodes are started:
+#
+# gateway.recover_after_nodes: 3
+#
+# For more information, see the documentation at:
+# <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-gateway.html>
+#
+# ---------------------------------- Various -----------------------------------
+#
+# Disable starting multiple nodes on a single system:
+#
+# node.max_local_storage_nodes: 1
+#
+# Require explicit names when deleting indices:
+#
+# action.destructive_requires_name: true
+network.bind_host: 0
+network.host: 0.0.0.0

--- a/config/init/vvv-start.conf
+++ b/config/init/vvv-start.conf
@@ -10,4 +10,5 @@ service php7.0-fpm start
 service memcached start
 service mysql start
 service mailcatcher start
+service elasticsearch start
 end script

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -546,6 +546,21 @@ mailcatcher_setup() {
   fi
 }
 
+elasticsearch_setup() {
+    pkg='elasticsearch'
+    if not_installed "${pkg}"; then
+      echo " *" "$pkg" [not installed]
+      wget --quiet "https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.3.4/elasticsearch-2.3.4.deb"
+      dpkg -i elasticsearch-2.3.4.deb
+      rm elasticsearch-2.3.4.deb
+    else
+      pkg_version=$(dpkg -s "${pkg}" 2>&1 | grep 'Version:' | cut -d " " -f 2)
+      print_pkg_info "$pkg" "$pkg_version"
+    fi
+
+    cp "/srv/config/elasticsearch/elasticsearch.yml" "/etc/elasticsearch/elasticsearch.yml"
+}
+
 services_restart() {
   # RESTART SERVICES
   #
@@ -554,6 +569,7 @@ services_restart() {
   service nginx restart
   service memcached restart
   service mailcatcher restart
+  service elasticsearch restart
 
   # Disable PHP Xdebug module by default
   phpdismod xdebug
@@ -872,6 +888,7 @@ package_install
 tools_install
 nginx_setup
 mailcatcher_setup
+elasticsearch_setup
 phpfpm_setup
 services_restart
 mysql_setup


### PR DESCRIPTION
- New Elasticsearch setup in provision
- Start Elasticsearch servic on startup
- Added Elasticsearch default config file
- Added Elasticsearch forwarded ports

Elasticsearch can be really useful to develop large sites with complex queries, so why don't add it to VVV? There's actually some plugins for WordPress.

Make a provision and then:

From guest VM: curl 127.0.0.1:9200
From host: curl or open your browser on http://192.168.50.4:9200/