### PR TITLE
Auto change SSH working dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@
 # No need to share individual site configs with each other
 /config/nginx-config/sites/*.conf
 
+# Ignore the cwd config for vagrant ssh
+/config/.vvv_temp_ssh_cwd
+
 # Ignore anything in the 'custom' directory in config
 /config/custom/*
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -473,5 +473,16 @@ Vagrant.configure("2") do |config|
     config.trigger.before :destroy, :stdout => true do
       system({'VVV_SKIP_LOGO'=> 'true'}, "vagrant ssh -c 'vagrant_destroy'")
     end
+    config.trigger.before :ssh, :stdout => true do |trigger|
+      current_location = "~"
+      current_site = ""
+      vvv_config['sites'].each do |site, args|
+        if ENV['PWD'].start_with?(args['local_dir'])
+          current_location = args['vm_dir']
+          current_site = site
+        end
+      end
+      File.open(vagrant_dir+"/config/.vvv_temp_ssh_cwd", 'w') { |file| file.write( current_location ) }
+    end
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -475,11 +475,10 @@ Vagrant.configure("2") do |config|
     end
     config.trigger.before :ssh, :stdout => true do |trigger|
       current_location = "~"
-      current_site = ""
       vvv_config['sites'].each do |site, args|
         if ENV['PWD'].start_with?(args['local_dir'])
-          current_location = args['vm_dir']
-          current_site = site
+          current_location = ENV['PWD'].dup
+          current_location = current_location.sub! args['local_dir'], args['vm_dir']
         end
       end
       File.open(vagrant_dir+"/config/.vvv_temp_ssh_cwd", 'w') { |file| file.write( current_location ) }

--- a/config/bash_profile
+++ b/config/bash_profile
@@ -44,3 +44,7 @@ export PATH="$PATH:/srv/www/phpcs/scripts/"
 # nvm path
 export NVM_DIR="/srv/config/nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" # This loads nvm
+
+# switch to the appropriate starting directory
+new_cwd=`cat /vagrant/config/.vvv_temp_ssh_cwd`
+cd "$new_cwd"

--- a/config/bash_profile
+++ b/config/bash_profile
@@ -45,6 +45,8 @@ export PATH="$PATH:/srv/www/phpcs/scripts/"
 export NVM_DIR="/srv/config/nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" # This loads nvm
 
-# switch to the appropriate starting directory
-new_cwd=`cat /vagrant/config/.vvv_temp_ssh_cwd`
-cd "$new_cwd"
+if [ -f "/vagrant/config/.vvv_temp_ssh_cwd" ]; then
+	# switch to the appropriate starting directory
+	new_cwd=`cat /vagrant/config/.vvv_temp_ssh_cwd`
+	cd "$new_cwd"
+fi


### PR DESCRIPTION
If I have a site named `gutenberg` and I'm in that sites folder at `www/gutenberg` then this change will make sure that when I run `vagrant ssh` I start in the `/srv/www/gutenberg` folder

note: requires vagrant triggers