### PR TITLE
adds a slightly nicer default prompt that adds colours

### DIFF
--- a/config/bash_profile
+++ b/config/bash_profile
@@ -13,6 +13,17 @@ if [ -n "$BASH_VERSION" ]; then
     fi
 fi
 
+# set variable identifying the chroot you work in (used in the prompt below)
+if [ -z "${debian_chroot:-}" ] && [ -r /etc/debian_chroot ]; then
+    debian_chroot=$(cat /etc/debian_chroot)
+fi
+red="\033[38;5;9m"
+green="\033[01;32m"
+blue="\033[38;5;4m"
+yellow="\033[38;5;3m"
+white="\033[00m"
+PS1="${debian_chroot:+($debian_chroot)}${red}\u${green}@${blue}\h${white}:${yellow}\w$ \033[0m"
+
 # setup bash prompt
 if [ -n "$BASH_VERSION" ]; then
     # include .bash_prompt if it exists


### PR DESCRIPTION
Updated the bash profile script to provide a more pleasant default prompt:

<img width="484" alt="screen shot 2018-07-02 at 19 49 19" src="https://user-images.githubusercontent.com/58855/42180965-17426c1e-7e31-11e8-8ff0-b6e02cfe29d0.png">

Users can still override this by putting a `.bash_prompt` file in their homefolder