### PR TITLE
[PR] Add the php-memcached package to default provisioning

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -39,6 +39,7 @@ apt_package_check_list=(
 
   # Extra PHP modules that we find useful
   php-pear
+  php-memcached
   php7.0-imagick
   php7.0-memcache
   php7.0-bcmath


### PR DESCRIPTION
This appears to be in better shape for PHP7 than php7.0-memcache
and provides php5.5-memcached, php5.6-memcached, php7.0-memcached,
and php7.1-memcached.

Fixes #1067.