### PR TITLE
fixes the installation of a nonexistent package

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -50,7 +50,6 @@ apt_package_check_list=(
   php7.2-curl
   php7.2-gd
   php7.2-mbstring
-  php7.2-mcrypt
   php7.2-mysql
   php7.2-imap
   php7.2-json


### PR DESCRIPTION
Without this, some PHP 7.2 packages don't get installed