### PR TITLE
Bump version number on develop so it doesn't get confused with master

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,7 +27,7 @@ STARS
   splash = <<-HEREDOC
 #{red}__   _#{green}__   #{blue}___   __ 
 #{red}\\ \\ / #{green}\\ \\ / #{blue}\\ \\ / / #{red}Varying #{green}Vagrant #{blue}Vagrants
-#{red} \\ \V /#{green} \\ \V /#{blue} \\ \V /  #{purple}v2.1.0-#{branch}
+#{red} \\ \V /#{green} \\ \V /#{blue} \\ \V /  #{purple}v2.2.0-#{branch}
 #{red}  \\_/  #{green} \\_/   #{blue}\\_/   #{stars}
 \033[0mDocs:       https://varyingvagrantvagrants.org/
 \033[0mContribute: https://github.com/varying-vagrant-vagrants/vvv


### PR DESCRIPTION
Bumps the develop version to 2.2 so that it's clearer when people say 2.1 if they mean stable or not

also saves some time when it comes to release