### PR TITLE
Update to phpunit to major version 5

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -362,7 +362,7 @@ tools_install() {
   if [[ -n "$(composer --version --no-ansi | grep 'Composer version')" ]]; then
     echo "Updating Composer..."
     COMPOSER_HOME=/usr/local/src/composer composer self-update
-    COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update phpunit/phpunit:4.8.*
+    COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update phpunit/phpunit:5.*
     COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update phpunit/php-invoker:1.1.*
     COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update mockery/mockery:0.9.*
     COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update d11wtq/boris:v1.0.8


### PR DESCRIPTION
PHPUnit 5.6 is the current stable release series.
It became stable on October 7, 2016.

It's also the only version officially supported by php7+ 

`PHPUnit 4.8 is supported on PHP 5.3, PHP 5.4, PHP 5.5, and PHP 5.6.`