### PR TITLE
[PR] Remove WordPress trunk from default provisioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@
 
 # We do have some default nginx configs that should be included
 !/config/nginx-config/sites/default.conf
+!/config/nginx-config/sites/deprecated.conf
 
 # And we do have a default SQL file that should be included
 !/database/init.sql

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Once Vagrant and VirtualBox are installed, download or clone VVV and type `vagra
 
 Multiple projects can be developed at once in the same environment.
 
-* Use `wp-content/themes` in either the `www/wordpress-default` or `www/wordpress-trunk` directories to develop themes.
-* Use `wp-content/plugins` in either the `www/wordpress-default` or `www/wordpress-trunk` directories to develop plugins.
+* Use `wp-content/themes` in either the `www/wordpress-default` or `www/wordpress-develop/src` directories to develop themes.
+* Use `wp-content/plugins` in either the `www/wordpress-default` or `www/wordpress-develop/src` directories to develop plugins.
 * Take advantage of VVV's [auto site configuration](https://github.com/varying-vagrant-vagrants/vvv/wiki/Auto-site-Setup) to provision additional instances of WordPress in `www/`. The [Variable VVV](https://github.com/bradp/vv) project helps to automate this process.
 * Use the `www/wordpress-develop` directory to participate in [WordPress core](https://make.wordpress.org/core) development.
 
@@ -66,7 +66,7 @@ Entirely different server configurations can be created by modifying the files i
 1. Optionally, install some convenient Vagrant plugins:
     1. Install the [vagrant-hostsupdater](https://github.com/cogitatio/vagrant-hostsupdater) plugin with `vagrant plugin install vagrant-hostsupdater`
         * Note: This step is not a requirement, though it does make the process of starting up a virtual machine nicer by automating the entries needed in your local machine's `hosts` file to access the provisioned VVV domains in your browser.
-        * If you choose not to install this plugin, a manual entry should be added to your local `hosts` file that looks like this: `192.168.50.4  vvv.dev local.wordpress.dev local.wordpress-trunk.dev src.wordpress-develop.dev build.wordpress-develop.dev`
+        * If you choose not to install this plugin, a manual entry should be added to your local `hosts` file that looks like this: `192.168.50.4  vvv.dev local.wordpress.dev src.wordpress-develop.dev build.wordpress-develop.dev`
     1. Install the [vagrant-triggers](https://github.com/emyl/vagrant-triggers) plugin with `vagrant plugin install vagrant-triggers`
         * Note: This step is not a requirement. When installed, it allows for various scripts to fire when issuing commands such as `vagrant halt` and `vagrant destroy`.
         * By default, if vagrant-triggers is installed, a `db_backup` script will run on halt, suspend, and destroy that backs up each database to a `dbname.sql` file in the `{vvv}/database/backups/` directory. These will then be imported automatically if starting from scratch. Custom scripts can be added to override this default behavior.
@@ -83,7 +83,6 @@ Entirely different server configurations can be created by modifying the files i
     * Watch as the script ends, as an administrator or `su` ***password may be required*** to properly modify the hosts file on your local machine.
 1. Visit any of the following default sites in your browser:
     * [http://local.wordpress.dev/](http://local.wordpress.dev/) for WordPress stable
-    * [http://local.wordpress-trunk.dev/](http://local.wordpress-trunk.dev/) for WordPress trunk
     * [http://src.wordpress-develop.dev/](http://src.wordpress-develop.dev/) for trunk WordPress development files
     * [http://build.wordpress-develop.dev/](http://build.wordpress-develop.dev/) for the version of those development files built with Grunt
     * [http://vvv.dev/](http://vvv.dev/) for a default dashboard containing several useful tools
@@ -132,7 +131,7 @@ Since version 1.2.0, VVV has used a 64bit version of Ubuntu. Some older CPUs (su
 
 ### [Credentials](#credentials)
 
-All database usernames and passwords for WordPress installations included by default are: 
+All database usernames and passwords for WordPress installations included by default are:
 
 __User:__ `wp`  
 __Password:__ `wp`
@@ -155,12 +154,6 @@ See: [Connecting to MySQL](https://github.com/varying-vagrant-vagrants/vvv/wiki/
 * URL: `http://local.wordpress.dev`
 * DB Name: `wordpress_default`
 
