### PR TITLE
deleted local.wordpress-trunk.dev

### DIFF
--- a/www/vvv-hosts
+++ b/www/vvv-hosts
@@ -9,6 +9,5 @@
 # of the www/ directory.
 vvv.dev
 local.wordpress.dev
-local.wordpress-trunk.dev
 src.wordpress-develop.dev
 build.wordpress-develop.dev


### PR DESCRIPTION
To my knowledge, local.wordpress-truck.dev is not loaded in the current version of VVV.
So, I deleted it in the file /www/vvv-hosts