### PR TITLE
Allow external connections to Memcached from host machine

### DIFF
--- a/config/memcached-config/memcached.conf
+++ b/config/memcached-config/memcached.conf
@@ -33,8 +33,9 @@ logfile /var/log/memcached.log
 
 # Specify which IP address to listen on. The default is to listen on all IP addresses
 # This parameter is one of the only security measures that memcached has, so make sure
-# it's listening on a firewalled interface.
--l 127.0.0.1
+# it's listening on a firewalled interface. Note that 192.168.50.4 is the private
+# network IP for the Vagrant box per the Vagrantfile, and as such, it is safe.
+-l 127.0.0.1,192.168.50.4
 
 # Limit the number of simultaneous incoming connections. The daemon default is 1024
 # -c 1024


### PR DESCRIPTION
If you have PHP installed on your host machine, it is possible to [run WP-CLI on your host machine](https://blog.handbuilt.co/2016/05/18/how-to-use-wp-cli-without-ssh-access-to-the-server/#comment-287) or [run PHPUnit](https://make.xwp.co/2016/03/10/running-phpunit-tests-outside-vvv/) (see #785 and #739) for a site located in VVV by putting this into your `wp-config.php`:

```php
if ( file_exists( '/vagrant' ) ) {
	define( 'DB_HOST', 'localhost' );
} else {
	define( 'DB_HOST', '192.168.50.4' );
}
```

This works, but if you have a persistent object cache installed, it will break. If Memcached is installed on the host machine (e.g. `brew install memcached && brew install php56-memcache`), then you should also be able to connect to the Memcached instance running in Vagrant just like you can connect to MySQL externally. The following is how this can be handled in `wp-config.php`:

```php
$memcached_servers = array(
	'default' => array(
		file_exists( '/vagrant' ) ? '127.0.0.1:11211' : '192.168.50.4:11211'
	),
);
```

This PR ensures that this can be done by allowing connections to Memcached in Vagrant from the host machine.