### PR TITLE
Changes the default core dev site to the new custom site template develop

### DIFF
--- a/vvv-config.yml
+++ b/vvv-config.yml
@@ -26,7 +26,7 @@ sites:
 
   # The wordpress-develop configuration is useful for contributing to WordPress.
   wordpress-develop:
-    repo: https://github.com/Varying-Vagrant-Vagrants/vvv-wordpress-develop.git
+    repo: https://github.com/Varying-Vagrant-Vagrants/custom-site-template-develop.git
     hosts:
       - src.wordpress-develop.test
       - build.wordpress-develop.test


### PR DESCRIPTION
The current dev template only works for a single domain, this one is a modern replacement, we should use it by default for new users