### PR TITLE
`.gitignore`: Ignore the nvm git clone in the 'nvm' directory in config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@
 # Ignore anything in the 'custom' directory in config
 /config/custom/*
 
+# Ignore the nvm git clone in the 'nvm' directory in config
+/config/nvm/*
+
 # Ignore a custom bash_prompt if it exists
 /config/bash_prompt
 


### PR DESCRIPTION
Following #863 the folder `config/nvm/` was showing as "Untracked files" by Git