### PR TITLE
[PR] Use wp core update, not upgrade

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -712,7 +712,7 @@ PHP
   else
     echo "Updating WordPress Stable..."
     cd /srv/www/wordpress-default
-    noroot wp core upgrade
+    noroot wp core update
   fi
 }
 


### PR DESCRIPTION
`wp core upgrade` would work just fine as an alias, but the correct
command is `wp core update`

Fixes #675.