### PR TITLE
WiP: Add docker provider support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.vagrant
+config
+database
+log
+www

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,10 @@ FROM ubuntu:trusty
 # As this image is not published, we do not optimize for size by combining RUN statements
 
 # Basic upgrades; install sudo and SSH.
+# wget: for network detection
 RUN set -x \
 	&& apt-get update \
-	&& apt-get install --no-install-recommends -y sudo openssh-server \
+	&& apt-get install --no-install-recommends -y sudo openssh-server wget \
 	&& mkdir /var/run/sshd \
 	&& sed -i 's/PermitRootLogin yes/PermitRootLogin no/' /etc/ssh/sshd_config \
 	&& echo 'UseDNS no' >> /etc/ssh/sshd_config \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM ubuntu:trusty
+
+# NOTE:
+# As this image is not published, we do not optimize for size by combining RUN statements
+
+# Basic upgrades; install sudo and SSH.
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install --no-install-recommends -y sudo openssh-server \
+	&& mkdir /var/run/sshd \
+	&& sed -i 's/PermitRootLogin yes/PermitRootLogin no/' /etc/ssh/sshd_config \
+	&& echo 'UseDNS no' >> /etc/ssh/sshd_config \
+	&& apt-get clean \
+	&& rm -rfv /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Remove the policy file once we're finished installing software.
+# This allows invoke-rc.d and friends to work as expected.
+RUN rm /usr/sbin/policy-rc.d
+
+# Add the Vagrant user and necessary passwords.
+RUN groupadd vagrant
+RUN useradd -c "Vagrant" -g vagrant -d /home/vagrant -m -s /bin/bash vagrant
+RUN echo 'root:vagrant' | chpasswd
+RUN echo 'vagrant:vagrant' | chpasswd
+
+# Allow the vagrant user to use sudo without a password.
+RUN echo 'vagrant ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/vagrant
+
+# Install Vagrant's insecure public key so provisioning and 'vagrant ssh' work.
+RUN mkdir /home/vagrant/.ssh
+ADD https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub /home/vagrant/.ssh/authorized_keys
+RUN chmod 0600 /home/vagrant/.ssh/authorized_keys
+RUN chown -R vagrant:vagrant /home/vagrant/.ssh
+RUN chmod 0700 /home/vagrant/.ssh
+
+EXPOSE 22
+CMD ["/usr/sbin/sshd", "-D"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM ubuntu:trusty
 # wget: for network detection
 RUN set -x \
 	&& apt-get update \
-	&& apt-get install --no-install-recommends -y sudo openssh-server wget \
+	&& apt-get install --no-install-recommends -y sudo openssh-server wget rsync apt-transport-https \
 	&& mkdir /var/run/sshd \
 	&& sed -i 's/PermitRootLogin yes/PermitRootLogin no/' /etc/ssh/sshd_config \
 	&& echo 'UseDNS no' >> /etc/ssh/sshd_config \

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,5 @@
 # -*- mode: ruby -*-
-# vi: set ft=ruby :
+# vi: set ft=ruby ts=2 sw=2 et:
 
 vagrant_dir = File.expand_path(File.dirname(__FILE__))
 
@@ -52,7 +52,9 @@ Vagrant.configure("2") do |config|
   # This box is provided by Ubuntu vagrantcloud.com and is a nicely sized (332MB)
   # box containing the Ubuntu 14.04 Trusty 64 bit release. Once this box is downloaded
   # to your host computer, it is cached for future use under the specified box name.
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.provider :virtualbox do |v, override|
+    override.vm.box = "ubuntu/trusty64"
+  end
 
   # The Parallels Provider uses a different naming scheme.
   config.vm.provider :parallels do |v, override|
@@ -72,6 +74,13 @@ Vagrant.configure("2") do |config|
   # Hyper-V uses a different base box.
   config.vm.provider :hyperv do |v, override|
     override.vm.box = "ericmann/trusty64"
+  end
+
+  # Docker base box is defined in Dockerfile
+  config.vm.provider 'docker' do |d|
+    d.build_dir = "."
+    # Required for provisioning and 'vagrant ssh' to work.
+    d.has_ssh = true
   end
 
   config.vm.hostname = "vvv"

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -102,7 +102,14 @@ apt_package_check_list=(
 
 network_detection() {
   # Network Detection
-  #
+
+  # Test that wget is installed to avoid giving bogus report about no network
+  command -v wget >/dev/null || {
+    echo "Unable to detect network: wget not installed"
+    ping_result="Not Connected"
+    return
+  }
+
   # Make an HTTP request to google.com to determine if outside access is available
   # to us. If 3 attempts with a timeout of 5 seconds are not successful, then we'll
   # skip a few things further in provisioning rather than create a bunch of errors.

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -135,13 +135,14 @@ git_ppa_check() {
   #
   # apt-get does not have latest version of git,
   # so let's the use ppa repository instead.
-  #
+
   # Install prerequisites.
+  sudo apt-get update &>/dev/null
   sudo apt-get install -y python-software-properties software-properties-common &>/dev/null
+
   # Add ppa repo.
   echo "Adding ppa:git-core/ppa repository"
   sudo add-apt-repository -y ppa:git-core/ppa &>/dev/null
-  # Update apt-get info.
   sudo apt-get update &>/dev/null
 }
 


### PR DESCRIPTION
Adds [Docker Provider](https://www.vagrantup.com/docs/docker/) support.

To be used as:

```
$ vagrant up --provider=docker
```