### PR TITLE
[PR] Disable xdebug early in provisioning

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -276,6 +276,9 @@ package_install() {
 }
 
 tools_install() {
+  # Disable xdebug before any composer provisioning.
+  sh /home/vagrant/bin/xdebug_off
+
   # nvm
   if [[ ! -d "/srv/config/nvm" ]]; then
     echo -e "\nDownloading nvm, see https://github.com/creationix/nvm"


### PR DESCRIPTION
If xdebug is enabled when composer runs, it will display warnings
and may result in slow provisioning. We should be able to assume
that xdebug is off during provisoning and remains off until enabled
again after provisioning.

Fixes #919.