### PR TITLE
PHPCS composer.json needs `phpcodesniffer-standard`

### DIFF
--- a/provision/phpcs/composer.json
+++ b/provision/phpcs/composer.json
@@ -6,7 +6,7 @@
         "wp-coding-standards/wpcs": "*"
     },
     "extra": {
-        "installer-types": ["library"],
+        "installer-types": ["library", "phpcodesniffer-standard"],
         "installer-paths": {
             "/srv/www/phpcs/": ["squizlabs/php_codesniffer"],
             "/srv/www/phpcs/CodeSniffer/Standards/WordPress/": ["wp-coding-standards/wpcs"]


### PR DESCRIPTION
WordPress Coding Standards are, currently, installed/updated to the wrong directory. Rather than being added to `/srv/www/phpcs/CodeSniffer/Standards/WordPress` as expected, the standards are being installed in `/vargrant/provision/phpcs/vendor`. I tracked the issue down to this comment, https://github.com/oomphinc/composer-installers-extender/issues/6#issuecomment-303054875.

Basically, we just need to make sure that `oomphinc/composer-installers-extender` knows that it should be working with dependencies of the type, `phpcodesniffer-standard`.