### PR TITLE
[PR] Add Jekyll template config to documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: Contributing to VVV
+permalink: /docs/en-US/contributing
+---
+
 # Contributing to VVV
 
 Contributions to the VVV project are more than welcome.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: Changelog
+permalink: /docs/en-US/changelog
+---
+
 # Varying Vagrant Vagrants Changelog
 
 ## 1.4.1 (January 16, 2017)

--- a/docs/en-US/adding-a-new-site/changing-php-version.md
+++ b/docs/en-US/adding-a-new-site/changing-php-version.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: Changing PHP Version
+permalink: /docs/en-US/adding-a-new-site/changing-php-version
+---
+
 # Changing PHP Version
 
 You can set the PHP version in `vvv-custom.yml` when defining a site. To do this, use the `nginx_upstream` option to specify the PHP version. VVV also needs to be told to install that version of PHP using the `utilities` section.

--- a/docs/en-US/adding-a-new-site/custom-domains-hosts.md
+++ b/docs/en-US/adding-a-new-site/custom-domains-hosts.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: Custom Domains and Hosts
+permalink: /docs/en-US/adding-a-new-site/custom-domains-hosts
+---
+
 # Custom Domains and Hosts
 
 There are 3 ways to define hosts
@@ -34,4 +40,3 @@ Here's an example that adds 2 domains:
 example.com
 example.net
 ```
-

--- a/docs/en-US/adding-a-new-site/custom-paths-and-folders.md
+++ b/docs/en-US/adding-a-new-site/custom-paths-and-folders.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: Custom Paths and Folders
+permalink: /docs/en-US/adding-a-new-site/custom-paths-and-folders
+---
+
 # Custom Paths and Folders
 
 A site in a non-standard folder can still be used via the `vm_dir` and `local_dir` keys. `local_dir` tells VVV where the site is located on the host machine, and `vm_dir` tells VVV where the site is located inside the Virtual machine.

--- a/docs/en-US/adding-a-new-site/index.md
+++ b/docs/en-US/adding-a-new-site/index.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: Adding a New Site
+permalink: /docs/en-US/adding-a-new-site
+---
+
 # Adding a New Site
 
 Adding a new site is as simple as adding it under the sites section of `vvv-custom.yml`.
@@ -106,4 +112,3 @@ There are several ways to do this:
  - Connect directly to the MySQL server using the default credentials
  - Restore a backup via a plugin
  - Automatically import an sql file in vvv-init.sh if the database is empty using the `mysql` command
- 

--- a/docs/en-US/adding-a-new-site/migrating-vvv1.md
+++ b/docs/en-US/adding-a-new-site/migrating-vvv1.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: Migrating from VVV 1.4.x
+permalink: /docs/en-US/adding-a-new-site/migrating-from-vvv-1-4-x
+---
+
 # Migrating from VVV 1
 
 VVV 1 sites still work, but they require an additional step.

--- a/docs/en-US/adding-a-new-site/nginx-configs.md
+++ b/docs/en-US/adding-a-new-site/nginx-configs.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: Nginx Configuration
+permalink: /docs/en-US/adding-a-new-site/nginx-configuration
+---
+
 # Nginx configs
 
 @TODO: Higher level notes and introduction to `vvv-nginx.conf`

--- a/docs/en-US/adding-a-new-site/setup-script.md
+++ b/docs/en-US/adding-a-new-site/setup-script.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: Setup Script
+permalink: /docs/en-US/adding-a-new-site/setup-script
+---
+
 # Setup script
 
 `vvv-init.sh` is ran when VVV sets up the site, and gives you an opportunity to execute shell commands, including WP CLI commands. This file is optional, but when combined with a git repository this becomes very powerful.

--- a/docs/en-US/basic-usage.md
+++ b/docs/en-US/basic-usage.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: Basic Usage
+permalink: /docs/en-US/references/basic-usage
+---
+
 # Basic Usage
 
 ## Using a GUI

--- a/docs/en-US/built-in-wp-installs.md
+++ b/docs/en-US/built-in-wp-installs.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: Built in WordPress installs
+permalink: /docs/en-US/built-in-wordpress-installs
+---
+
 # Built in WordPress installs
 
 #### VVV as a MAMP/XAMPP Replacement

--- a/docs/en-US/default-credentials.md
+++ b/docs/en-US/default-credentials.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: Default Credentials
+permalink: /docs/en-US/default-credentials
+---
+
 # Default Credentials
 
 All database usernames and passwords for WordPress installations included by default are:

--- a/docs/en-US/governance.md
+++ b/docs/en-US/governance.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: Governance
+permalink: /docs/en-US/governance
+---
+
 # Governance
 
 ## Overview

--- a/docs/en-US/history.md
+++ b/docs/en-US/history.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: History
+permalink: /docs/en-US/history
+---
+
 # History
 
 VVV is a [10up](http://10up.com) creation and [transitioned](http://10up.com/blog/varying-vagrant-vagrants-future/) to a community organization in 2014.

--- a/docs/en-US/index.md
+++ b/docs/en-US/index.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: VVV Documentation
+permalink: /docs/en-US/
+---
+
 # Varying Vagrant Vagrants
 
 ### Varying Vagrant Vagrants Objectives
@@ -46,4 +52,3 @@ The dashboard provided by VVV allows for easy replacement by looking for a `www/
 ## [Copyright / License](#license)
 
 VVV is copyright (c), the contributors of the VVV project under the [MIT License](LICENSE).
-

--- a/docs/en-US/installation/index.md
+++ b/docs/en-US/installation/index.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: Installation
+permalink: /docs/en-US/installation/
+---
+
 # Installation
 
 1. Start with any local operating system such as Mac OS X, Linux, or Windows.

--- a/docs/en-US/installation/software-requirements.md
+++ b/docs/en-US/installation/software-requirements.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: Software Requirements
+permalink: /docs/en-US/installation/software-requirements
+---
+
 # Software Requirements
 
 VVV requires recent versions of both Vagrant and VirtualBox to be installed.

--- a/docs/en-US/troubleshooting.md
+++ b/docs/en-US/troubleshooting.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: Troubleshooting
+permalink: /docs/en-US/troubleshooting
+---
+
 # Troubleshooting
 
 Need help?

--- a/docs/en-US/vm_config.md
+++ b/docs/en-US/vm_config.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: vm_config
+permalink: /docs/en-US/vm-config
+---
+
 # vm_config
 
 This is an optional section of the VVV configuration file that allows setting virtual machine parameters.

--- a/docs/en-US/vvv-config.yml.md
+++ b/docs/en-US/vvv-config.yml.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: vvv-config.yml
+permalink: /docs/en-US/vvv-config
+---
+
 # vvv-config.yml
 
 `vvv-config.yml` is the default config file that VVV uses to set itself up. Copy this file to `vvv-custom.yml` to make changes and add your own site.

--- a/docs/en-US/what-is-vvv.md
+++ b/docs/en-US/what-is-vvv.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: What is VVV?
+permalink: /docs/en-US/what-is-vvv
+---
+
 # What is VVV?
 
 Varying Vagrant Vagrants is an open source [Vagrant](https://www.vagrantup.com) configuration focused on [WordPress](https://wordpress.org) development. VVV is [MIT Licensed](https://github.com/varying-vagrant-vagrants/vvv/blob/master/LICENSE).


### PR DESCRIPTION
We'll be using Jekyll in the near future, along with the docs repo at https://github.com/Varying-Vagrant-Vagrants/varyingvagrantvagrants.org.

This change makes it easier to manage permalinks, page titles, and templates.