### PR TITLE
[PR] Set colordiff as the default svn diff cmd-tool

### DIFF
--- a/config/subversion-config
+++ b/config/subversion-config
@@ -1,0 +1,4 @@
+# This file is copied to /home/vagrant/.subversion during provisioning.
+
+[helpers]
+diff-cmd = colordiff

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -156,6 +156,7 @@ profile_setup() {
   fi
 
   cp "/srv/config/subversion-servers" "/home/vagrant/.subversion/servers"
+  cp "/srv/config/subversion-config" "/home/vagrant/.subversion/config"
 
   if [[ ! -d "/home/vagrant/bin" ]]; then
     mkdir "/home/vagrant/bin"
@@ -167,6 +168,7 @@ profile_setup() {
   echo " * Copied /srv/config/bash_aliases                      to /home/vagrant/.bash_aliases"
   echo " * Copied /srv/config/vimrc                             to /home/vagrant/.vimrc"
   echo " * Copied /srv/config/subversion-servers                to /home/vagrant/.subversion/servers"
+  echo " * Copied /srv/config/subversion-config                 to /home/vagrant/.subversion/config"
   echo " * rsync'd /srv/config/homebin                          to /home/vagrant/bin"
 
   # If a bash_prompt file exists in the VVV config/ directory, copy to the VM.


### PR DESCRIPTION
This adds a `config` file for the `vagrant` user and defines
`colordiff` as the diff command to use when running `svn diff`
from within the VM.

Fixes #908.