### PR TITLE
Merge change in master from #1306

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -346,13 +346,13 @@ tools_install() {
   # the master branch on its GitHub repository.
   if [[ -n "$(composer --version --no-ansi | grep 'Composer version')" ]]; then
     echo "Updating Composer..."
-    COMPOSER_HOME=/usr/local/src/composer composer --no-ansi self-update
-    COMPOSER_HOME=/usr/local/src/composer composer --no-ansi global require --no-update phpunit/phpunit:5.*
-    COMPOSER_HOME=/usr/local/src/composer composer --no-ansi global require --no-update phpunit/php-invoker:1.1.*
-    COMPOSER_HOME=/usr/local/src/composer composer --no-ansi global require --no-update mockery/mockery:0.9.*
-    COMPOSER_HOME=/usr/local/src/composer composer --no-ansi global require --no-update d11wtq/boris:v1.0.8
+    COMPOSER_HOME=/usr/local/src/composer composer --no-ansi self-update --no-progress --no-interaction
+    COMPOSER_HOME=/usr/local/src/composer composer --no-ansi global require --no-update --no-progress --no-interaction phpunit/phpunit:5.*
+    COMPOSER_HOME=/usr/local/src/composer composer --no-ansi global require --no-update --no-progress --no-interaction phpunit/php-invoker:1.1.*
+    COMPOSER_HOME=/usr/local/src/composer composer --no-ansi global require --no-update --no-progress --no-interaction mockery/mockery:0.9.*
+    COMPOSER_HOME=/usr/local/src/composer composer --no-ansi global require --no-update --no-progress --no-interaction d11wtq/boris:v1.0.8
     COMPOSER_HOME=/usr/local/src/composer composer --no-ansi global config bin-dir /usr/local/bin
-    COMPOSER_HOME=/usr/local/src/composer composer --no-ansi global update
+    COMPOSER_HOME=/usr/local/src/composer composer --no-ansi global update --no-progress --no-interaction
   fi
 
   # Grunt


### PR DESCRIPTION
#1306 was accidentally merged into the master branch rather than develop.

Fix composer polluting logs with progress

Adds `--no-progress` and `--no-interraction` arguments for composer `update` and `self-update` commands:

`--no-progress`: Do not output download progress.
`--no-interaction`: Do not ask any interactive question.