### PR TITLE
1024mb -> 2048mb VM RAM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -124,7 +124,7 @@ if ! vvv_config['vm_config'].kind_of? Hash then
 end
 
 defaults = Hash.new
-defaults['memory'] = 1024
+defaults['memory'] = 2048
 defaults['cores'] = 1
 
 vvv_config['vm_config'] = defaults.merge(vvv_config['vm_config'])


### PR DESCRIPTION
Bumps up the default memory allocation from 1024 to 2048 in the vagrant file

Fixes https://github.com/Varying-Vagrant-Vagrants/VVV/issues/1366