### PR TITLE
Install phpMyAdmin via Composer

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -684,10 +684,7 @@ phpmyadmin_setup() {
   if [[ ! -d /srv/www/default/database-admin ]]; then
     echo "Downloading phpMyAdmin..."
     cd /srv/www/default
-    wget -q -O phpmyadmin.tar.gz "https://files.phpmyadmin.net/phpMyAdmin/4.6.0/phpMyAdmin-4.6.0-all-languages.tar.gz"
-    tar -xf phpmyadmin.tar.gz
-    mv phpMyAdmin-4.6.0-all-languages database-admin
-    rm phpmyadmin.tar.gz
+    composer create-project phpmyadmin/phpmyadmin:4.6.* database-admin --repository-url=https://www.phpmyadmin.net/packages.json --no-dev
   else
     echo "PHPMyAdmin already installed."
   fi


### PR DESCRIPTION
This has been discussed a few times (#286 and #576), but for various reasons, it's never been commited.

Using Composer allows us maintain the current behavior of only installing on provision. We can control which x.y release we'd like to use, since new x.y versions can have PHP/MySQL requirement changes. But, on a subsequent provision, users can get the latest bugfix/security release without having to explicity update the provision script.
