### PR TITLE
don't restart nginx if a site is set to skip provisioning

### DIFF
--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -121,5 +121,6 @@ if [[ false == "${SKIP_PROVISIONING}" ]]; then
     fi
     done
   fi
+  service nginx restart
 fi
-service nginx restart
+


### PR DESCRIPTION
<img width="1022" alt="screen shot 2018-06-25 at 19 29 56" src="https://user-images.githubusercontent.com/58855/41868550-4948e7de-78ae-11e8-838c-439537f0c3af.png">

Most of those sites would have triggered the nginx service to restart despite me telling VVV to skip them. Ideally the vagrant file wouldn't even trigger the site provisioner for those sites, that would be a future step