### PR TITLE
Fix wrong path for phpcs and phpcbf executables.

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -610,8 +610,8 @@ php_codesniff() {
   fi
 
   # Link `phpcbf` and `phpcs` to the `/usr/local/bin` directory
-  ln -sf "/srv/www/phpcs/scripts/phpcbf" "/usr/local/bin/phpcbf"
-  ln -sf "/srv/www/phpcs/scripts/phpcs" "/usr/local/bin/phpcs"
+  ln -sf "/srv/www/phpcs/bin/phpcbf" "/usr/local/bin/phpcbf"
+  ln -sf "/srv/www/phpcs/bin/phpcs" "/usr/local/bin/phpcs"
 
   # Sniffs WordPress Coding Standards
   if [[ ! -d "/srv/www/phpcs/CodeSniffer/Standards/WordPress" ]]; then


### PR DESCRIPTION
Fix for issue #1199 