### PR TITLE
Ignore the whole /config/nvm/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@
 /config/custom/*
 
 # Ignore the nvm git clone in the 'nvm' directory in config
-/config/nvm/*
+/config/nvm/
 
 # Ignore a custom bash_prompt if it exists
 /config/bash_prompt


### PR DESCRIPTION
Noticed this because I'm using `status.showUntrackedFiles = all`, see https://git-scm.com/docs/git-config#git-config-statusshowUntrackedFiles.

```
➜  vagrant-local git:(develop) ✗ git status -u .
On branch develop
Your branch is up to date with 'origin/develop'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	config/nvm/

nothing added to commit but untracked files present (use "git add" to track)
```