### PR TITLE
Add vm_config settings for the private network ip and vagrant provider

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -126,8 +126,15 @@ end
 defaults = Hash.new
 defaults['memory'] = 2048
 defaults['cores'] = 1
+# This should rarely be overridden, so it's not included in the default vvv-config.yml file.
+defaults['private_network_ip'] = '192.168.50.4'
 
 vvv_config['vm_config'] = defaults.merge(vvv_config['vm_config'])
+
+if defined? vvv_config['vm_config']['provider'] then
+  # Override or set the vagrant provider.
+  ENV['VAGRANT_DEFAULT_PROVIDER'] = vvv_config['vm_config']['provider']
+end
 
 vvv_config['hosts'] = vvv_config['hosts'].uniq
 
@@ -237,7 +244,7 @@ Vagrant.configure("2") do |config|
   # should be changed. If more than one VM is running through VirtualBox, including other
   # Vagrant machines, different subnets should be used for each.
   #
-  config.vm.network :private_network, id: "vvv_primary", ip: "192.168.50.4"
+  config.vm.network :private_network, id: "vvv_primary", ip: vvv_config['vm_config']['private_network_ip']
 
   config.vm.provider :hyperv do |v, override|
     override.vm.network :private_network, id: "vvv_primary", ip: nil

--- a/vvv-config.yml
+++ b/vvv-config.yml
@@ -60,6 +60,11 @@ utilities:
 # vm_config controls how Vagrant provisions the virtual machine, and can be used to
 # increase the memory given to VVV and the number of CPU cores. For WP core development
 # we recommend at least 2GB ( 2048 )
+# It can also be used to override the default provider being used within Vagrant.
+# Due to a limitation within Vagrant, the specified provider is only respected on a clean `vagrant up`
+# as Vagrant currently restricts you to one provider per machine
+# https://www.vagrantup.com/docs/providers/basic_usage.html#vagrant-up
 vm_config:
   memory: 2048
   cores: 1
+  # provider: vmware_workstation


### PR DESCRIPTION
- Provide the ability to specify the default provider to use for vvv without having to use the `--provider` parameter.
- In the rare case a user's existing network is using a `192.168.50.x` subnet, it can now be overridden in the config rather than the `Vagrantfile`. As it's a rare occurrence, it's not documented in the `vvv-config.yml` file.