### PR TITLE
Better default config

### DIFF
--- a/vvv-config.yml
+++ b/vvv-config.yml
@@ -14,34 +14,37 @@
 # and options are
 sites:
   # The wordpress-default configuration provides a default installation of the
-  # latest version of WordPress.
-  wordpress-default:
-    repo: https://github.com/Varying-Vagrant-Vagrants/vvv-wordpress-default.git
+  # latest version of WordPress in www/example-site/ in aviable at 
+  # http://example-site.local.
+  example-site.local:
+    repo: https://github.com/Varying-Vagrant-Vagrants/custom-site-template.git
     hosts:
-      - local.wordpress.test
+      - example-site.local
 
-  # The wordpress-develop configuration is useful for contributing to WordPress.
-  wordpress-develop:
-    repo: https://github.com/Varying-Vagrant-Vagrants/vvv-wordpress-develop.git
-    hosts:
-      - src.wordpress-develop.test
-      - build.wordpress-develop.test
-
-  # The following commented out site configuration will create a standard WordPress
-  # site in www/example-site/ available at http://my-example-site.dev.
+  # The following commented out site configuration will create a WordPress
+  # Multisite in subdirectory mode site in www/example-site/ available at 
+  # http://example-multisite.local
   # Remember, whitespace is significant! Tabs and spaces mean different things
 
-  #example-site:
+  #example-multisite.local:
   #  repo: https://github.com/Varying-Vagrant-Vagrants/custom-site-template.git
   #  hosts:
-  #    - my-example-site.test
+  #    - example-multisite.local
+  #  custom:
+  #    wp_type: subdirectory
+
+  # The wordpress-develop configuration is useful for contributing to WordPress.
+  #wordpress-develop:
+  #  repo: https://github.com/Varying-Vagrant-Vagrants/vvv-wordpress-develop.git
+  #  hosts:
+  #    - src.wordpress-develop.test
+  #    - build.wordpress-develop.test
 
   # The following commented out site configuration will create a environment useful
   # for contributions to the WordPress meta team:
   
   #wordpress-meta-environment:
   #  repo: https://github.com/WordPress/meta-environment.git
-
 
 # Utilities are system level items rather than sites, that install tools or packages
 # the core utilities install tools such as phpmyadmin

--- a/vvv-config.yml
+++ b/vvv-config.yml
@@ -14,7 +14,7 @@
 # and options are
 sites:
   # The wordpress-default configuration provides a default installation of the
-  # latest version of WordPress in www/example-site/ in aviable at 
+  # latest version of WordPress in www/example-site/ aviable at 
   # http://example-site.local.
   example-site.local:
     repo: https://github.com/Varying-Vagrant-Vagrants/custom-site-template.git


### PR DESCRIPTION
First of all thanks to making vvv better, I suggested some config options a while back and it turned into  https://github.com/Varying-Vagrant-Vagrants/custom-site-template.git among other things.

I think this is a better default config, and I wish I would have encounter this when I digged into VVV the first time because:

1. I think the default site thing should be abandoned because its basically the same as a custom site just with hardcoded stuff right? That can bite you hard if you try to edit the config nothing will happen! And I think it should have perfect parity with the default site setup so why maintain both when one can do it?
2. `.dev` is becoming a actual domain soon. This is why just picked .local no subdomain just straight to the point.
3. Made it the folders actually represent the domains like its often seen on actual servers.
4. Put a multisite example in there, the `custom: wp_type: subdirectory` does not make it very obvious that it will create a multisite because 'multisite' is no where mentioned in the config, that could be improved if you ask me.
5. Commented out then development env because I think not everyone needs that installed by default.

This way a new user can have a way easier start with VVV without reading much of the docs at all after installing.