### PR TITLE
skips running a site provisioner if the site has been skipped in the config file

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -532,17 +532,19 @@ Vagrant.configure("2") do |config|
   end
 
   vvv_config['sites'].each do |site, args|
-    config.vm.provision "site-#{site}",
-      type: "shell",
-      path: File.join( "provision", "provision-site.sh" ),
-      args: [
-        site,
-        args['repo'].to_s,
-        args['branch'],
-        args['vm_dir'],
-        args['skip_provisioning'].to_s,
-        args['nginx_upstream']
-      ]
+    if args['skip_provisioning'] === false then
+      config.vm.provision "site-#{site}",
+        type: "shell",
+        path: File.join( "provision", "provision-site.sh" ),
+        args: [
+          site,
+          args['repo'].to_s,
+          args['branch'],
+          args['vm_dir'],
+          args['skip_provisioning'].to_s,
+          args['nginx_upstream']
+        ]
+    end
   end
 
 


### PR DESCRIPTION
If you set a site to skip provisioning, its provisioner still runs, but exits immediatley.

Instead, this PR adds the same check to the Vagrant file, speeding things up a little bit, and reducing provisioner output