### PR TITLE
Allow security updates to be installed on provision

### DIFF
--- a/config/apt/10periodic
+++ b/config/apt/10periodic
@@ -1,0 +1,4 @@
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::Download-Upgradeable-Packages "1";
+APT::Periodic::AutocleanInterval "7";
+APT::Periodic::Unattended-Upgrade "1";

--- a/config/apt/50unattended-upgrades
+++ b/config/apt/50unattended-upgrades
@@ -1,0 +1,61 @@
+// Automatically upgrade packages from these (origin:archive) pairs
+Unattended-Upgrade::Allowed-Origins {
+	"${distro_id}:${distro_codename}-security";
+//	"${distro_id}:${distro_codename}-updates";
+//	"${distro_id}:${distro_codename}-proposed";
+//	"${distro_id}:${distro_codename}-backports";
+	"nginx:stable";
+	"LP-PPA-ondrej-php:trusty";
+};
+
+// List of packages to not update (regexp are supported)
+Unattended-Upgrade::Package-Blacklist {
+//	"vim";
+//	"libc6";
+//	"libc6-dev";
+//	"libc6-i686";
+};
+
+// This option allows you to control if on a unclean dpkg exit
+// unattended-upgrades will automatically run
+//   dpkg --force-confold --configure -a
+// The default is true, to ensure updates keep getting installed
+//Unattended-Upgrade::AutoFixInterruptedDpkg "false";
+
+// Split the upgrade into the smallest possible chunks so that
+// they can be interrupted with SIGUSR1. This makes the upgrade
+// a bit slower but it has the benefit that shutdown while a upgrade
+// is running is possible (with a small delay)
+//Unattended-Upgrade::MinimalSteps "true";
+
+// Install all unattended-upgrades when the machine is shuting down
+// instead of doing it in the background while the machine is running
+// This will (obviously) make shutdown slower
+//Unattended-Upgrade::InstallOnShutdown "true";
+
+// Send email to this address for problems or packages upgrades
+// If empty or unset then no email is sent, make sure that you
+// have a working mail setup on your system. A package that provides
+// 'mailx' must be installed. E.g. "user@example.com"
+//Unattended-Upgrade::Mail "root";
+
+// Set this value to "true" to get emails only on errors. Default
+// is to always send a mail if Unattended-Upgrade::Mail is set
+//Unattended-Upgrade::MailOnlyOnError "true";
+
+// Do automatic removal of new unused dependencies after the upgrade
+// (equivalent to apt-get autoremove)
+Unattended-Upgrade::Remove-Unused-Dependencies "false";
+
+// Automatically reboot *WITHOUT CONFIRMATION*
+//  if the file /var/run/reboot-required is found after the upgrade
+//Unattended-Upgrade::Automatic-Reboot "false";
+
+// If automatic reboot is enabled and needed, reboot at the specific
+// time instead of immediately
+//  Default: "now"
+//Unattended-Upgrade::Automatic-Reboot-Time "02:00";
+
+// Use apt bandwidth limit feature, this example limits the download
+// speed to 70kb/sec
+//Acquire::http::Dl-Limit "70";

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -195,6 +195,12 @@ print_pkg_info() {
   pack_space_count="$(( 30 - ${#pkg_version} ))"
   real_space="$(( space_count + pack_space_count + ${#pkg_version} ))"
   printf " * $pkg %${real_space}.${#pkg_version}s ${pkg_version}\n"
+unattended_upgrades_setup() {
+  cp "/srv/config/apt/10periodic" "/etc/apt/apt.conf.d/10periodic"
+  echo " * Copied /srv/config/apt/10periodic to /etc/apt/apt.conf.d/10periodic"
+
+  cp "/srv/config/apt/50unattended-upgrades" "/etc/apt/apt.conf.d/50unattended-upgrades"
+  echo " * Copied /srv/config/apt/50unattended-upgrades to /etc/apt/apt.conf.d/50unattended-upgrades"
 }
 
 package_check() {
@@ -249,6 +255,9 @@ package_install() {
 
   if [[ ${#apt_package_install_list[@]} = 0 ]]; then
     echo -e "No apt packages to install.\n"
+
+    echo "Running apt-get update..."
+    apt-get update -y
   else
     # Before running `apt-get update`, we should add the public keys for
     # the packages that we are installing from non standard sources via
@@ -277,6 +286,10 @@ package_install() {
     # Clean up apt caches
     apt-get clean
   fi
+
+  # Check for security updates
+  echo "Checking for security updates"
+  unattended-upgrades
 }
 
 tools_install() {
@@ -863,6 +876,7 @@ network_check
 echo " "
 echo "Main packages check and install."
 git_ppa_check
+unattended_upgrades_setup
 package_install
 tools_install
 nginx_setup


### PR DESCRIPTION
Also, installs security updates on a daily basis while the server is up.

Things to note:

1. Restarts are not forced, but may be required for situations like kernel upgrades.

2. Both nginx mainline and ppa:ondrej/php are also checked for updates, even though all updates aren't explicitly security updates.

See #457