### PR TITLE
WP-CLI: Use composer install instead of update

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -582,7 +582,7 @@ wp_cli() {
     echo -e "\nUpdating wp-cli..."
     cd /srv/www/wp-cli
     git pull --rebase origin master
-    composer update
+    composer install
   fi
   # Link `wp` to the `/usr/local/bin` directory
   ln -sf "/srv/www/wp-cli/bin/wp" "/usr/local/bin/wp"


### PR DESCRIPTION
I noticed that WP-CLI wasn't updating successfully on `vagrant provision` and noticed the error `Cannot pull with rebase: You have unstaged changes.` so I dug around in the provision file and found that after pulling the latest WP-CLI version `composer update` runs.

This command does install dependencies but also updates them to the latest version, writing `composer.lock` in the process and makes it impossible to pull a new version from GitHub. 

This is easily solved by running `composer install` instead which is the proper way to install dependencies.

Ping @jeremyfelt 
