### PR TITLE
Speed up checking for `vvv-hosts` files

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,7 +41,7 @@ end
 
 vvv_config['hosts'] += ['vvv.dev']
 
-host_paths = Dir[File.join(vagrant_dir, 'www', '*', 'vvv-hosts'), File.join(vagrant_dir, 'www', '*', 'provision', 'vvv-hosts')]
+host_paths = Dir[File.join(vagrant_dir, 'www', '*', 'vvv-hosts'), File.join(vagrant_dir, 'www', '*', '*', 'vvv-hosts'), File.join(vagrant_dir, 'www', '*', '*', '*', 'vvv-hosts'), File.join(vagrant_dir, 'www', '*', '*', '*', '*', 'vvv-hosts')]
 
 vvv_config['hosts'] += host_paths.map do |path|
   lines = File.readlines(path).map(&:chomp)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -64,8 +64,7 @@ vvv_config['sites'].each do |site, args|
 
   vvv_config['sites'][site] = defaults.merge(args)
 
-  site_local_dir = vvv_config['sites'][site]['local_dir']
-  site_host_paths = Dir[File.join(site_local_dir, '*', 'vvv-hosts'), File.join(site_local_dir, '*', '*', 'vvv-hosts'), File.join(site_local_dir, '*', '*', '*', 'vvv-hosts'), File.join(site_local_dir, '*', '*', '*', '*', 'vvv-hosts')]
+  site_host_paths = Dir.glob(Array.new(4) {|i| vvv_config['sites'][site]['local_dir'] + '/*'*(i+1) + '/vvv-hosts'})
 
   vvv_config['sites'][site]['hosts'] += site_host_paths.map do |path|
     lines = File.readlines(path).map(&:chomp)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,13 +41,6 @@ end
 
 vvv_config['hosts'] += ['vvv.dev']
 
-host_paths = Dir[File.join(vagrant_dir, 'www', '*', 'vvv-hosts'), File.join(vagrant_dir, 'www', '*', '*', 'vvv-hosts'), File.join(vagrant_dir, 'www', '*', '*', '*', 'vvv-hosts'), File.join(vagrant_dir, 'www', '*', '*', '*', '*', 'vvv-hosts')]
-
-vvv_config['hosts'] += host_paths.map do |path|
-  lines = File.readlines(path).map(&:chomp)
-  lines.grep(/\A[^#]/)
-end.flatten
-
 vvv_config['sites'].each do |site, args|
   if args.kind_of? String then
       repo = args
@@ -70,6 +63,14 @@ vvv_config['sites'].each do |site, args|
   defaults['hosts'] = Array.new
 
   vvv_config['sites'][site] = defaults.merge(args)
+
+  site_local_dir = vvv_config['sites'][site]['local_dir']
+  site_host_paths = Dir[File.join(site_local_dir, '*', 'vvv-hosts'), File.join(site_local_dir, '*', '*', 'vvv-hosts'), File.join(site_local_dir, '*', '*', '*', 'vvv-hosts'), File.join(site_local_dir, '*', '*', '*', '*', 'vvv-hosts')]
+
+  vvv_config['sites'][site]['hosts'] += site_host_paths.map do |path|
+    lines = File.readlines(path).map(&:chomp)
+    lines.grep(/\A[^#]/)
+  end.flatten
 
   vvv_config['hosts'] += vvv_config['sites'][site]['hosts']
   vvv_config['sites'][site].delete('hosts')

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,7 +41,7 @@ end
 
 vvv_config['hosts'] += ['vvv.dev']
 
-host_paths = Dir[File.join(vagrant_dir, 'www', '**', 'vvv-hosts')]
+host_paths = Dir[File.join(vagrant_dir, 'www', '*', 'vvv-hosts'), File.join(vagrant_dir, 'www', '*', 'provision', 'vvv-hosts')]
 
 vvv_config['hosts'] += host_paths.map do |path|
   lines = File.readlines(path).map(&:chomp)


### PR DESCRIPTION
The existing recursive blob causes massive slowdown of everything (provision, ssh etc) once I've got a few projects setup, especially if they have numerous directories.

This change limits the lookups to only look at the primary directory and a `provision` subfolder rather than unlimited depth. This matches what is documented, though other code such as provision-site.sh still looks [4 levels deep](https://github.com/Varying-Vagrant-Vagrants/VVV/blob/develop/provision/provision-site.sh#L93).

On my setup doing `vagrant ssh` returns in seconds rather than potentially minutes. Should be useful in situations such as https://jjj.blog/2016/05/slow-vagrant/

Related: #595