### PR TITLE
Tighter Splash

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,17 +7,25 @@ vagrant_dir = File.expand_path(File.dirname(__FILE__))
 
 if ! ENV['VVV_SKIP_LOGO'] then
   branch = `if [ -f #{vagrant_dir}/.git/HEAD ]; then git rev-parse --abbrev-ref HEAD; else echo 'novcs'; fi`
-  puts "  \033[38;5;196m__     _\033[38;5;118m__     _\033[38;5;33m__     __ \033[38;5;129m ____    "
-  puts "  \033[38;5;196m\\ \\   / \033[38;5;118m\\ \\   / \033[38;5;33m\\ \\   / / \033[38;5;129m|___ \\   "
-  puts "  \033[38;5;196m \\ \\ / /\033[38;5;118m \\ \\ / /\033[38;5;33m \\ \\ / /  \033[38;5;129m  __) |  "
-  puts "  \033[38;5;196m  \\ V / \033[38;5;118m  \\ V / \033[38;5;33m  \\ V /   \033[38;5;129m / __/   "
-  puts "  \033[38;5;196m   \\_/  \033[38;5;118m   \\_/  \033[38;5;33m   \\_/    \033[38;5;129m|_____|  "
-  puts ""
-  puts "  \033[38;5;196mVarying \033[38;5;118mVagrant \033[38;5;33mVagrants \033[38;5;129mv2.1.0-" + branch
-  puts "  \033[0mDocs:       https://varyingvagrantvagrants.org/"
-  puts "  \033[0mContribute: https://github.com/varying-vagrant-vagrants/vvv"
-  puts "  \033[0mDashboard:  http://vvv.test"
-  puts "\033[0m"
+  branch = branch.chomp("\n"); # remove trailing newline so it doesnt break the ascii art
+  red="\033[38;5;196m"
+  green="\033[38;5;118m"
+  blue="\033[38;5;33m"
+  purple="\033[38;5;129m"
+  stars = <<-STARS
+\033[38;5;203m☆\033[0m\033[38;5;203m☆\033[0m\033[38;5;203m☆\033[0m\033[38;5;203m☆\033[0m\033[38;5;203m☆\033[0m\033[38;5;203m☆\033[0m\033[38;5;203m☆\033[0m\033[38;5;203m☆\033[0m\033[38;5;204m☆\033[0m\033[38;5;198m☆\033[0m\033[38;5;198m☆\033[0m\033[38;5;198m☆\033[0m\033[38;5;198m☆\033[0m\033[38;5;198m☆\033[0m\033[38;5;198m☆\033[0m\033[38;5;198m☆\033[0m\033[38;5;198m☆\033[0m\033[38;5;198m☆\033[0m\033[38;5;199m☆\033[0m\033[38;5;199m☆\033[0m\033[38;5;199m☆\033[0m\033[38;5;199m☆\033[0m\033[38;5;199m☆\033[0m\033[38;5;199m☆\033[0m
+STARS
+  splash = <<-HEREDOC
+#{red}__   _#{green}__   #{blue}___   __ 
+#{red}\\ \\ / #{green}\\ \\ / #{blue}\\ \\ / / #{red}Varying #{green}Vagrant #{blue}Vagrants
+#{red} \\ \V /#{green} \\ \V /#{blue} \\ \V /  #{purple}v2.1.0-#{branch}
+#{red}  \\_/  #{green} \\_/   #{blue}\\_/   #{stars}
+\033[0mDocs:       https://varyingvagrantvagrants.org/
+\033[0mContribute: https://github.com/varying-vagrant-vagrants/vvv
+\033[0mDashboard:  http://vvv.test
+\033[0m
+  HEREDOC
+  puts splash
 end
 
 


### PR DESCRIPTION
cleans up the splash with Heredocs, colour variables, and compacts the ASCII art down to 3 lines. Also adds some nice coloured stars to fix visual balance

I'm going to recommend this be merged into 2.2 once 2.1 is released

before:

<img width="541" alt="screen shot 2017-11-04 at 16 12 45" src="https://user-images.githubusercontent.com/58855/32407086-6feecca4-c17b-11e7-9185-edd754aaa184.png">

after:

<img width="544" alt="screen shot 2017-11-04 at 16 12 23" src="https://user-images.githubusercontent.com/58855/32407090-7c310144-c17b-11e7-89ac-811922959df8.png">
