### PR TITLE
Change wp-cli to standard installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@
 # Ignore a custom bash_prompt if it exists
 /config/bash_prompt
 
+# Ignore downloaded wp-cli bash completions
+/config/wp-cli/wp-completion.bash
+
 # No need to share our mysql data with each other
 /database/data/*
 

--- a/config/bash_profile
+++ b/config/bash_profile
@@ -36,7 +36,7 @@ export WP_CORE_DIR=/srv/www/wordpress-develop/src/
 eval "$(grunt --completion=bash)"
 
 # add autocomplete for wp-cli
-. /srv/www/wp-cli/utils/wp-completion.bash
+. /srv/config/wp-cli/wp-completion.bash
 
 # PHPCS path
 export PATH="$PATH:/srv/www/phpcs/scripts/"

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -559,19 +559,27 @@ services_restart() {
 
 wp_cli() {
   # WP-CLI Install
-  if [[ ! -d "/srv/www/wp-cli" ]]; then
+  local exists_wpcli
+
+  # Remove old wp-cli symlink, if it exists.
+  if [[ -L "/usr/local/bin/wp" ]]; then
+    echo "\nRemoving old wp-cli"
+    rm -f /usr/local/bin/wp
+  fi
+
+  exists_wpcli="$(which wp)"
+  if [[ "/usr/local/bin/wp" != "${exists_wpcli}" ]]; then
     echo -e "\nDownloading wp-cli, see http://wp-cli.org"
-    git clone "https://github.com/wp-cli/wp-cli.git" "/srv/www/wp-cli"
-    cd /srv/www/wp-cli
-    composer install
+    curl -sO https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar
+    chmod +x wp-cli-nightly.phar
+    sudo mv wp-cli-nightly.phar /usr/local/bin/wp
+
+    # Install bash completions
+    curl -s https://raw.githubusercontent.com/wp-cli/wp-cli/master/utils/wp-completion.bash -o /srv/config/wp-cli/wp-completion.bash
   else
     echo -e "\nUpdating wp-cli..."
-    cd /srv/www/wp-cli
-    git pull --rebase origin master
-    composer install
+    wp --allow-root cli update --nightly --yes
   fi
-  # Link `wp` to the `/usr/local/bin` directory
-  ln -sf "/srv/www/wp-cli/bin/wp" "/usr/local/bin/wp"
 }
 
 php_codesniff() {


### PR DESCRIPTION
Previously, VVV was cloning the wp-cli repo and installing
composer dependencies. This switches to the standard wp-cli
installation method which will make updating wp-cli easier.

`wp cli update` will run on re-provision.

Users can run `wp cli update` at any time
or `wp cli update --nightly` to update to the latest nightly.

Fixes #983.