### PR TITLE
Add support for custom git branches for utility sources

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -109,9 +109,11 @@ else
   end
 end
 
-vvv_config['utility-sources']['core'] = Hash.new
-vvv_config['utility-sources']['core']['repo'] = 'https://github.com/Varying-Vagrant-Vagrants/vvv-utilities.git'
-vvv_config['utility-sources']['core']['branch'] = 'master'
+if ! vvv_config['utility-sources'].key?('core')
+  vvv_config['utility-sources']['core'] = Hash.new
+  vvv_config['utility-sources']['core']['repo'] = 'https://github.com/Varying-Vagrant-Vagrants/vvv-utilities.git'
+  vvv_config['utility-sources']['core']['branch'] = 'master'
+end
 
 if ! vvv_config['utilities'].kind_of? Hash then
   vvv_config['utilities'] = Hash.new

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,7 +25,7 @@ if show_logo then
 \033[38;5;203m☆\033[0m\033[38;5;203m☆\033[0m\033[38;5;203m☆\033[0m\033[38;5;203m☆\033[0m\033[38;5;203m☆\033[0m\033[38;5;203m☆\033[0m\033[38;5;203m☆\033[0m\033[38;5;203m☆\033[0m\033[38;5;204m☆\033[0m\033[38;5;198m☆\033[0m\033[38;5;198m☆\033[0m\033[38;5;198m☆\033[0m\033[38;5;198m☆\033[0m\033[38;5;198m☆\033[0m\033[38;5;198m☆\033[0m\033[38;5;198m☆\033[0m\033[38;5;198m☆\033[0m\033[38;5;198m☆\033[0m\033[38;5;199m☆\033[0m\033[38;5;199m☆\033[0m\033[38;5;199m☆\033[0m\033[38;5;199m☆\033[0m\033[38;5;199m☆\033[0m\033[38;5;199m☆\033[0m
 STARS
   splash = <<-HEREDOC
-#{red}__   _#{green}__   #{blue}___   __ 
+#{red}__   _#{green}__   #{blue}___   __
 #{red}\\ \\ / #{green}\\ \\ / #{blue}\\ \\ / / #{red}Varying #{green}Vagrant #{blue}Vagrants
 #{red} \\ \V /#{green} \\ \V /#{blue} \\ \V /  #{purple}v2.2.0-#{branch}
 #{red}  \\_/  #{green} \\_/   #{blue}\\_/   #{stars}
@@ -96,8 +96,22 @@ end
 
 if ! vvv_config['utility-sources'].kind_of? Hash then
   vvv_config['utility-sources'] = Hash.new
+else
+  vvv_config['utility-sources'].each do |name, args|
+    if args.kind_of? String then
+        repo = args
+        args = Hash.new
+        args['repo'] = repo
+        args['branch'] = 'master'
+
+        vvv_config['utility-sources'][name] = args
+    end
+  end
 end
-vvv_config['utility-sources']['core'] = 'https://github.com/Varying-Vagrant-Vagrants/vvv-utilities.git'
+
+vvv_config['utility-sources']['core'] = Hash.new
+vvv_config['utility-sources']['core']['repo'] = 'https://github.com/Varying-Vagrant-Vagrants/vvv-utilities.git'
+vvv_config['utility-sources']['core']['branch'] = 'master'
 
 if ! vvv_config['utilities'].kind_of? Hash then
   vvv_config['utilities'] = Hash.new
@@ -405,13 +419,14 @@ Vagrant.configure("2") do |config|
     config.vm.provision "default", type: "shell", path: File.join( "provision", "provision.sh" )
   end
 
-  vvv_config['utility-sources'].each do |name, repo|
+  vvv_config['utility-sources'].each do |name, args|
     config.vm.provision "utility-source-#{name}",
       type: "shell",
       path: File.join( "provision", "provision-utility-source.sh" ),
       args: [
           name,
-          repo
+          args['repo'].to_s,
+          args['branch'],
       ]
   end
 

--- a/provision/provision-utility-source.sh
+++ b/provision/provision-utility-source.sh
@@ -2,20 +2,21 @@
 
 NAME=$1
 REPO=$2
+BRANCH=${3:-master}
 DIR="/vagrant/provision/resources/${NAME}"
 
 if [[ false != "${NAME}" && false != "${REPO}" ]]; then
   # Clone or pull the resources repository
   if [[ ! -d ${DIR}/.git ]]; then
     echo -e "\nDownloading ${NAME} resources, see ${REPO}"
-    git clone ${REPO} ${DIR} -q
+    git clone ${REPO} --branch ${BRANCH} ${DIR} -q
     cd ${DIR}
-    git checkout master -q
+    git checkout ${BRANCH} -q
   else
     echo -e "\nUpdating ${NAME} resources..."
     cd ${DIR}
-    git pull origin master -q
-    git checkout master -q
+    git pull origin ${BRANCH} -q
+    git checkout ${BRANCH} -q
   fi
 fi
 


### PR DESCRIPTION
This adds support for custom git branches for utility sources, same as we do for sites. For back-compat the default branch will be `master`.

I also added a check whether there is already a `core` utility before adding the default repo. This is to support a custom branch/repo for `core` as well.

Example config:

```yml
utility-sources:
  fancy:
    repo: https://github.com/fancy/fancy-utilities.git
    branch: master
  solr: https://github.com/ocean90/vvv-solr-utilities.git
  core:
    repo: https://github.com/ocean90/vvv-utilities.git
    branch: my-new-feature
```