### PR TITLE
switches the phpcs install to use github rather than vcs for the vip coding standards

### DIFF
--- a/provision/phpcs/composer.json
+++ b/provision/phpcs/composer.json
@@ -3,7 +3,7 @@
     "type": "project",
     "repositories": [
         {
-            "type": "vcs",
+            "type": "github",
             "url":  "https://github.com/Automattic/VIP-Coding-Standards.git"
         }
     ],


### PR DESCRIPTION
Fixes #1412 