### PR TITLE
Alternate Dashboard domains

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -40,6 +40,9 @@ if ! vvv_config['hosts'].kind_of? Hash then
 end
 
 vvv_config['hosts'] += ['vvv.dev']
+vvv_config['hosts'] += ['vvv.test']
+vvv_config['hosts'] += ['vvv.local']
+vvv_config['hosts'] += ['vvv.localhost']
 
 vvv_config['sites'].each do |site, args|
   if args.kind_of? String then

--- a/config/nginx-config/sites/default.conf
+++ b/config/nginx-config/sites/default.conf
@@ -9,7 +9,7 @@ server {
     listen       80 default_server;
     listen       443 ssl;
     root         /srv/www/default;
-    server_name  vvv.dev;
+    server_name  vvv.dev vvv.test vvv.local vvv.localhost;
 
     location / {
         index index.php;

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -418,7 +418,7 @@ nginx_setup() {
             -key /etc/nginx/server.key \
             -out /etc/nginx/server.crt \
             -days 3650 \
-            -subj /CN=*.wordpress-develop.dev/CN=*.wordpress.dev/CN=*.vvv.dev 2>&1)"
+            -subj /CN=*.wordpress-develop.dev/CN=*.wordpress.dev/CN=*.vvv.dev/CN=*.vvv.local/CN=*.vvv.localhost/CN=*.vvv.test 2>&1)"
 	  echo "$vvvsigncert"
   fi
 

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -710,4 +710,4 @@ cleanup_vvv
 end_seconds="$(date +%s)"
 echo "-----------------------------"
 echo "Provisioning complete in "$(( end_seconds - start_seconds ))" seconds"
-echo "For further setup instructions, visit http://vvv.dev"
+echo "For further setup instructions, visit http://vvv.test"

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -660,6 +660,9 @@ cleanup_vvv(){
   echo "Cleaning the virtual machine's /etc/hosts file..."
   sed -n '/# vvv-auto$/!p' /etc/hosts > /tmp/hosts
   echo "127.0.0.1 vvv.dev # vvv-auto" >> "/etc/hosts"
+  echo "127.0.0.1 vvv.local # vvv-auto" >> "/etc/hosts"
+  echo "127.0.0.1 vvv.localhost # vvv-auto" >> "/etc/hosts"
+  echo "127.0.0.1 vvv.test # vvv-auto" >> "/etc/hosts"
   mv /tmp/hosts /etc/hosts
 }
 

--- a/vvv-config.yml
+++ b/vvv-config.yml
@@ -18,14 +18,14 @@ sites:
   wordpress-default:
     repo: https://github.com/Varying-Vagrant-Vagrants/vvv-wordpress-default.git
     hosts:
-      - local.wordpress.dev
+      - local.wordpress.test
 
   # The wordpress-develop configuration is useful for contributing to WordPress.
   wordpress-develop:
     repo: https://github.com/Varying-Vagrant-Vagrants/vvv-wordpress-develop.git
     hosts:
-      - src.wordpress-develop.dev
-      - build.wordpress-develop.dev
+      - src.wordpress-develop.test
+      - build.wordpress-develop.test
 
   # The following commented out site configuration will create a standard WordPress
   # site in www/example-site/ available at http://my-example-site.dev.
@@ -34,7 +34,7 @@ sites:
   #example-site:
   #  repo: https://github.com/Varying-Vagrant-Vagrants/custom-site-template.git
   #  hosts:
-  #    - my-example-site.dev
+  #    - my-example-site.test
 
   # The following commented out site configuration will create a environment useful
   # for contributions to the WordPress meta team:

--- a/www/default/index.php
+++ b/www/default/index.php
@@ -9,6 +9,13 @@ if ( file_exists( 'dashboard-custom.php' ) ) {
 	exit;
 }
 
+function endsWith( $haystack, $needle ) {
+    $length = strlen( $needle );
+
+    return $length === 0 || 
+    ( substr( $haystack, -$length ) === $needle );
+}
+
 require( __DIR__. '/yaml.php' );
 
 // Begin default dashboard.
@@ -73,8 +80,26 @@ require( __DIR__. '/yaml.php' );
 					}
 					?></h4>
 					<p><?php echo $description; ?></p>
