### PR TITLE
Fix composer polluting logs with progress

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -342,13 +342,13 @@ tools_install() {
   # the master branch on its GitHub repository.
   if [[ -n "$(composer --version --no-ansi | grep 'Composer version')" ]]; then
     echo "Updating Composer..."
-    COMPOSER_HOME=/usr/local/src/composer composer self-update
-    COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update phpunit/phpunit:5.*
-    COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update phpunit/php-invoker:1.1.*
-    COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update mockery/mockery:0.9.*
-    COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update d11wtq/boris:v1.0.8
+    COMPOSER_HOME=/usr/local/src/composer composer self-update --no-progress --no-interaction
+    COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update --no-progress --no-interaction phpunit/phpunit:5.*
+    COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update --no-progress --no-interaction phpunit/php-invoker:1.1.*
+    COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update --no-progress --no-interaction mockery/mockery:0.9.*
+    COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update --no-progress --no-interaction d11wtq/boris:v1.0.8
     COMPOSER_HOME=/usr/local/src/composer composer -q global config bin-dir /usr/local/bin
-    COMPOSER_HOME=/usr/local/src/composer composer global update
+    COMPOSER_HOME=/usr/local/src/composer composer global update --no-progress --no-interaction
   fi
 
   # Grunt


### PR DESCRIPTION
Adds `--no-progress` and `--no-interraction` arguments for composer `update` and `self-update` commands:

`--no-progress`: Do not output download progress.
`--no-interaction`: Do not ask any interactive question.

Previously logs would look like this:
```
==> default:   - Installing mockery/mockery (0.9.9):
==> default: Downloading (connecting...)
==> default:
==> default: Downloading (0%)
==> default:
==> default:
==> default:
==> default: Downloading (5%)
==> default:
==> default: Downloading (10%)
==> default:
==> default: Downloading (15%)
==> default:
==> default: Downloading (20%)
==> default:
==> default: Downloading (25%)
==> default:
==> default: Downloading (30%)
==> default:
==> default: Downloading (35%)
==> default:
==> default: Downloading (40%)
==> default:
==> default: Downloading (45%)
==> default:
==> default: Downloading (50%)
==> default:
==> default: Downloading (55%)
==> default:
==> default: Downloading (60%)
==> default:
==> default: Downloading (65%)
==> default:
==> default: Downloading (70%)
==> default:
==> default: Downloading (75%)
==> default:
==> default: Downloading (80%)
==> default:
==> default: Downloading (85%)
==> default:
==> default: Downloading (90%)
==> default:
==> default: Downloading (95%)
==> default:
==> default: Downloading (100%)
```

After this they will look like this:
```
==> default:   - Installing mockery/mockery (0.9.9):
==> default: Downloading
==> default:  (100%)
```