### PR TITLE
Switch from MySQL 5.5 to MariaDB 5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ All WordPress admin usernames and passwords for WordPress installations included
 __User:__ `admin`  
 __Password:__ `password`
 
-MySQL Root:
+MariaDB/MySQL Root:
 
 __User:__ `root`
 __Password:__ `root`
@@ -172,7 +172,7 @@ A bunch of stuff!
 1. [WordPress Stable](https://wordpress.org/)
 1. [WP-CLI](http://wp-cli.org/) (master branch)
 1. [nginx](http://nginx.org/) ([mainline](http://nginx.com/blog/nginx-1-6-1-7-released/) version)
-1. [mysql](https://www.mysql.com/) 5.5.x
+1. [MariaDB](https://mariadb.org/) 5.5.x (drop-in replacement for MySQL)
 1. [php-fpm](http://php-fpm.org/) 7.0.x
 1. [memcached](http://memcached.org/)
 1. PHP [memcache extension](https://pecl.php.net/package/memcache)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -192,7 +192,7 @@ Vagrant.configure("2") do |config|
   # If a database directory exists in the same directory as your Vagrantfile,
   # a mapped directory inside the VM will be created that contains these files.
   # This directory is used to maintain default database scripts as well as backed
-  # up mysql dumps (SQL files) that are to be imported automatically on vagrant up
+  # up MariaDB/MySQL dumps (SQL files) that are to be imported automatically on vagrant up
   config.vm.synced_folder "database/", "/srv/database"
 
   # If the mysql_upgrade_info file from a previous persistent database mapping is detected,
@@ -354,7 +354,7 @@ Vagrant.configure("2") do |config|
     config.vm.provision "post", type: "shell", path: File.join( "provision", "provision-post.sh" )
   end
 
-  # Always start MySQL on boot, even when not running the full provisioner
+  # Always start MariaDB/MySQL on boot, even when not running the full provisioner
   # (run: "always" support added in 1.6.0)
   if vagrant_version >= "1.6.0"
     config.vm.provision :shell, inline: "sudo service mysql restart", run: "always"

--- a/config/mysql-config/my.cnf
+++ b/config/mysql-config/my.cnf
@@ -1,5 +1,5 @@
 #
-# The MySQL database server configuration file.
+# The MariaDB/MySQL database server configuration file.
 #
 # You can copy this to one of:
 # - "/etc/mysql/my.cnf" to set global options,

--- a/config/mysql-config/my.cnf
+++ b/config/mysql-config/my.cnf
@@ -4,7 +4,7 @@
 # You can copy this to one of:
 # - "/etc/mysql/my.cnf" to set global options,
 # - "~/.my.cnf" to set user-specific options.
-# 
+#
 # One can use all long options that the program supports.
 # Run program with --help to get a list of available options and with
 # --print-defaults to see which it would actually understand and use.
@@ -19,6 +19,9 @@
 [client]
 port		= 3306
 socket		= /var/run/mysqld/mysqld.sock
+
+# Default is Latin1, WordPress needs UTF-8 (see also server section)
+default-character-set = utf8mb4
 
 # Here is entries for some specific programs
 # The following values assume you have at least 32M ram
@@ -71,6 +74,15 @@ query_cache_size = 104857600
 query_cache_type = 1
 query_cache_limit = 1048576
 
+#
+# * Character sets
+#
+# MySQL/MariaDB default is Latin1, but in Debian we rather default to the full
+# utf8 4-byte character set. See also client.cnf
+#
+character-set-server  = utf8mb4
+collation-server      = utf8mb4_general_ci
+
 [mysqldump]
 quick
 quote-names
@@ -78,6 +90,9 @@ max_allowed_packet	= 128M
 
 [mysql]
 #no-auto-rehash	# faster start of mysql but no tab completion
+
+# Default is Latin1, WordPress needs UTF-8 (see also server section)
+default-character-set = utf8mb4
 
 [isamchk]
 

--- a/config/mysql-config/root-my.cnf
+++ b/config/mysql-config/root-my.cnf
@@ -1,10 +1,10 @@
-# Custom MySQL configuration to save the root user's password for both client
+# Custom MariaDB/MySQL configuration to save the root user's password for both client
 # and mysqladmin access. This allows us to use `mysql -u root` to access
 # MySQL rather than having to use a password.
 [client]
 user     = root
 password = root
 
-[mysqladmin] 
+[mysqladmin]
 user     = root
 password = root

--- a/database/import-sql.sh
+++ b/database/import-sql.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Import provided SQL files in to MySQL.
+# Import provided SQL files in to MariaDB/MySQL.
 #
 # The files in the {vvv-dir}/database/backups/ directory should be created by
 # mysqldump or some other export process that generates a full set of SQL commands
@@ -19,7 +19,7 @@
 # Let's begin...
 
 # Move into the newly mapped backups directory, where mysqldump(ed) SQL files are stored
-printf "\nStart MySQL Database Import\n"
+printf "\nStart MariaDB Database Import\n"
 cd /srv/database/backups/
 
 # Parse through each file in the directory and use the file name to

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -60,8 +60,8 @@ apt_package_check_list=(
   # memcached is made available for object caching
   memcached
 
-  # mysql is the default database
-  mysql-server
+  # mariadb (drop-in replacement on mysql) is the default database
+  mariadb-server
 
   # other packages that come in handy
   imagemagick
@@ -217,13 +217,13 @@ package_check() {
 package_install() {
   package_check
 
-  # MySQL
+  # MariaDB/MySQL
   #
-  # Use debconf-set-selections to specify the default password for the root MySQL
-  # account. This runs on every provision, even if MySQL has been installed. If
-  # MySQL is already installed, it will not affect anything.
-  echo mysql-server mysql-server/root_password password "root" | debconf-set-selections
-  echo mysql-server mysql-server/root_password_again password "root" | debconf-set-selections
+  # Use debconf-set-selections to specify the default password for the root MariaDB
+  # account. This runs on every provision, even if MariaDB has been installed. If
+  # MariaDB is already installed, it will not affect anything.
+  echo mariadb-server-5.5 mysql-server/root_password password "root" | debconf-set-selections
+  echo mariadb-server-5.5 mysql-server/root_password_again password "root" | debconf-set-selections
 
   # Postfix
   #
@@ -458,7 +458,7 @@ phpfpm_setup() {
 }
 
 mysql_setup() {
-  # If MySQL is installed, go through the various imports and service tasks.
+  # If MariaDB/MySQL is installed, go through the various imports and service tasks.
   local exists_mysql
 
   exists_mysql="$(service mysql status)"


### PR DESCRIPTION
This is the first step in #876 and #949. Switching to MariaDB available
in the official Ubuntu 14.04 repositories is a very safe change and
it paves way to easily upgrade to 10.0 or 10.1 in a later step.
