### PR TITLE
Script to facilitate changes to xdebug.ini and php-custom.ini

### DIFF
--- a/config/homebin/copyxdebug
+++ b/config/homebin/copyxdebug
@@ -1,0 +1,13 @@
+#!/bin/bash
+sudo cp /srv/config/php-config/xdebug.ini /etc/php/7.0/mods-available/xdebug.ini
+sudo cp "/srv/config/php-config/php-custom.ini" "/etc/php/7.0/fpm/conf.d/php-custom.ini"
+
+  # Find the path to Xdebug and prepend it to xdebug.ini
+XDEBUG_PATH=$( find /usr/lib/php/ -name 'xdebug.so' | head -1 )
+sudo sed -i "1izend_extension=\"$XDEBUG_PATH\"" "/etc/php/7.0/mods-available/xdebug.ini"
+
+sudo service php7.0-fpm restart
+
+# Ensure the log file for xdebug is group writeable.
+sudo touch /srv/log/xdebug-remote.log
+sudo chmod 664 /srv/log/xdebug-remote.log

--- a/config/php-config/php-custom.ini
+++ b/config/php-config/php-custom.ini
@@ -10,7 +10,7 @@ short_open_tag = Off
 allow_call_time_pass_reference = Off
 
 ; Maximum execution time of each script, in seconds. (Hard coded at 0 for CLI)
-max_execution_time = 30
+;max_execution_time = 30
 
 ; Maximum amount of memory a script may consume.
 memory_limit = 128M

--- a/config/php-config/xdebug.ini
+++ b/config/php-config/xdebug.ini
@@ -3,6 +3,7 @@
 max_execution_time = 300
 
 [XDebug]
+xdebug.remote_autostart = 0
 
 ; xdebug.auto_trace
 ; Type: boolean, Default value: 0
@@ -164,7 +165,8 @@ xdebug.profiler_output_name = "cachegrind.out.%t-%s"
 ; Normally you need to use a specific HTTP GET/POST variable to start remote debugging (see Remote
 ; Debugging). When this setting is set to 'On' Xdebug will always attempt to start a remote debugging
 ; session and try to connect to a client, even if the GET/POST/COOKIE variable was not present.
-xdebug.remote_autostart = 1
+;xdebug.remote_autostart = 1
+
 
 ; xdebug.remote_enable
 ; Type: boolean, Default value: 0

--- a/config/php-config/xdebug.ini
+++ b/config/php-config/xdebug.ini
@@ -1,3 +1,7 @@
+[PHP]
+; change max execution time to a large value if in xdebug mode
+max_execution_time = 300
+
 [XDebug]
 
 ; xdebug.auto_trace


### PR DESCRIPTION
These three commits do the following:
One removes max_execution_time from php-custom.ini, and puts it in xdebug.ini.  This means that max_execution_time changes when xdebug is enabled automatically.  A value in php-custom.ini would override it.
the next one adds a script to homebin called 'copyxdebug'.  This script replicates what provision.sh does for the xdebug.ini and php-custom.ini - copies them to the correct location (and adds a line to the top of xdebug.ini indicating the location of the xdebug library.
The final one sets xdebug.remote_autostart = 0
It also moves this to the top of xdebug.ini for easy access.  When set to the VVV default '1', if xdebug is turned on, then you can't view the website unless you have a debugger at the target debug address running?  not sure of the impact of this on other using different environments.