-#### WordPress Trunk
-* LOCAL PATH: vagrant-local/www/wordpress-trunk
-* VM PATH: /srv/www/wordpress-trunk
-* URL: `http://local.wordpress-trunk.dev`
-* DB Name: `wordpress_trunk`
-
 #### WordPress Develop
 * LOCAL PATH: vagrant-local/www/wordpress-develop
 * VM PATH: /srv/www/wordpress-develop
@@ -177,7 +170,6 @@ A bunch of stuff!
 1. [Ubuntu](http://www.ubuntu.com/) 14.04 LTS (Trusty Tahr)
 1. [WordPress Develop](https://develop.svn.wordpress.org/trunk/)
 1. [WordPress Stable](https://wordpress.org/)
-1. [WordPress Trunk](https://core.svn.wordpress.org/trunk/)
 1. [WP-CLI](http://wp-cli.org/) (master branch)
 1. [nginx](http://nginx.org/) ([mainline](http://nginx.com/blog/nginx-1-6-1-7-released/) version)
 1. [mysql](https://www.mysql.com/) 5.5.x

--- a/config/nginx-config/sites/default.conf
+++ b/config/nginx-config/sites/default.conf
@@ -10,10 +10,6 @@
 #       - Latest stable version of WordPress
 #       - Files available locally in this repository's www/wordpress-default
 #       - Files available on guest (vagrant ssh) in /srv/www/wordpress-default
-#   http://local.wordpress-trunk.dev
-#       - SVN repository of WordPress trunk
-#       - Files available locally in this repository's www/wordpress-trunk
-#       - Files available on guest (vagrant ssh) in /srv/www/wordpress-trunk
 #
 
 ################################################################
@@ -84,21 +80,6 @@ server {
     listen       443 ssl;
     server_name  local.wordpress.dev *.local.wordpress.dev ~^local\.wordpress\.\d+\.\d+\.\d+\.\d+\.xip\.io$;
     root         /srv/www/wordpress-default;
-    include      /etc/nginx/nginx-wp-common.conf;
-}
-
-################################################################
-# WordPress trunk nginx configuration
-#
-# http://local.wordpress-trunk.dev - this server configuration is
-# setup to listen on port 80 for any requests coming in to
-# local.wordpress-trunk.dev and use the /srv/www/wordpress-trunk
-# directory to serve them.
-server {
-    listen       80;
-    listen       443 ssl;
-    server_name  local.wordpress-trunk.dev *.local.wordpress-trunk.dev ~^local\.wordpress-trunk\.\d+\.\d+\.\d+\.\d+\.xip\.io$;
-    root         /srv/www/wordpress-trunk;
     include      /etc/nginx/nginx-wp-common.conf;
 }
 

--- a/config/nginx-config/sites/deprecated.conf
+++ b/config/nginx-config/sites/deprecated.conf
@@ -1,0 +1,14 @@
+################################################################
+# WordPress trunk nginx configuration
+#
+# http://local.wordpress-trunk.dev - this server configuration is
+# setup to listen on port 80 for any requests coming in to
+# local.wordpress-trunk.dev and use the /srv/www/wordpress-trunk
+# directory to serve them.
+server {
+    listen       80;
+    listen       443 ssl;
+    server_name  local.wordpress-trunk.dev *.local.wordpress-trunk.dev ~^local\.wordpress-trunk\.\d+\.\d+\.\d+\.\d+\.xip\.io$;
+    root         /srv/www/wordpress-trunk;
+    include      /etc/nginx/nginx-wp-common.conf;
+}

--- a/database/init.sql
+++ b/database/init.sql
@@ -3,8 +3,6 @@
 # available for use.
 CREATE DATABASE IF NOT EXISTS `wordpress_default`;
 GRANT ALL PRIVILEGES ON `wordpress_default`.* TO 'wp'@'localhost' IDENTIFIED BY 'wp';
-CREATE DATABASE IF NOT EXISTS `wordpress_trunk`;
-GRANT ALL PRIVILEGES ON `wordpress_trunk`.* TO 'wp'@'localhost' IDENTIFIED BY 'wp';
 CREATE DATABASE IF NOT EXISTS `wordpress_develop`;
 GRANT ALL PRIVILEGES ON `wordpress_develop`.* TO 'wp'@'localhost' IDENTIFIED BY 'wp';
 CREATE DATABASE IF NOT EXISTS `wordpress_unit_tests`;

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -403,7 +403,7 @@ nginx_setup() {
             -key /etc/nginx/server.key \
             -out /etc/nginx/server.crt \
             -days 3650 \
-            -subj /CN=*.wordpress-develop.dev/CN=*.wordpress.dev/CN=*.vvv.dev/CN=*.wordpress-trunk.dev 2>&1)"
+            -subj /CN=*.wordpress-develop.dev/CN=*.wordpress.dev/CN=*.vvv.dev 2>&1)"
 	  echo "$vvvsigncert"
   fi
 
@@ -728,31 +728,6 @@ wpsvn_check() {
   fi;
 }
 
-wordpress_trunk() {
-  # Checkout, install and configure WordPress trunk via core.svn
-  if [[ ! -d "/srv/www/wordpress-trunk" ]]; then
-    echo "Checking out WordPress trunk from core.svn, see https://core.svn.wordpress.org/trunk"
-    svn checkout "https://core.svn.wordpress.org/trunk/" "/srv/www/wordpress-trunk"
-    cd /srv/www/wordpress-trunk
-    echo "Configuring WordPress trunk..."
-    noroot wp core config --dbname=wordpress_trunk --dbuser=wp --dbpass=wp --quiet --extra-php <<PHP
-// Match any requests made via xip.io.
-if ( isset( \$_SERVER['HTTP_HOST'] ) && preg_match('/^(local.wordpress-trunk.)\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(.xip.io)\z/', \$_SERVER['HTTP_HOST'] ) ) {
-define( 'WP_HOME', 'http://' . \$_SERVER['HTTP_HOST'] );
-define( 'WP_SITEURL', 'http://' . \$_SERVER['HTTP_HOST'] );
-}
-
-define( 'WP_DEBUG', true );
-PHP
-    echo "Installing WordPress trunk..."
-    noroot wp core install --url=local.wordpress-trunk.dev --quiet --title="Local WordPress Trunk Dev" --admin_name=admin --admin_email="admin@local.dev" --admin_password="password"
-  else
-    echo "Updating WordPress trunk..."
-    cd /srv/www/wordpress-trunk
-    svn up
-  fi
-}
-
 wordpress_develop(){
   # Checkout, install and configure WordPress trunk via develop.svn
   if [[ ! -d "/srv/www/wordpress-develop" ]]; then
@@ -894,11 +869,10 @@ phpmyadmin_setup
 network_check
 # Time for WordPress!
 echo " "
-echo "Installing/updating WordPress Stable, Trunk & Develop"
+echo "Installing/updating WordPress Stable & Develop"
 
 wordpress_default
 wpsvn_check
-wordpress_trunk
 wordpress_develop
 
 # VVV custom site import

--- a/www/default/index.php
+++ b/www/default/index.php
@@ -32,7 +32,6 @@ if ( file_exists( 'dashboard-custom.php' ) ) {
 
 <ul class="nav">
 	<li><a href="http://local.wordpress.dev/">http://local.wordpress.dev</a> for WordPress stable (www/wordpress-default)</li>
-	<li><a href="http://local.wordpress-trunk.dev/">http://local.wordpress-trunk.dev</a> for WordPress trunk (www/wordpress-trunk)</li>
 	<li><a href="http://src.wordpress-develop.dev/">http://src.wordpress-develop.dev</a> for trunk WordPress development files (www/wordpress-develop/src)</li>
 	<li><a href="http://build.wordpress-develop.dev/">http://build.wordpress-develop.dev</a> for a Grunt build of those development files (www/wordpress-develop/build)</li>
 </ul>


### PR DESCRIPTION
This has been around since the beginning of VVV, when the develop
repos had not yet been created. There's not much sense in providing
both the legacy trunk repo and the modern develop repo.

We'll still want to document the best way to continue using the
wordpress-trunk directory if it exists in your VVV instance.

See #921.