### PR TITLE
Branch & 2.1 in Splash

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ require 'yaml'
 vagrant_dir = File.expand_path(File.dirname(__FILE__))
 
 if ! ENV['VVV_SKIP_LOGO'] then
-  branch = `if [ -f #{vagrant_dir}/.git/HEAD ]; then git rev-parse --abbrev-ref HEAD; fi`
+  branch = `if [ -f #{vagrant_dir}/.git/HEAD ]; then git rev-parse --abbrev-ref HEAD; else echo 'novcs'; fi`
   puts "  \033[38;5;196m__     _\033[38;5;118m__     _\033[38;5;33m__     __ \033[38;5;129m ____    "
   puts "  \033[38;5;196m\\ \\   / \033[38;5;118m\\ \\   / \033[38;5;33m\\ \\   / / \033[38;5;129m|___ \\   "
   puts "  \033[38;5;196m \\ \\ / /\033[38;5;118m \\ \\ / /\033[38;5;33m \\ \\ / /  \033[38;5;129m  __) |  "

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,8 +3,10 @@
 
 require 'yaml'
 
+vagrant_dir = File.expand_path(File.dirname(__FILE__))
+
 if ! ENV['VVV_SKIP_LOGO'] then
-  branch = `if [ -f .git/HEAD ]; then git rev-parse --abbrev-ref HEAD; fi`
+  branch = `if [ -f #{vagrant_dir}/.git/HEAD ]; then git rev-parse --abbrev-ref HEAD; fi`
   puts "  \033[38;5;196m__     _\033[38;5;118m__     _\033[38;5;33m__     __ \033[38;5;129m ____    "
   puts "  \033[38;5;196m\\ \\   / \033[38;5;118m\\ \\   / \033[38;5;33m\\ \\   / / \033[38;5;129m|___ \\   "
   puts "  \033[38;5;196m \\ \\ / /\033[38;5;118m \\ \\ / /\033[38;5;33m \\ \\ / /  \033[38;5;129m  __) |  "
@@ -18,7 +20,7 @@ if ! ENV['VVV_SKIP_LOGO'] then
   puts "\033[0m"
 end
 
-vagrant_dir = File.expand_path(File.dirname(__FILE__))
+
 
 if File.file?(File.join(vagrant_dir, 'vvv-custom.yml')) then
   vvv_config_file = File.join(vagrant_dir, 'vvv-custom.yml')

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,14 +4,14 @@
 require 'yaml'
 
 if ! ENV['VVV_SKIP_LOGO'] then
+  branch = `if [ -f .git/HEAD ]; then git rev-parse --abbrev-ref HEAD; fi`
   puts "  \033[38;5;196m__     _\033[38;5;118m__     _\033[38;5;33m__     __ \033[38;5;129m ____    "
   puts "  \033[38;5;196m\\ \\   / \033[38;5;118m\\ \\   / \033[38;5;33m\\ \\   / / \033[38;5;129m|___ \\   "
   puts "  \033[38;5;196m \\ \\ / /\033[38;5;118m \\ \\ / /\033[38;5;33m \\ \\ / /  \033[38;5;129m  __) |  "
   puts "  \033[38;5;196m  \\ V / \033[38;5;118m  \\ V / \033[38;5;33m  \\ V /   \033[38;5;129m / __/   "
   puts "  \033[38;5;196m   \\_/  \033[38;5;118m   \\_/  \033[38;5;33m   \\_/    \033[38;5;129m|_____|  "
   puts ""
-  puts "  \033[38;5;196mVarying \033[38;5;118mVagrant \033[38;5;33mVagrants \033[38;5;129m2.0.0"
-  #puts ""
+  puts "  \033[38;5;196mVarying \033[38;5;118mVagrant \033[38;5;33mVagrants \033[38;5;129mv2.1.0-" + branch
   puts "  \033[0mDocs:       https://varyingvagrantvagrants.org/"
   puts "  \033[0mContribute: https://github.com/varying-vagrant-vagrants/vvv"
   puts "  \033[0mDashboard:  http://vvv.test"


### PR DESCRIPTION
Right now the splash indicates 2.0.0 for both `master` and `develop`, which isn't accurate.

Instead, lets bump `develop` to 2.1.0, indicating 2.1 is in development, and add the git branch to the splash. This PR does that:

<img width="574" alt="screen shot 2017-10-31 at 23 48 03" src="https://user-images.githubusercontent.com/58855/32254031-3cb85f86-be96-11e7-925b-d784df59841e.png">

When we release 2.1, we can bump the version in `develop` to 2.2 or 2.1.1, without needing to do the faff of updating the version number on release