### PR TITLE
[PR] Ensure the log file for xdebug is group writeable

### DIFF
--- a/config/homebin/xdebug_on
+++ b/config/homebin/xdebug_on
@@ -2,3 +2,6 @@
 sudo phpenmod xdebug
 sudo service php7.0-fpm restart
 
+# Ensure the log file for xdebug is group writeable.
+sudo touch /srv/log/xdebug-remote.log
+sudo chmod 664 /srv/log/xdebug-remote.log


### PR DESCRIPTION
By default, the xdebug log file is owner writeable (www-data). When
the vagrant user runs PHP inside the VM, say for `wp`, while xdebug
is enabled, it needs access to the file as well.

We made vagrant part of the www-data group in #705, and moved the
log file to a more accessible location, but it was still not
writeable.

Fixes #621.