### PR TITLE
Customize the initial working directory when connecting via SSH

### DIFF
--- a/config/bash_login
+++ b/config/bash_login
@@ -1,0 +1,7 @@
+# Change initial working directory if one is present.
+if [ -e "/srv/config/custom/initial_cwd_once" ]; then
+    cd "$( cat /srv/config/custom/initial_cwd_once )"
+    rm /srv/config/custom/initial_cwd_once
+elif [ -e "/srv/config/custom/initial_cwd" ]; then
+    cd "$( cat /srv/config/custom/initial_cwd )"
+fi

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -149,7 +149,16 @@ noroot() {
 }
 
 profile_setup() {
+
+  # Make sure .bash_login is loaded in TTY and non-TTY.
+  if ! grep -q "bash_login" /home/vagrant/.bashrc; then
+    echo "if [ -e ~/.bash_login ]; then . ~/.bash_login; fi" >> /home/vagrant/.bashrc~
+    cat /home/vagrant/.bashrc >> /home/vagrant/.bashrc~
+    mv /home/vagrant/.bashrc~ /home/vagrant/.bashrc
+  fi
+
   # Copy custom dotfiles and bin file for the vagrant user from local
+  cp "/srv/config/bash_login" "/home/vagrant/.bash_login"
   cp "/srv/config/bash_profile" "/home/vagrant/.bash_profile"
   cp "/srv/config/bash_aliases" "/home/vagrant/.bash_aliases"
   cp "/srv/config/vimrc" "/home/vagrant/.vimrc"
@@ -167,6 +176,8 @@ profile_setup() {
 
   rsync -rvzh --delete "/srv/config/homebin/" "/home/vagrant/bin/"
 
+  echo " * Ensured .bash_login loading is prepended to .bashrc"
+  echo " * Copied /srv/config/bash_login                        to /home/vagrant/.bash_login"
   echo " * Copied /srv/config/bash_profile                      to /home/vagrant/.bash_profile"
   echo " * Copied /srv/config/bash_aliases                      to /home/vagrant/.bash_aliases"
   echo " * Copied /srv/config/vimrc                             to /home/vagrant/.vimrc"


### PR DESCRIPTION
By far my biggest annoyance with Vagrant is connecting to the VM over SSH and being dropped into `$HOME`, not the corresponding synced working directory on my host machine.  Previously I was using [`vassh`](https://github.com/xwp/vassh) to work around this, but I was not really fully satisfied because it was very slow, being that it needed to make two SSH connections for each connection (at least when invoking `vasshin` for TTY). I realized that VVV could just add first-class support for changing the initial working directory when connecting to the VM. 

What this PR adds support for a new `/srv/config/custom/initial_cwd` config file. When this is present, the `.bash_login` script will it and `cd` to whatever is inside. Additionally, it also adds support for `/srv/config/custom/initial_cwd_once` which will do the same, but the file will get removed immediately after it is read. This allows the host machine to do something like this:

```sh
pwd | sed 's:.*/vvv/www/:/srv/:' > /path/to/vvv/config/custom/initial_cwd_once; vagrant ssh
```

And then you will be dropped into the corresponding synced directory in the VM. For example:

`/Users/jsmith/vvv/www/wordpress-develop/public_html/src/wp-content` 
=> 
`/srv/www/wordpress-develop/public_html`

Eventually this could be used to create a `vagrant-ssh` script bundled with VVV which could then do this for you.