### PR TITLE
Add direct link to installation instructions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ VVV requires recent versions of both Vagrant and VirtualBox.
 
 Besides VirtualBox, provider support is also included for Parallels, Hyper-V, VMWare Fusion, and VMWare Workstation.
 
+Installation instructions can be found [here](https://varyingvagrantvagrants.org/docs/en-US/installation/).
+
 Full documentation can be found in the `docs/` directory of this repository and on the [varyingvagrantvagrants.org](https://varyingvagrantvagrants.org) website.
 
 ## Contributors


### PR DESCRIPTION
The [installation instructions](https://varyingvagrantvagrants.org/docs/en-US/installation/) are nice.

However, it takes 3 clicks to get there, and it took me a bit to figure out the first click:

- https://github.com/Varying-Vagrant-Vagrants/VVV#how-to-use-varying-vagrant-vagrants - click the link to the website
- click the "documentation" link under the "Documentation" section
- click "Installing VVV 2"

I would also make a similar change to the front page of https://varyingvagrantvagrants.org/ but I don't see how to do it.