### PR TITLE
adds the ruby-dev package

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -101,6 +101,10 @@ apt_package_check_list=(
   # Mailcatcher requirement
   libsqlite3-dev
 
+
+  # ruby dev, needed or mailcatcher
+  ruby-dev
+
 )
 
 ### FUNCTIONS


### PR DESCRIPTION
 which is needed when building some ruby package dependencies, such as those mail catcher relies on

With this, mailcatcher builds, though I can't access it via the `http://vvv.test:1080` url