### PR TITLE
Improves Network Connection Detection

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -107,7 +107,7 @@ network_detection() {
   # Make an HTTP request to google.com to determine if outside access is available
   # to us. If 3 attempts with a timeout of 5 seconds are not successful, then we'll
   # skip a few things further in provisioning rather than create a bunch of errors.
-  if [[ "$(wget --tries=3 --timeout=5 --spider http://google.com 2>&1 | grep 'connected')" ]]; then
+  if [[ "$(wget --tries=3 --timeout=5 --spider --recursive --level=2 http://google.com 2>&1 | grep 'connected')" ]]; then
     echo "Network connection detected..."
     ping_result="Connected"
   else


### PR DESCRIPTION
Google.com redirects to a local server like Google.co.in based on geolocation. Without recursion the wget call does not detect such redirects. That further results in major provisioning errors since the `network_check` call happens at multiple stages.

This PR follows such redirects upto 2 levels. I've tested provision over mobile networks with and without this PR. Network connection detection is much more reliable with this recursion flag enabled.