### PR TITLE
[PR] Add explicit support for php7.0-xml and php7.0-json packages

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -38,15 +38,16 @@ apt_package_check_list=(
   php7.0-dev
 
   # Extra PHP modules that we find useful
-  php-memcache
   php-imagick
+  php-memcache
+  php-pear
+  php7.0-curl
+  php7.0-gd
   php7.0-mbstring
   php7.0-mcrypt
   php7.0-mysql
   php7.0-imap
-  php7.0-curl
-  php-pear
-  php7.0-gd
+  php7.0-json
   php7.0-soap
   php7.0-xml
   php7.0-zip

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -48,6 +48,7 @@ apt_package_check_list=(
   php-pear
   php7.0-gd
   php7.0-soap
+  php7.0-xml
   php7.0-zip
 
   # nginx is installed as the default web server


### PR DESCRIPTION
These are currently being installed with the common packages automatically, but have been missing in the past.

This also reorders the current list of extensions for readability.

Fixes #893.