### PR TITLE
Add support for custom YAML config file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 # This is a file intended for hooking in a custom Vagrant configuration on up
 /Customfile
+/vvv-custom.yml
 
 # Allow for custom provisioning scripts that are not included with the repo
 /provision/provision-custom.sh

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,12 @@ require 'yaml'
 
 vagrant_dir = File.expand_path(File.dirname(__FILE__))
 
-vvv_config_file = File.join(vagrant_dir, 'vvv-config.yml')
+if File.file?(File.join(vagrant_dir, 'vvv-custom.yml')) then
+  vvv_config_file = File.join(vagrant_dir, 'vvv-custom.yml')
+else
+  vvv_config_file = File.join(vagrant_dir, 'vvv-config.yml')
+end
+
 vvv_config = YAML.load_file(vvv_config_file)
 
 vvv_config['sites'].each do |site, args|


### PR DESCRIPTION
This commit adds support for a `vvv-custom.yml` file and, if it exists, completely overrides the `vvv-config.yml` files.

In my opinion, if a user is adding a custom config, she/he should have complete control over all configuration and not a merged configuration with the default.

Resolves #1045