### PR TITLE
rvm (and hence mailcatcher) installation broken (upstream bug)

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -515,7 +515,7 @@ mailcatcher_setup() {
     gpg -q --no-tty --batch --keyserver "hkp://keyserver.ubuntu.com:80" --recv-keys BF04FF17
 
     printf " * RVM [not installed]\n Installing from source"
-    curl --silent -L "https://get.rvm.io" | sudo bash -s stable --ruby
+    curl --silent -L "https://raw.githubusercontent.com/rvm/rvm/stable/binscripts/rvm-installer" | sudo bash -s stable --ruby
     source "/usr/local/rvm/scripts/rvm"
   fi
 


### PR DESCRIPTION
## Expected Behavior
`vagrant up` installs rvm with a current ruby and then installs mailcatcher

## Current Behavior
Due to an [upstream bug in rvm](https://github.com/rvm/rvm/issues/4068) (or better the installer) the installation of rvm somewhat fails, skipping the ruby installation, which then leads to mailcatcher failing to install with symptoms similar to #985

## Possible Solution

[This line](https://github.com/Varying-Vagrant-Vagrants/VVV/blob/ed7bee10d29b989d05c7ce8203af1dd8e42f4cc1/provision/provision.sh#L518)

    curl --silent -L "https://get.rvm.io" | sudo bash -s stable --ruby

could be replaced by

    curl --silent -L "https://raw.githubusercontent.com/rvm/rvm/stable/binscripts/rvm-installer" | sudo bash -s stable --ruby

The reasoning for this is that `https://get.rvm.io` points to the `master` branch of rvm which might not play along with the stable version we're installing. [Fix taken from the upstream issue.](https://github.com/rvm/rvm/issues/4068#issuecomment-309416731)

I have applied the above fix and the provisioning worked flawlessly.

## Steps to Reproduce (for bugs)
1. `vagrant up`
2. Watch the provisioning and look for this section

```
==> default: bash: line 880: __rvm_print_headline: command not found
==> default:  * Mailcatcher [not installed]
==> default: Building native extensions.  This could take a while...
==> default: ERROR:  Error installing mailcatcher:
==> default:    ERROR: Failed to build gem native extension.
==> default: 
==> default:         /usr/bin/ruby1.9.1 extconf.rb
==> default: /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require': cannot load such file -- mkmf (LoadError)
==> default:    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
==> default:    from extconf.rb:2:in `<main>'
```

3. e.g. run `rvm list` to check that `ruby-2.4.0` is not installed

## Your Environment
<!--- Include as many relevant details about the environment you experienced the bug in -->
* VVV version: 2.0.0 / [master](https://github.com/Varying-Vagrant-Vagrants/VVV/tree/81654e47d2cc8904eba70c56bcb6cbea4dae51d8)
* Vagrant version: 1.7.2
* VM Provider name: VirtualBox
* VM Provider version: 4.3.36_Ubuntur105129
* Operating System and version: Ubuntu 14.04
