### PR TITLE
Remove symlink in docs to CONTRIBUTING.md

### DIFF
--- a/docs/en-US/contributing.md
+++ b/docs/en-US/contributing.md
@@ -1,1 +1,0 @@
-../../.github/CONTRIBUTING.md


### PR DESCRIPTION
This is making the build more confusing (likely my fault) in Travis,
so I'm going to remove it for now and work around it in another way.