### PR TITLE
Force composer to use the scripts folder not the bin folder

### DIFF
--- a/provision/phpcs/composer.json
+++ b/provision/phpcs/composer.json
@@ -11,5 +11,8 @@
             "/srv/www/phpcs/": ["squizlabs/php_codesniffer"],
             "/srv/www/phpcs/CodeSniffer/Standards/WordPress/": ["wp-coding-standards/wpcs"]
         }
+    },
+    "config": {
+        "bin-dir": "scripts"
     }
 }


### PR DESCRIPTION
Tells composer to use the scripts folder for PHPCS, this ensures that new machines have the correct path, and old machines continue to work