### PR TITLE
Update Copyright Year Range to Present

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014-2017 the contributors of the VVV project
+Copyright (c) 2014-present the contributors of the VVV project
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ VVV is a [10up](https://10up.com) creation and [transitioned](http://10up.com/bl
 * **Web**: [https://varyingvagrantvagrants.org/](https://varyingvagrantvagrants.org/)
 * **Contributing**: Contributions are more than welcome. Please see our current [contributing guidelines](https://varyingvagrantvagrants.org/docs/en-US/contributing/). Thanks!
 
-VVV is copyright (c) 2014-2017, the contributors of the VVV project under the [MIT License](LICENSE).
+VVV is copyright (c) 2014-present, the contributors of the VVV project under the [MIT License](LICENSE).
 
 ## Objectives
 


### PR DESCRIPTION
Rather than having to update this each year, let's use `present` in the copyright range.