### PR TITLE
Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,47 @@ FROM phusion/baseimage
 
 RUN rm -f /etc/service/sshd/down
 
-RUN apt-get update && apt-get install -y sudo
+RUN echo "mysql-server mysql-server/root_password password root"       | debconf-set-selections && \
+    echo "mysql-server mysql-server/root_password_again password root" | debconf-set-selections && \
+    echo "postfix postfix/main_mailer_type select Internet Site"       | debconf-set-selections && \
+    echo "postfix postfix/mailname string vvv"                         | debconf-set-selections && \
+    apt-get update && apt-get install -y \
+        colordiff \
+        dos2unix \
+        gettext \
+        git \
+        graphviz \
+        imagemagick \
+        memcached \
+        mysql-server \
+        nginx \
+        ngrep \
+        ntp \
+        php-imagick \
+        php-memcache \
+        php-pear \
+        php7.0-cli \
+        php7.0-common \
+        php7.0-curl \
+        php7.0-dev \
+        php7.0-fpm \
+        php7.0-gd \
+        php7.0-imap \
+        php7.0-json \
+        php7.0-mbstring \
+        php7.0-mcrypt \
+        php7.0-mysql \
+        php7.0-soap \
+        php7.0-xml \
+        php7.0-zip \
+        postfix \
+        rsync \
+        subversion \
+        sudo \
+        unzip \
+        vim \
+        wget \
+        zip
 
 # Setup the vagrant user and default SSH Key
 RUN if ! getent passwd vagrant; then useradd -d /home/vagrant -m -s /bin/bash vagrant; fi \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM phusion/baseimage
+
+RUN rm -f /etc/service/sshd/down
+
+RUN apt-get update && apt-get install -y sudo
+
+# Setup the vagrant user and default SSH Key
+RUN if ! getent passwd vagrant; then useradd -d /home/vagrant -m -s /bin/bash vagrant; fi \
+    && echo vagrant:vagrant | chpasswd \
+    && echo 'vagrant ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
+    && mkdir -p /etc/sudoers.d \
+    && echo 'vagrant ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/vagrant \
+    && chmod 0440 /etc/sudoers.d/vagrant
+
+RUN mkdir -p /home/vagrant/.ssh \
+    && chmod 0700 /home/vagrant/.ssh \
+    && curl https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub \
+      -L -o /home/vagrant/.ssh/authorized_keys \
+    && chmod 0600 /home/vagrant/.ssh/authorized_keys \
+    && chown -R vagrant /home/vagrant/.ssh
+
+CMD ["/sbin/my_init"]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ VVV requires recent versions of both Vagrant and VirtualBox to be installed.
 
 [Vagrant](https://www.vagrantup.com) is a "tool for building and distributing development environments". It works with [virtualization](https://en.wikipedia.org/wiki/X86_virtualization) software such as [VirtualBox](https://www.virtualbox.org/) to provide a virtual machine sandboxed from your local environment.
 
-Provider support is included for VirtualBox, Parallels, Hyper-V, VMWare Fusion, and VMWare Workstation.
+Provider support is included for VirtualBox, Parallels, Hyper-V, VMWare Fusion, VMWare Workstation, and Docker.
 
 #### VVV as a MAMP/XAMPP Replacement
 
@@ -132,7 +132,7 @@ Since version 1.2.0, VVV has used a 64bit version of Ubuntu. Some older CPUs (su
 
 ### [Credentials](#credentials)
 
-All database usernames and passwords for WordPress installations included by default are: 
+All database usernames and passwords for WordPress installations included by default are:
 
 __User:__ `wp`  
 __Password:__ `wp`
@@ -236,6 +236,18 @@ To enable Git for core development, use `vagrant ssh` to access the virtual mach
 * Provide an approachable development environment with a modern server configuration.
 * Continue to work towards a stable state of software and configuration included in the default provisioning.
 * Provide excellent and clear documentation throughout VVV to aid in both learning and scaffolding.
+
+### Native Docker Support on Windows and macOS ###
+
+Docker on Windows and macOS is currently available in two versions. Originally the Docker project used a virtual machine installed into VirtualBox called boot2docker. The newer system, sometimes referred-to as "Native Docker" no-longer uses VirtualBox but instead uses macOS' Hypervisor.framework or Windows Professional's Hyper-V to run the Docker Virtual Machine.
+
+By default Vagrant tries to run a new boot2docker-style virtual machine, which means if you want to use Native Docker on your non-Linux system you will need to create a file called `CustomFile` with contents similar to below. This will tell Vagrant to not spawn a new virtual machine but to use Docker commands directly anyway.
+
+```ruby
+config.vm.provider :docker do |v|
+  v.force_host_vm = false
+end
+```
 
 ## [Copyright / License](#license)
 

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ To enable Git for core development, use `vagrant ssh` to access the virtual mach
 
 Docker on Windows and macOS is currently available in two versions. Originally the Docker project used a virtual machine installed into VirtualBox called boot2docker. The newer system, sometimes referred-to as "Native Docker" no-longer uses VirtualBox but instead uses macOS' Hypervisor.framework or Windows Professional's Hyper-V to run the Docker Virtual Machine.
 
-By default Vagrant tries to run a new boot2docker-style virtual machine, which means if you want to use Native Docker on your non-Linux system you will need to create a file called `CustomFile` with contents similar to below. This will tell Vagrant to not spawn a new virtual machine but to use Docker commands directly anyway.
+By default Vagrant tries to run a new boot2docker-style virtual machine, which means if you want to use Native Docker on your non-Linux system you will need to create a file called `Customfile` with contents similar to below. This will tell Vagrant to not spawn a new virtual machine but to use Docker commands directly anyway.
 
 ```ruby
 config.vm.provider :docker do |v|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,6 +47,13 @@ Vagrant.configure("2") do |config|
   # on your host machine inside the guest. See the manual for `ssh-add`.
   config.ssh.forward_agent = true
 
+  # Expose SSH for Docker
+  config.vm.provider :docker do |v, override|
+    v.has_ssh = true
+    override.ssh.host = "127.0.0.1"
+    override.ssh.port = 2222
+  end
+
   # Default Ubuntu Box
   #
   # This box is provided by Ubuntu vagrantcloud.com and is a nicely sized (332MB)
@@ -72,6 +79,13 @@ Vagrant.configure("2") do |config|
   # Hyper-V uses a different base box.
   config.vm.provider :hyperv do |v, override|
     override.vm.box = "ericmann/trusty64"
+  end
+
+  # Docker uses a Dockerfile instead of a box
+  config.vm.provider :docker do |v, override|
+    override.vm.box = nil
+    v.build_dir = vagrant_dir
+    v.name = "vvv"
   end
 
   config.vm.hostname = "vvv"


### PR DESCRIPTION
Requires my previous PR #967.

Support Docker and Native Docker on all platforms (Windows, macOS, and Linux).
Update readme with details of how to prevent vagrant from creating a new VM on Windows and macOS when you have native-docker installed.
