### PR TITLE
Use absolute vm_dir paths in custom-paths-and-folders.md

### DIFF
--- a/docs/en-US/adding-a-new-site/custom-paths-and-folders.md
+++ b/docs/en-US/adding-a-new-site/custom-paths-and-folders.md
@@ -10,19 +10,19 @@ For example, if we put our test sites in a subfolder, we can specify each site l
 
 ```YAML
 test-site-1:
-  vm_dir: www/test-sites/test-site-1
+  vm_dir: /srv/www/test-sites/test-site-1
   local_dir: www/test-sites/test-site-1
   hosts:
     - testsite1.com
 
 test-site-2:
-  vm_dir: www/test-sites/test-site-2
+  vm_dir: /srv/www/test-sites/test-site-2
   local_dir: www/test-sites/test-site-2
   hosts:
     - testsite2.com
 ```
 
-In the above example, the `vm_dir` and `local_dir` folders are relative paths that match, however, this doesn't have to be the case.
+In the above example, the `vm_dir` and `local_dir` point to the same folder (`vm_dir` needs to be an absolute path), however, this doesn’t have to be the case.
 
 In this example, VVV is told to use a site stored outside of the main VVV folder, and mapped to an absolute path in the virtual machine:
 


### PR DESCRIPTION
I tried to use a relative path for `vm_dir` but get the following error:

```
vm:
* The shared folder guest path must be absolute: www/patternlab/theme/public
```

So there should be absolute paths in the docs :)