### PR TITLE
Use direct package names rather than alias names

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -39,9 +39,11 @@ apt_package_check_list=(
 
   # Extra PHP modules that we find useful
   php-pear
-  php7.0-imagick
-  php7.0-memcache
-  php7.0-memcached
+  php-imagick
+  php-memcache
+  php-memcached
+  php-ssh2
+  php-xdebug
   php7.0-bcmath
   php7.0-curl
   php7.0-gd
@@ -51,8 +53,6 @@ apt_package_check_list=(
   php7.0-imap
   php7.0-json
   php7.0-soap
-  php7.0-ssh2
-  php7.0-xdebug
   php7.0-xml
   php7.0-zip
 


### PR DESCRIPTION
The command we use to check if a package is installed, `dpkg -s`, does not appear to properly follow alias names. After initial provision, `dpkg` fails to see that several packages are already installed and then falsely flags them to be installed.

Output during a provisioning looked like this:

```
==> default:  * php7.0-dev                                          7.0.16-4+deb.sury.org~trusty+1
==> default:  * php-pear                                            1:1.10.1+submodules+notgz-8+donate.sury.org~trusty+2
==> default:  * php7.0-imagick [not installed]
==> default:  * php7.0-memcache [not installed]
==> default:  * php7.0-memcached [not installed]
==> default:  * php7.0-bcmath                                       7.0.16-4+deb.sury.org~trusty+1
==> default:  * php7.0-curl                                         7.0.16-4+deb.sury.org~trusty+1
```

With this change, all packages should be picked up properly:

```
==> default:  * php-pear                                            1:1.10.1+submodules+notgz-8+donate.sury.org~trusty+2
==> default:  * php-imagick                                         3.4.3~rc2-2+deb.sury.org~trusty+1
==> default:  * php-memcache                                        3.0.9~20160311.4991c2f-6+deb.sury.org~trusty+1
==> default:  * php-memcached                                       3.0.3+2.2.0-1+deb.sury.org~trusty+1
==> default:  * php-ssh2                                            1.0+0.13-2+deb.sury.org~trusty+1
==> default:  * php-xdebug                                          2.5.0-1+deb.sury.org~trusty+1
==> default:  * php7.0-bcmath                                       7.0.16-4+deb.sury.org~trusty+1
==> default:  * php7.0-curl                                         7.0.16-4+deb.sury.org~trusty+1
```

I also reordered a couple of the packages as they lost the `7.0` portion.