### PR TITLE
Remove attempt to enforce ipv4 in postfix

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -239,9 +239,6 @@ package_install() {
   echo postfix postfix/main_mailer_type select Internet Site | debconf-set-selections
   echo postfix postfix/mailname string vvv | debconf-set-selections
 
-  # Disable ipv6 as some ISPs/mail servers have problems with it
-  echo "inet_protocols = ipv4" >> "/etc/postfix/main.cf"
-
   # Provide our custom apt sources before running `apt-get update`
   ln -sf /srv/config/apt-source-append.list /etc/apt/sources.list.d/vvv-sources.list
   echo "Linked custom apt sources"


### PR DESCRIPTION
In #420, we added a line to provisioning that attempts to set "ipv4" as the only allowed protocol for postfix due to issues in how network connections managed the ipv6 connection.

Because the config file does not yet exist during initial provisioning, that caused an error message saying as much. See #628.

It turns out that this line hasn't been doing anything. :)

I first went down the path of using `debconf-set-selections` to set the protocol value. This works, but then disables ipv6 entirely as a valid protocol. Since we haven't heard of any other issues
besides the original in #420, I think it's safe to not make any change here and then watch for any problems.

I have a feeling that postfix has gotten better about this. In the documentation for the `inet_protocols` config, it's mentioned that "versions before 2.8 attempt to connect via IPv6 before attempting to use IPv4."

http://www.postfix.org/postconf.5.html#inet_protocols

Now that we're past 2.8, it's entirely possible that the protocol detection has gotten better. If we do run into an issue, there is a newer `smtp_address_preference` config that allows us to specify
which protocol should be attempted first.

http://www.postfix.org/postconf.5.html#smtp_address_preference

In that case, we may need to create our own custom config file as it's not entirely obvious that `debconf-set-selections` will work for this value.

See #420.
Fixes #628.