### PR TITLE
Correct Hyper-V Box Template

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -164,7 +164,7 @@ Vagrant.configure("2") do |config|
 
   # Hyper-V uses a different base box.
   config.vm.provider :hyperv do |v, override|
-    override.vm.box = "ericmann/trusty64"
+    override.vm.box = "withinboredom/Trusty64"
   end
 
   config.vm.hostname = "vvv"


### PR DESCRIPTION
The previous trusty64 box is no longer available.  Replaced with withinboredom/Trusty64