-					<p><strong>URL:</strong> <a href="<?php echo 'http://'.$site['hosts'][0]; ?>" target="_blank"><?php echo 'http://'.$site['hosts'][0]; ?></a><br/>
+					<p><strong>URL:</strong> <?php
+					$has_dev = false;
+					foreach( $site['hosts'] as $host ) {
+
+						?>
+						<a href="<?php echo 'http://'.$host; ?>" target="_blank"><?php echo 'http://'.$host; ?></a>,
+						<?php
+						if ( $has_dev ){
+							continue;
+						}
+						$has_dev = endsWith( $host, '.dev' );
+					}
+					?><br/>
 					<strong>Folder:</strong> <code>www/<?php echo $name;?></code></p>
+					<?php if ( $has_dev ) {
+						?>
+						<p class="warning"><strong>Warning:</strong> the .dev TLD is owned by Google, you should migrate to .test</p>
+						<?php
+					}
+					?>
 				</div>
 				<?php
 			}

--- a/www/default/index.php
+++ b/www/default/index.php
@@ -18,7 +18,7 @@ require( __DIR__. '/yaml.php' );
 <head>
 	<title>Varying Vagrant Vagrants Dashboard</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<link rel="stylesheet" type="text/css" href="http://vvv.dev/style.css">
+	<link rel="stylesheet" type="text/css" href="http://vvv.test/style.css">
 </head>
 <body>
 <p id="vvv_provision_fail" style="display:none"><strong>Problem:</strong> Could not load the site, this implies that provisioning the site failed, please check there were no errors during provisioning, and reprovision.<br><br>
@@ -120,7 +120,7 @@ require( __DIR__. '/yaml.php' );
 			<a class="button" href="database-admin/" target="_blank">phpMyAdmin</a>
 			<a class="button" href="memcached-admin/" target="_blank">phpMemcachedAdmin</a>
 			<a class="button" href="opcache-status/opcache.php" target="_blank">Opcache Status</a>
-			<a class="button" href="http://vvv.dev:1080" target="_blank">Mailcatcher</a>
+			<a class="button" href="http://vvv.test:1080" target="_blank">Mailcatcher</a>
 			<a class="button" href="webgrind/" target="_blank">Webgrind</a>
 			<a class="button" href="phpinfo/" target="_blank">PHP Info</a>
 			<a class="button" href="php-status?html&amp;full" target="_blank">PHP Status</a>
@@ -144,8 +144,12 @@ require( __DIR__. '/yaml.php' );
 
 
 <script>
-// If it's not vvv.dev then this site has failed to provision, let the user know
-if ( location.hostname != "vvv.dev" ){
+// If it's not vvv.test then this site has failed to provision, let the user know
+if ( ( location.hostname != "vvv.dev" )
+	&& ( location.hostname != "vvv.test" )
+	&& ( location.hostname != "vvv.local" )
+	&& ( location.hostname != "vvv.localhost" ) )
+{
 	var notice = document.getElementById( 'vvv_provision_fail' );
 	notice.style.display = 'block';
 }

--- a/www/default/style.css
+++ b/www/default/style.css
@@ -112,6 +112,12 @@ input:focus,
 	text-decoration: none;
 	outline: none;
 }
+
+.warning {
+	color: #d08770;
+	font-style: italic;
+}
+
 /**
  * Source Code Pro License and Copyright:
  * https://github.com/adobe-fonts/source-code-pro/blob/master/LICENSE.txt


### PR DESCRIPTION
Adds support for `vvv.local` `vvv.test` and `vvv.localhost`, and changes prompts to recommend `vvv.test`

This goes some of the way towards correcting https://github.com/Varying-Vagrant-Vagrants/VVV/issues/583 though it doesn't impact the default sites