### PR TITLE
Allow CPU & Memory to be configured.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -66,6 +66,16 @@ if ! vvv_config['utilities'].kind_of? Hash then
   vvv_config['utilities'] = Hash.new
 end
 
+if ! vvv_config['vm_config'].kind_of? Hash then
+  vvv_config['vm_config'] = Hash.new
+end
+
+defaults = Hash.new
+defaults['memory'] = 1024
+defaults['cores'] = 1
+
+vvv_config['vm_config'] = defaults.merge(vvv_config['vm_config'])
+
 vvv_config['hosts'] = vvv_config['hosts'].uniq
 
 Vagrant.configure("2") do |config|
@@ -76,8 +86,8 @@ Vagrant.configure("2") do |config|
 
   # Configurations from 1.0.x can be placed in Vagrant 1.1.x specs like the following.
   config.vm.provider :virtualbox do |v|
-    v.customize ["modifyvm", :id, "--memory", 1024]
-    v.customize ["modifyvm", :id, "--cpus", 1]
+    v.customize ["modifyvm", :id, "--memory", vvv_config['vm_config']['memory']]
+    v.customize ["modifyvm", :id, "--cpus", vvv_config['vm_config']['cores']]
     v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
     v.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
 
@@ -90,20 +100,20 @@ Vagrant.configure("2") do |config|
   config.vm.provider :parallels do |v|
     v.update_guest_tools = true
     v.customize ["set", :id, "--longer-battery-life", "off"]
-    v.memory = 1024
-    v.cpus = 1
+    v.memory = vvv_config['vm_config']['memory']
+    v.cpus = vvv_config['vm_config']['cores']
   end
 
   # Configuration options for the VMware Fusion provider.
   config.vm.provider :vmware_fusion do |v|
-    v.vmx["memsize"] = "1024"
-    v.vmx["numvcpus"] = "1"
+    v.vmx["memsize"] = vvv_config['vm_config']['memory']
+    v.vmx["numvcpus"] = vvv_config['vm_config']['cores']
   end
 
   # Configuration options for Hyper-V provider.
   config.vm.provider :hyperv do |v, override|
-    v.memory = 1024
-    v.cpus = 1
+    v.memory = vvv_config['vm_config']['memory']
+    v.cpus = vvv_config['vm_config']['cores']
   end
 
   # SSH Agent Forwarding


### PR DESCRIPTION
New vvv-config.yml keys.
```
vm_config:
  memory: 1024
  cores: 1
```
Fixes #1120 