### PR TITLE
Swaps the git repo of the default site to the custom site template

### DIFF
--- a/vvv-config.yml
+++ b/vvv-config.yml
@@ -17,10 +17,10 @@
 # located in. See the docs for how to define these, and what all the keys
 # and options are
 sites:
-  # The wordpress-default configuration provides a default installation of the
+  # The wordpress-default configuration provides an installation of the
   # latest version of WordPress.
   wordpress-default:
-    repo: https://github.com/Varying-Vagrant-Vagrants/vvv-wordpress-default.git
+    repo: https://github.com/Varying-Vagrant-Vagrants/custom-site-template.git
     hosts:
       - local.wordpress.test
 


### PR DESCRIPTION
The custom site templates provisioner is more robust, we can make sure new users get it instead of the older default site template