### PR TITLE
[PR] Include `$is_args` in nginx `try_files`

### DIFF
--- a/config/nginx-config/nginx-wp-common.conf
+++ b/config/nginx-config/nginx-wp-common.conf
@@ -9,7 +9,7 @@
 # See local-nginx-example.conf-sample for a full example
 location / {
     index index.php index.html;
-    try_files $uri $uri/ /index.php?$args;
+    try_files $uri $uri/ /index.php$is_args$args;
 }
 
 # Specify a charset

--- a/config/nginx-config/sites/default.conf
+++ b/config/nginx-config/sites/default.conf
@@ -13,7 +13,7 @@ server {
 
     location / {
         index index.php;
-        try_files $uri $uri/ /index.php?$args;
+        try_files $uri $uri/ /index.php$is_args$args;
     }
 
     gzip off;


### PR DESCRIPTION
Before `$args` are passed to the URL, `$is_args` will add a `?` if
args are detected and nothing if args are not.

Not having this in place can cause some strange issues with ignored
query params. See
http://v2.wp-api.org/guide/problems/#query-parameters-are-ignored

Fixes #1062.