### PR TITLE
Fix link to custom paths and folders docs

### DIFF
--- a/docs/en-US/migrating-vvv1.md
+++ b/docs/en-US/migrating-vvv1.md
@@ -64,7 +64,7 @@ Once these directories are deleted, run `vagrant provision` or `vagrant provisio
 
 ## Custom sites in non-standard folders
 
-Some sites are in nested or non-standard folder structures. See the [custom paths and folders](custom-paths-and-folders.md) documentation for how to configure these sites.
+Some sites are in nested or non-standard folder structures. See the [custom paths and folders](adding-a-new-site/custom-paths-and-folders.md) documentation for how to configure these sites.
 
 ## Why is this necessary?
 


### PR DESCRIPTION
The link in the migration page was incorrect.  See https://varyingvagrantvagrants.org/docs/en-US/migrate-vvv-1/. The link should point to https://varyingvagrantvagrants.org/docs/en-US/adding-a-new-site/custom-paths-and-folders/, but points to https://varyingvagrantvagrants.org/docs/en-US/migrate-vvv-1/custom-paths-and-folders.md instead.