### PR TITLE
Adds PHPCS WP.com VIP Minimum Coding Standards Ruleset

### DIFF
--- a/provision/phpcs/composer.json
+++ b/provision/phpcs/composer.json
@@ -1,15 +1,23 @@
 {
     "name": "VVV/phpcs",
     "type": "project",
+    "repositories": [
+        {
+            "type": "vcs",
+            "url":  "https://github.com/Automattic/VIP-Coding-Standards.git"
+        }
+    ],
     "require": {
         "oomphinc/composer-installers-extender": "^1.1",
-        "wp-coding-standards/wpcs": "*"
+        "wp-coding-standards/wpcs": "*",
+        "automattic/vipwpcs": "dev-master"
     },
     "extra": {
         "installer-types": ["library", "phpcodesniffer-standard"],
         "installer-paths": {
             "/srv/www/phpcs/": ["squizlabs/php_codesniffer"],
-            "/srv/www/phpcs/CodeSniffer/Standards/WordPress/": ["wp-coding-standards/wpcs"]
+            "/srv/www/phpcs/CodeSniffer/Standards/WordPress/": ["wp-coding-standards/wpcs"],
+            "/srv/www/phpcs/CodeSniffer/Standards/VIP-Coding-Standards/": ["automattic/vipwpcs"]
         }
     },
     "config": {

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -629,7 +629,7 @@ php_codesniff() {
   ln -sf "/srv/www/phpcs/bin/phpcs" "/usr/local/bin/phpcs"
 
   # Install the standards in PHPCS
-  phpcs --config-set installed_paths ./CodeSniffer/Standards/WordPress/
+  phpcs --config-set installed_paths ./CodeSniffer/Standards/WordPress/,./CodeSniffer/Standards/VIP-Coding-Standards/
   phpcs --config-set default_standard WordPress-Core
   phpcs -i
 }


### PR DESCRIPTION
Adds the minimum VIP coding standards ruleset used to check deploys and review automation at WordPress.com VIP.

This ruleset doesn't replace the one in the main WP coding standards, it's the bare minimum intended to flag anything serious with only the things that are absolutely essential, while letting VIP iterate faster