### PR TITLE
[PR] Checkout and initialize wordpress-develop in /tmp/

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -756,10 +756,22 @@ PHP
 wordpress_develop(){
   # Checkout, install and configure WordPress trunk via develop.svn
   if [[ ! -d "/srv/www/wordpress-develop" ]]; then
-    echo "Checking out WordPress trunk from develop.svn, see https://develop.svn.wordpress.org/trunk"
-    svn checkout "https://develop.svn.wordpress.org/trunk/" "/srv/www/wordpress-develop"
+    echo "Checking out WordPress trunk. See https://develop.svn.wordpress.org/trunk"
+    noroot svn checkout "https://develop.svn.wordpress.org/trunk/" "/tmp/wordpress-develop"
+
+    cd /tmp/wordpress-develop/src/
+
+    echo "Installing local npm packages for src.wordpress-develop.dev, this may take several minutes."
+    noroot npm install
+
+    echo "Initializing grunt and creating build.wordpress-develop.dev, this may take several minutes."
+    noroot grunt
+
+    echo "Moving WordPress develop to a shared directory, /srv/www/wordpress-develop"
+    mv /tmp/wordpress-develop /srv/www/
+
     cd /srv/www/wordpress-develop/src/
-    echo "Configuring WordPress develop..."
+    echo "Creating wp-config.php for src.wordpress-develop.dev and build.wordpress-develop.dev."
     noroot wp core config --dbname=wordpress_develop --dbuser=wp --dbpass=wp --quiet --extra-php <<PHP
 // Match any requests made via xip.io.
 if ( isset( \$_SERVER['HTTP_HOST'] ) && preg_match('/^(src|build)(.wordpress-develop.)\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(.xip.io)\z/', \$_SERVER['HTTP_HOST'] ) ) {
@@ -773,12 +785,10 @@ define( 'WP_SITEURL', 'http://build.wordpress-develop.dev' );
 
 define( 'WP_DEBUG', true );
 PHP
-    echo "Installing WordPress develop..."
+    echo "Installing src.wordpress-develop.dev."
     noroot wp core install --url=src.wordpress-develop.dev --quiet --title="WordPress Develop" --admin_name=admin --admin_email="admin@local.dev" --admin_password="password"
     cp /srv/config/wordpress-config/wp-tests-config.php /srv/www/wordpress-develop/
     cd /srv/www/wordpress-develop/
-    echo "Running npm install for the first time, this may take several minutes..."
-    noroot npm install &>/dev/null
   else
     echo "Updating WordPress develop..."
     cd /srv/www/wordpress-develop/


### PR DESCRIPTION
The installation of local npm packages was running into trouble
due to what is likely a race condition caused by slow shared drives
between the host and guest machines. This is mostly a guess, but
seems plausible.

We can instead handle the initial SVN checkout, the npm package
installation, and the initial build via grunt in the VM's `/tmp`
machine. Once this is all prepped, it is then moved to the final
location in `/srv/www/wordpress-develop` before other scripts that
install WordPress run.

Anything involving files runs quite a bit quicker during the initial
setup. The move of the directory takes a long while though, which
kind of negates the original speed. :)

But speed isn't the problem, incomplete local npm packages is.

Fixes #825.