### PR TITLE
VM Config in vvv-config.yml

### DIFF
--- a/vvv-config.yml
+++ b/vvv-config.yml
@@ -56,3 +56,10 @@ utilities:
     - phpmyadmin
     - webgrind
     - trusted-hosts
+
+# vm_config controls how Vagrant provisions the virtual machine, and can be used to
+# increase the memory given to VVV and the number of CPU cores. For WP core development
+# we recommend at least 2GB ( 2048 )
+vm_config:
+  memory: 2048
+  cores: 1


### PR DESCRIPTION
Adds the vm_config section to the config file by default so users are aware of it, and bump up the memory from 1024 to 2048


Related to https://github.com/Varying-Vagrant-Vagrants/VVV/issues/1366