### PR TITLE
Generate a new certificate and private key including .test domains

### DIFF
--- a/config/nginx-config/nginx.conf
+++ b/config/nginx-config/nginx.conf
@@ -116,8 +116,8 @@ http {
     server_names_hash_bucket_size 512;
 
     # Make Nginx aware of our default SSL certificates
-    ssl_certificate     /etc/nginx/server.crt;
-    ssl_certificate_key /etc/nginx/server.key;
+    ssl_certificate     /etc/nginx/server-2.1.0.crt;
+    ssl_certificate_key /etc/nginx/server-2.1.0.key;
 
     # This directory is mapped to config/nginx-config/sites in the varying vagrant
     # vagrants repository. Additional conf files for sites should be put there.

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -407,18 +407,18 @@ tools_install() {
 
 nginx_setup() {
   # Create an SSL key and certificate for HTTPS support.
-  if [[ ! -e /etc/nginx/server.key ]]; then
+  if [[ ! -e /etc/nginx/server-2.1.0.key ]]; then
 	  echo "Generate Nginx server private key..."
-	  vvvgenrsa="$(openssl genrsa -out /etc/nginx/server.key 2048 2>&1)"
+	  vvvgenrsa="$(openssl genrsa -out /etc/nginx/server-2.1.0.key 2048 2>&1)"
 	  echo "$vvvgenrsa"
   fi
-  if [[ ! -e /etc/nginx/server.crt ]]; then
+  if [[ ! -e /etc/nginx/server-2.1.0.crt ]]; then
 	  echo "Sign the certificate using the above private key..."
 	  vvvsigncert="$(openssl req -new -x509 \
-            -key /etc/nginx/server.key \
-            -out /etc/nginx/server.crt \
+            -key /etc/nginx/server-2.1.0.key \
+            -out /etc/nginx/server-2.1.0.crt \
             -days 3650 \
-            -subj /CN=*.wordpress-develop.dev/CN=*.wordpress.dev/CN=*.vvv.dev/CN=*.vvv.local/CN=*.vvv.localhost/CN=*.vvv.test 2>&1)"
+            -subj /CN=*.wordpress-develop.test/CN=*.wordpress.test/CN=*.wordpress-develop.dev/CN=*.wordpress.dev/CN=*.vvv.dev/CN=*.vvv.local/CN=*.vvv.localhost/CN=*.vvv.test 2>&1)"
 	  echo "$vvvsigncert"
   fi
 


### PR DESCRIPTION
This will automatically refresh the cert used for domains by default by appending a version number to the server.crt and server.key files.

Pretty sure this cert is half broken anyway, but it at least aligns with where we're currently at. 🙈 