### PR TITLE
Update WP_{TESTS|CORE}_DIR to match changes in #1068

### DIFF
--- a/config/bash_profile
+++ b/config/bash_profile
@@ -28,9 +28,9 @@ fi
 
 # Set the WP_TESTS_DIR path directory so that we can use phpunit inside
 # plugins almost immediately.
-export WP_TESTS_DIR=/srv/www/wordpress-develop/tests/phpunit/
+export WP_TESTS_DIR=/srv/www/wordpress-develop/public_html/tests/phpunit/
 # Set the WP_CORE_DIR path so phpunit tests are run against WP trunk
-export WP_CORE_DIR=/srv/www/wordpress-develop/src/
+export WP_CORE_DIR=/srv/www/wordpress-develop/public_html/src/
 
 # add autocomplete for grunt
 eval "$(grunt --completion=bash)"


### PR DESCRIPTION
After the modifications associated with #1068, PHPUnit tests files and WordPress source code in wordpress-develop site are no longer in `/srv/www/wordpress-develop/tests/phpunit/` and `/srv/www/wordpress-develop/src/`. They were moved to `/srv/www/wordpress-develop/public_html/tests/phpunit/` and `/srv/www/wordpress-develop/public_html/src`, respectively.

The modifications in this PR simply update the `config/bash_profile` file with the new paths.