### PR TITLE
Support multiple php versions through vvv-config.yml & utilities

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -48,7 +48,7 @@ vvv_config['sites'].each do |site, args|
   defaults['branch'] = 'master'
   defaults['skip_provisioning'] = false
   defaults['allow_customfile'] = false
-  defaults['upstream'] = 'php'
+  defaults['nginx_upstream'] = 'php'
   defaults['hosts'] = Array.new
 
   vvv_config['sites'][site] = defaults.merge(args)
@@ -391,7 +391,7 @@ Vagrant.configure("2") do |config|
         args['branch'],
         args['vm_dir'],
         args['skip_provisioning'].to_s,
-        args['upstream']
+        args['nginx_upstream']
       ]
   end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -48,6 +48,7 @@ vvv_config['sites'].each do |site, args|
   defaults['branch'] = 'master'
   defaults['skip_provisioning'] = false
   defaults['allow_customfile'] = false
+  defaults['upstream'] = 'php'
   defaults['hosts'] = Array.new
 
   vvv_config['sites'][site] = defaults.merge(args)
@@ -389,7 +390,8 @@ Vagrant.configure("2") do |config|
         args['repo'].to_s,
         args['branch'],
         args['vm_dir'],
-        args['skip_provisioning'].to_s
+        args['skip_provisioning'].to_s,
+        args['upstream']
       ]
   end
 

--- a/config/homebin/xdebug_off
+++ b/config/homebin/xdebug_off
@@ -2,3 +2,11 @@
 sudo phpdismod xdebug
 sudo service php7.0-fpm restart
 
+if [ -f "/etc/init.d/php5.6-fpm" ]; then
+    sudo service php5.6-fpm restart
+fi
+
+if [ -f "/etc/init.d/php7.1-fpm" ]; then
+    sudo service php7.1-fpm restart
+fi
+

--- a/config/homebin/xdebug_on
+++ b/config/homebin/xdebug_on
@@ -2,6 +2,14 @@
 sudo phpenmod xdebug
 sudo service php7.0-fpm restart
 
+if [ -f "/etc/init.d/php5.6-fpm" ]; then
+    sudo service php5.6-fpm restart
+fi
+
+if [ -f "/etc/init.d/php7.1-fpm" ]; then
+    sudo service php7.1-fpm restart
+fi
+
 # Ensure the log file for xdebug is group writeable.
 sudo touch /srv/log/xdebug-remote.log
 sudo chmod 664 /srv/log/xdebug-remote.log

