### PR TITLE
Run composer install after WP-CLI update

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -592,7 +592,7 @@ wp_cli() {
     echo -e "\nUpdating wp-cli..."
     cd /srv/www/wp-cli
     git pull --rebase origin master
-    composer update
+    composer install
   fi
   # Link `wp` to the `/usr/local/bin` directory
   ln -sf "/srv/www/wp-cli/bin/wp" "/usr/local/bin/wp"


### PR DESCRIPTION
If we run `composer update` then it will update the `composer.lock` which we don't want. This may also be the cause of issues in the past.

Once the `composer.lock` has been updated in the WP-CLI update then we just need to install the newest versions with `composer install`.

Related: #82, #983