### PR TITLE
Switch to the Node.js 6.x LTS release

### DIFF
--- a/config/apt-source-append.list
+++ b/config/apt-source-append.list
@@ -10,5 +10,5 @@ deb http://ppa.launchpad.net/ondrej/php/ubuntu trusty main
 deb-src http://ppa.launchpad.net/ondrej/php/ubuntu trusty main
 
 # Provides Node.js
-deb https://deb.nodesource.com/node_4.x trusty main
-deb-src https://deb.nodesource.com/node_4.x trusty main
+deb https://deb.nodesource.com/node_6.x trusty main
+deb-src https://deb.nodesource.com/node_6.x trusty main


### PR DESCRIPTION
On October 18th, with the release of Node.js 6.9.0, the 6.x branch was moved to LTS status. Seems like now is a good time to update our default version.