### PR TITLE
Custom keys for custom provisioning in vvv-init.sh

### DIFF
--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -15,7 +15,7 @@ noroot() {
 
 # Takes 2 values, a key to fetch a value for, and an optional default value
 # e.g. echo `customvalue 'key' 'defaultvalue'`
-customvalue() {
+get_config_key() {
   local config=/vagrant/vvv-config.yml
   if [[ -f /vagrant/vvv-custom.yml ]]; then
     config=/vagrant/vvv-custom.yml

--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -14,8 +14,8 @@ noroot() {
 }
 
 # Takes 2 values, a key to fetch a value for, and an optional default value
-# e.g. echo `customvalue 'key' 'defaultvalue'`
-get_config_key() {
+# e.g. echo `get_config_value 'key' 'defaultvalue'`
+get_config_value() {
   local config=/vagrant/vvv-config.yml
   if [[ -f /vagrant/vvv-custom.yml ]]; then
     config=/vagrant/vvv-custom.yml

--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -13,6 +13,17 @@ noroot() {
   sudo -EH -u "vagrant" "$@";
 }
 
+# Takes 2 values, a key to fetch a value for, and an optional default value
+# e.g. echo `customvalue 'key' 'defaultvalue'`
+customvalue() {
+  local config=/vagrant/vvv-config.yml
+  if [[ -f /vagrant/vvv-custom.yml ]]; then
+    config=/vagrant/vvv-custom.yml
+  fi
+  local value=`cat ${config} | shyaml get-value sites.${SITE}.custom.${1} 2> /dev/null`
+  echo ${value:-$2}
+}
+
 if [[ true == $SKIP_PROVISIONING ]]; then
     REPO=false
 fi

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -76,6 +76,7 @@ apt_package_check_list=(
   vim
   colordiff
   postfix
+  python-pip
 
   # ntp service to keep clock current
   ntp
@@ -369,6 +370,12 @@ tools_install() {
   # config and actual path.
   echo "Adding graphviz symlink for Webgrind..."
   ln -sf "/usr/bin/dot" "/usr/local/bin/dot"
+
+  # Shyaml
+  #
+  # Used for passing custom parameters to the bash provisioning scripts
+  echo "Installing Shyaml for bash provisioning.."
+  sudo pip install shyaml
 }
 
 nginx_setup() {


### PR DESCRIPTION
The new `vvv-config.yml`/`vvv-custom.yml` allows you to specify a site or sites, with various keys. However, a `vvv-init.sh` may want to specify custom keys that are too specific to apply to all VVV sites.

This PR installs `python-pip` and the `shyaml` dependency, and adds a bash function named `customvalue` for retrieving those keys. When the `custom` section or the requested key are not defined or found, the function will return nothing

E.g. in `vvv-init.sh`

```
colour=`customvalue 'colour' 'pink'`
echo "Hello there :) This site is a ${colour} site"
```

Which when ran will print `Hello there :) This site is a pink site`, and can be changed as follows in `vvv-custom.yml`:

```
  redsite:
    custom:
      colour: red
```

Resulting in `Hello there :) This site is a red site`

Nested keys can be accessed using dot syntax, e.g.:

```
  redsite:
    custom:
      colour:
        primary: red
        secondary: blue
```

```
primarycolour=`customvalue 'colour.primary' 'pink'`
echo "Hello there :) This site is a ${primarycolour} site"
```