--- a/config/nginx-config/nginx-wp-common.conf
+++ b/config/nginx-config/nginx-wp-common.conf
@@ -73,8 +73,8 @@ location ~ \.php$ {
     # We define it here to be sure that it exists.
     fastcgi_param   SCRIPT_FILENAME         $document_root$fastcgi_script_name;
 
-    # Use the upstream for php7-fpm that we defined in nginx.conf
-    fastcgi_pass   php;
+    # Use the upstream defined in the upstream variable.
+    fastcgi_pass   $upstream;
 
     # And get to serving the file!
     fastcgi_index  index.php;

--- a/config/nginx-config/nginx.conf
+++ b/config/nginx-config/nginx.conf
@@ -90,6 +90,8 @@ http {
         server unix:/var/run/php7.0-fpm.sock;
     }
 
+	include /etc/nginx/upstreams/*.conf;
+
     # If the requested body size is more than the buffer size, the entire body is
     # written to a temporary file. Default is 8k or 16k depending on the platform.
     client_body_buffer_size 16k;

--- a/config/nginx-config/nginx.conf
+++ b/config/nginx-config/nginx.conf
@@ -87,7 +87,7 @@ http {
 
     # Upstream to abstract backend connection(s) for PHP.
     upstream php {
-        server unix:/var/run/php7-fpm.sock;
+        server unix:/var/run/php7.0-fpm.sock;
     }
 
     # If the requested body size is more than the buffer size, the entire body is

--- a/config/nginx-config/nginx.conf
+++ b/config/nginx-config/nginx.conf
@@ -92,6 +92,10 @@ http {
 
 	include /etc/nginx/upstreams/*.conf;
 
+	map '' $upstream {
+		default php;
+	}
+
     # If the requested body size is more than the buffer size, the entire body is
     # written to a temporary file. Default is 8k or 16k depending on the platform.
     client_body_buffer_size 16k;

--- a/config/nginx-config/nginx.conf
+++ b/config/nginx-config/nginx.conf
@@ -90,11 +90,11 @@ http {
         server unix:/var/run/php7.0-fpm.sock;
     }
 
-	include /etc/nginx/upstreams/*.conf;
+    include /etc/nginx/upstreams/*.conf;
 
-	map '' $upstream {
-		default php;
-	}
+    map '' $upstream {
+        default php;
+    }
 
     # If the requested body size is more than the buffer size, the entire body is
     # written to a temporary file. Default is 8k or 16k depending on the platform.

--- a/config/nginx-config/php7.0-upstream.conf
+++ b/config/nginx-config/php7.0-upstream.conf
@@ -1,0 +1,4 @@
+# Upstream to abstract backend connection(s) for PHP.
+upstream php70 {
+	server unix:/var/run/php7.0-fpm.sock;
+}

--- a/config/php-config/php7.0-custom.ini
+++ b/config/php-config/php7.0-custom.ini
@@ -38,7 +38,7 @@ track_errors = Off
 html_errors = 1
 
 ; Log errors to specified file.
-error_log = /srv/log/php_errors.log
+error_log = /srv/log/php7.0_errors.log
 
 ; Maximum size of POST data that PHP will accept.
 post_max_size = 1024M

--- a/config/php-config/php7.0-fpm.conf
+++ b/config/php-config/php7.0-fpm.conf
@@ -22,14 +22,14 @@
 ; Pid file
 ; Note: the default prefix is /var
 ; Default Value: none
-pid = /var/run/php7-fpm.pid
+pid = /var/run/php7.0-fpm.pid
 
 ; Error log file
 ; If it's set to "syslog", log is sent to syslogd instead of being written
 ; in a local file.
 ; Note: the default prefix is /var
 ; Default Value: log/php-fpm.log
-error_log = /var/log/php7-fpm.log
+error_log = /var/log/php7.0-fpm.log
 
 ; syslog_facility is used to specify what type of program is logging the
 ; message. This lets syslogd specify that messages from different facilities

--- a/config/php-config/php7.0-www.conf
+++ b/config/php-config/php7.0-www.conf
@@ -30,7 +30,7 @@ group = www-data
 ;                            specific port;
 ;   '/path/to/unix/socket' - to listen on a unix socket.
 ; Note: This value is mandatory.
-listen = /var/run/php7-fpm.sock
+listen = /var/run/php7.0-fpm.sock
 
 ; Set listen(2) backlog. A value of '-1' means unlimited.
 ; Default Value: 128 (-1 on FreeBSD and OpenBSD)

--- a/config/php-config/xdebug.ini
+++ b/config/php-config/xdebug.ini
@@ -1,3 +1,5 @@
+zend_extension=xdebug.so
+
 [XDebug]
 
 ; xdebug.auto_trace

--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -5,7 +5,7 @@ REPO=$2
 BRANCH=$3
 VM_DIR=$4
 SKIP_PROVISIONING=$5
-UPSTREAM=$6
+NGINX_UPSTREAM=$6
 VVV_PATH_TO_SITE=${VM_DIR}
 VVV_SITE_NAME=${SITE}
 
@@ -57,7 +57,7 @@ if [[ -d ${VM_DIR} ]]; then
     sed "s#{vvv_path_to_folder}#$DIR#" "$SITE_CONFIG_FILE" > "/etc/nginx/custom-sites/${DEST_CONFIG_FILE}"
     sed -i "s#{vvv_path_to_site}#$VM_DIR#" "/etc/nginx/custom-sites/${DEST_CONFIG_FILE}"
     sed -i "s#{vvv_site_name}#$SITE#" "/etc/nginx/custom-sites/${DEST_CONFIG_FILE}"
-    sed -i "s#{upstream}#$UPSTREAM#" "/etc/nginx/custom-sites/${DEST_CONFIG_FILE}"
+    sed -i "s#{upstream}#$NGINX_UPSTREAM#" "/etc/nginx/custom-sites/${DEST_CONFIG_FILE}"
 
     # Resolve relative paths since not supported in Nginx root.
     while grep -sqE '/[^/][^/]*/\.\.' "/etc/nginx/custom-sites/${DEST_CONFIG_FILE}"; do

--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -5,6 +5,7 @@ REPO=$2
 BRANCH=$3
 VM_DIR=$4
 SKIP_PROVISIONING=$5
+UPSTREAM=$6
 VVV_PATH_TO_SITE=${VM_DIR}
 VVV_SITE_NAME=${SITE}
 
@@ -56,6 +57,7 @@ if [[ -d ${VM_DIR} ]]; then
     sed "s#{vvv_path_to_folder}#$DIR#" "$SITE_CONFIG_FILE" > "/etc/nginx/custom-sites/${DEST_CONFIG_FILE}"
     sed -i "s#{vvv_path_to_site}#$VM_DIR#" "/etc/nginx/custom-sites/${DEST_CONFIG_FILE}"
     sed -i "s#{vvv_site_name}#$SITE#" "/etc/nginx/custom-sites/${DEST_CONFIG_FILE}"
+    sed -i "s#{upstream}#$UPSTREAM#" "/etc/nginx/custom-sites/${DEST_CONFIG_FILE}"
 
     # Resolve relative paths since not supported in Nginx root.
     while grep -sqE '/[^/][^/]*/\.\.' "/etc/nginx/custom-sites/${DEST_CONFIG_FILE}"; do

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -51,6 +51,7 @@ apt_package_check_list=(
   php7.0-json
   php7.0-soap
   php7.0-ssh2
+  php7.0-xdebug
   php7.0-xml
   php7.0-zip
 
@@ -304,33 +305,6 @@ tools_install() {
   npm install -g npm
   npm install -g npm-check-updates
 
-  # Xdebug
-  #
-  # The version of Xdebug 2.4.0 that is available for our Ubuntu installation
-  # is not compatible with PHP 7.0. We instead retrieve the source package and
-  # go through the manual installation steps.
-  if [[ -f /usr/lib/php/20151012/xdebug.so ]]; then
-      echo "Xdebug already installed"
-  else
-      echo "Installing Xdebug"
-      # Download and extract Xdebug.
-      curl -L -O --silent https://xdebug.org/files/xdebug-2.4.0.tgz
-      tar -xf xdebug-2.4.0.tgz
-      cd xdebug-2.4.0
-      # Create a build environment for Xdebug based on our PHP configuration.
-      phpize7.0
-      # Complete configuration of the Xdebug build.
-      ./configure -q
-      # Build the Xdebug module for use with PHP.
-      make -s > /dev/null
-      # Install the module.
-      cp modules/xdebug.so /usr/lib/php/20151012/xdebug.so
-      # Clean up.
-      cd ..
-      rm -rf xdebug-2.4.0*
-      echo "Xdebug installed"
-  fi
-
   # ack-grep
   #
   # Install ack-rep directory from the version hosted at beyondgrep.com as the
@@ -446,10 +420,6 @@ phpfpm_setup() {
   cp "/srv/config/php-config/php7.0-custom.ini" "/etc/php/7.0/fpm/conf.d/php-custom.ini"
   cp "/srv/config/php-config/opcache.ini" "/etc/php/7.0/fpm/conf.d/opcache.ini"
   cp "/srv/config/php-config/xdebug.ini" "/etc/php/7.0/mods-available/xdebug.ini"
-
-  # Find the path to Xdebug and prepend it to xdebug.ini
-  XDEBUG_PATH=$( find /usr/lib/php/ -name 'xdebug.so' | head -1 )
-  sed -i "1izend_extension=\"$XDEBUG_PATH\"" "/etc/php/7.0/mods-available/xdebug.ini"
 
   echo " * Copied /srv/config/php-config/php7.0-fpm.conf   to /etc/php/7.0/fpm/php-fpm.conf"
   echo " * Copied /srv/config/php-config/php7.0-www.conf   to /etc/php/7.0/fpm/pool.d/www.conf"

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -38,9 +38,9 @@ apt_package_check_list=(
   php7.0-dev
 
   # Extra PHP modules that we find useful
-  php-imagick
-  php-memcache
   php-pear
+  php7.0-imagick
+  php7.0-memcache
   php7.0-bcmath
   php7.0-curl
   php7.0-gd

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -435,9 +435,9 @@ nginx_setup() {
 
 phpfpm_setup() {
   # Copy php-fpm configuration from local
-  cp "/srv/config/php-config/php7-fpm.conf" "/etc/php/7.0/fpm/php-fpm.conf"
-  cp "/srv/config/php-config/www.conf" "/etc/php/7.0/fpm/pool.d/www.conf"
-  cp "/srv/config/php-config/php-custom.ini" "/etc/php/7.0/fpm/conf.d/php-custom.ini"
+  cp "/srv/config/php-config/php7.0-fpm.conf" "/etc/php/7.0/fpm/php-fpm.conf"
+  cp "/srv/config/php-config/php7.0-www.conf" "/etc/php/7.0/fpm/pool.d/www.conf"
+  cp "/srv/config/php-config/php7.0-custom.ini" "/etc/php/7.0/fpm/conf.d/php-custom.ini"
   cp "/srv/config/php-config/opcache.ini" "/etc/php/7.0/fpm/conf.d/opcache.ini"
   cp "/srv/config/php-config/xdebug.ini" "/etc/php/7.0/mods-available/xdebug.ini"
 
@@ -445,9 +445,9 @@ phpfpm_setup() {
   XDEBUG_PATH=$( find /usr/lib/php/ -name 'xdebug.so' | head -1 )
   sed -i "1izend_extension=\"$XDEBUG_PATH\"" "/etc/php/7.0/mods-available/xdebug.ini"
 
-  echo " * Copied /srv/config/php-config/php7-fpm.conf     to /etc/php/7.0/fpm/php-fpm.conf"
-  echo " * Copied /srv/config/php-config/www.conf          to /etc/php/7.0/fpm/pool.d/www.conf"
-  echo " * Copied /srv/config/php-config/php-custom.ini    to /etc/php/7.0/fpm/conf.d/php-custom.ini"
+  echo " * Copied /srv/config/php-config/php7.0-fpm.conf   to /etc/php/7.0/fpm/php-fpm.conf"
+  echo " * Copied /srv/config/php-config/php7.0-www.conf   to /etc/php/7.0/fpm/pool.d/www.conf"
+  echo " * Copied /srv/config/php-config/php7.0-custom.ini to /etc/php/7.0/fpm/conf.d/php-custom.ini"
   echo " * Copied /srv/config/php-config/opcache.ini       to /etc/php/7.0/fpm/conf.d/opcache.ini"
   echo " * Copied /srv/config/php-config/xdebug.ini        to /etc/php/7.0/mods-available/xdebug.ini"
 

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -318,7 +318,7 @@ tools_install() {
       tar -xf xdebug-2.4.0.tgz
       cd xdebug-2.4.0
       # Create a build environment for Xdebug based on our PHP configuration.
-      phpize
+      phpize7.0
       # Complete configuration of the Xdebug build.
       ./configure -q
       # Build the Xdebug module for use with PHP.

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -423,6 +423,12 @@ nginx_setup() {
   # Copy nginx configuration from local
   cp "/srv/config/nginx-config/nginx.conf" "/etc/nginx/nginx.conf"
   cp "/srv/config/nginx-config/nginx-wp-common.conf" "/etc/nginx/nginx-wp-common.conf"
+
+  if [[ ! -d "/etc/nginx/upstreams" ]]; then
+    mkdir "/etc/nginx/upstreams/"
+  fi
+  cp "/srv/config/nginx-config/php7.0-upstream.conf" "/etc/nginx/upstreams/php70.conf"
+
   if [[ ! -d "/etc/nginx/custom-sites" ]]; then
     mkdir "/etc/nginx/custom-sites/"
   fi


### PR DESCRIPTION
This adds an additional optional variable of `upstream` to vvv-config.yml to allow you to set the nginx upstream. 
It also switches xDebug from source to the PPA as this is compatible with multiole PHP versions.

An example config for testing:
```
---
sites:
  wordpress-default:
    repo: https://github.com/Varying-Vagrant-Vagrants/vvv-wordpress-default.git
    vm_dir: '/srv/www/wordpress-default-provisioner'
    upstream: php71
    hosts:
      - local.wordpress.dev

  wordpress-develop:
    repo: https://github.com/Varying-Vagrant-Vagrants/vvv-wordpress-develop.git
    vm_dir: '/srv/www/wordpress-develop-provisioner'
    upstream: php56
    hosts:
      - src.wordpress-develop.dev
      - build.wordpress-develop.dev

  wordpress-trunk:
    repo: https://github.com/Varying-Vagrant-Vagrants/vvv-wordpress-trunk.git
    vm_dir: /srv/www/wordpress-trunk-provisioner
    hosts:
      - local.wordpress-trunk.dev

utility-repos:
  LoreleiAurora: https://github.com/LoreleiAurora/vvv-utilities.git

utilities:
  core:
    - memcached-admin
    - opcache-status
    - phpmyadmin
    - webgrind
  LoreleiAurora:
    - php56
    - php71
```

Requires Varying-Vagrant-Vagrants/vvv-utilities#3 to stop my custom repo being needed.