### PR TITLE
fix bash prompt not wrapping correctly. 

### DIFF
--- a/config/bash_profile
+++ b/config/bash_profile
@@ -17,12 +17,12 @@ fi
 if [ -z "${debian_chroot:-}" ] && [ -r /etc/debian_chroot ]; then
     debian_chroot=$(cat /etc/debian_chroot)
 fi
-red="\033[38;5;9m"
-green="\033[01;32m"
-blue="\033[38;5;4m"
-yellow="\033[38;5;3m"
-white="\033[00m"
-PS1="${debian_chroot:+($debian_chroot)}${red}\u${green}@${blue}\h${white}:${yellow}\w$ \033[0m"
+red="\[\033[38;5;9m\]"
+green="\[\033[01;32m\]"
+blue="\[\033[38;5;4m\]"
+yellow="\[\033[38;5;3m\]"
+white="\[\033[00m\]"
+PS1="${debian_chroot:+($debian_chroot)}${red}\u${green}@${blue}\h${white}:${yellow}\w$ \[\033[0m\]"
 
 # setup bash prompt
 if [ -n "$BASH_VERSION" ]; then


### PR DESCRIPTION
Fix #1602 

Before:
![screen shot 2018-08-09 at 00 02 33](https://user-images.githubusercontent.com/656006/43852568-c2e5782e-9b67-11e8-8066-ebceaa910ca9.png)

After:
![screen shot 2018-08-09 at 00 02 56](https://user-images.githubusercontent.com/656006/43852582-c9977c6c-9b67-11e8-81fb-a162e945af35.png)

PS: the color of the RGB is might different since i'm using custom color scheme with iTerm2 on Mac

