### PR TITLE
Source Code Pro License

### DIFF
--- a/www/default/index.php
+++ b/www/default/index.php
@@ -76,6 +76,10 @@ if ( file_exists( 'dashboard-custom.php' ) ) {
 	<li><a href="http://build.wordpress-develop.dev/">http://build.wordpress-develop.dev</a> for a Grunt build of those development files (www/wordpress-develop/build)</li>
 </ul>
 <style>
+/**
+ * Source Code Pro License and Copyright:
+ * https://github.com/adobe-fonts/source-code-pro/blob/master/LICENSE.txt
+ */
 /* latin-ext */
 @font-face {
   font-family: 'Source Code Pro';


### PR DESCRIPTION
The fonts license require we mention it when using or bundling it. I've added a CSS comment before it's inclusion directing users to the license

Related to https://github.com/Varying-Vagrant-Vagrants/VVV/pull/1122