### PR TITLE
allow symlinks

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -226,6 +226,7 @@ Vagrant.configure("2") do |config|
     v.customize ["modifyvm", :id, "--rtcuseutc", "on"]
     v.customize ["modifyvm", :id, "--audio", "none"]
     v.customize ["modifyvm", :id, "--paravirtprovider", "kvm"]
+    v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate//srv/www", "1"]
 
     # Set the box name in VirtualBox to match the working directory.
     vvv_pwd = Dir.pwd

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -227,6 +227,7 @@ Vagrant.configure("2") do |config|
     v.customize ["modifyvm", :id, "--audio", "none"]
     v.customize ["modifyvm", :id, "--paravirtprovider", "kvm"]
     v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate//srv/www", "1"]
+    v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate//srv/config", "1"]
 
     # Set the box name in VirtualBox to match the working directory.
     vvv_pwd = Dir.pwd


### PR DESCRIPTION
These are the changes I made to my local vagrant file as described on https://github.com/Varying-Vagrant-Vagrants/VVV/issues/1579.

Basically, this just allows you to create symlinks inside shared folders. This is handy, as described on the related ticket, so users on Windows host machines can replace their node_modules folders inside shared folders with a symlink, because npm, when ran from the guest OS, doesn't work well in folders shared with a windows host machine.