### PR TITLE
Install MariaDB 10.1 in default provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ VVV is ideal for developing themes and plugins as well as for [contributing to W
 VVV is built on a Ubuntu 14.04 LTS (Trusty) base VM and provisions the server with current versions of several software packages, including:
 
 1. [nginx](http://nginx.org/) ([mainline](http://nginx.com/blog/nginx-1-6-1-7-released/) version)
-1. [MariaDB](https://mariadb.org/) 5.5.x (drop-in replacement for MySQL)
+1. [MariaDB](https://mariadb.org/) 10.1.x (drop-in replacement for MySQL)
 1. [php-fpm](http://php-fpm.org/) 7.0.x
 1. [WP-CLI](http://wp-cli.org/) (master branch)
 1. [memcached](http://memcached.org/)

--- a/config/apt-source-append.list
+++ b/config/apt-source-append.list
@@ -9,6 +9,11 @@ deb-src http://nginx.org/packages/mainline/ubuntu/ trusty nginx
 deb http://ppa.launchpad.net/ondrej/php/ubuntu trusty main
 deb-src http://ppa.launchpad.net/ondrej/php/ubuntu trusty main
 
+# MariaDB 10.1 repository list as of 2017-03-04 21:42 UTC
+# http://downloads.mariadb.org/mariadb/repositories/
+deb [arch=amd64,i386] http://mirrors.accretive-networks.net/mariadb/repo/10.1/ubuntu trusty main
+deb-src http://mirrors.accretive-networks.net/mariadb/repo/10.1/ubuntu trusty main
+
 # Provides Node.js
 deb https://deb.nodesource.com/node_6.x trusty main
 deb-src https://deb.nodesource.com/node_6.x trusty main

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -227,8 +227,8 @@ package_install() {
   # Use debconf-set-selections to specify the default password for the root MariaDB
   # account. This runs on every provision, even if MariaDB has been installed. If
   # MariaDB is already installed, it will not affect anything.
-  echo mariadb-server-5.5 mysql-server/root_password password "root" | debconf-set-selections
-  echo mariadb-server-5.5 mysql-server/root_password_again password "root" | debconf-set-selections
+  echo mariadb-server-10.1 mysql-server/root_password password "root" | debconf-set-selections
+  echo mariadb-server-10.1 mysql-server/root_password_again password "root" | debconf-set-selections
 
   # Postfix
   #
@@ -264,8 +264,13 @@ package_install() {
     wget --quiet "http://nginx.org/keys/nginx_signing.key" -O- | apt-key add -
 
     # Apply the PHP signing key
+    echo "Applying the PHP signing key..."
     apt-key adv --quiet --keyserver "hkp://keyserver.ubuntu.com:80" --recv-key E5267A6C 2>&1 | grep "gpg:"
     apt-key export E5267A6C | apt-key add -
+
+    # Apply the MariaDB signing key
+    echo "Applying the MariaDB signing key..."
+    apt-key adv --quiet --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xcbcb082a1bb943db
 
     # Update all of the package references before installing anything
     echo "Running apt-get update..."


### PR DESCRIPTION
This makes the upgrade from MariaDB 5.5 to 10.1, the current stable release.

I first looked at using the [ondrej repo](https://launchpad.net/~ondrej/+archive/ubuntu/mariadb-10.0), mentioned by @LoreleiAurora in #876, but that repo has been deprecated.

Instead, the [official MariaDB repositories](https://downloads.mariadb.org/mariadb/repositories/) provide a nice guide to finding the proper packages for Ubuntu 14.04 and seem to be working fine after a fresh provision.

The upgrade from MariaDB 5.5 to 10.1 on an existing VM involves a few steps. We should get this into 2.0.0 so that fresh provisions already have the latest.

See #949.
Fixes #876.