### PR TITLE
Reduce nvm and Go footprint

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -93,10 +93,6 @@ apt_package_install_list=(
   # nodejs for use by grunt
   g++
   nodejs
-
-  # MailHog requirement
-  golang-go
-
 )
 
 ### FUNCTIONS
@@ -533,12 +529,18 @@ phpfpm_setup() {
 
 go_setup() {
   if [[ ! -e /usr/local/bin/mailhog ]]; then
-    echo " * Installing GoLang 1.10.3"
-    curl -sO https://dl.google.com/go/go1.10.3.linux-amd64.tar.gz
-    tar -xvf go1.10.3.linux-amd64.tar.gz
-    rm go1.10.3.linux-amd64.tar.gz
-    mv go /usr/local
-    export PATH="$PATH:/usr/local/go/bin"
+      local DOWNLOADS_PAGE=$(curl --silent "https://golang.org/dl/")
+      local DOWNLOADS_RE="https://dl\\.google\\.com/go/go([0-9]\\.[0-9]+)+\\.linux-amd64\\.tar\\.gz"
+
+      if [[ $DOWNLOADS_PAGE =~ $DOWNLOADS_RE ]]; then
+          echo " * Installing GoLang ${BASH_REMATCH[1]}"
+          curl -so- ${BASH_REMATCH[0]} | tar zxvf -
+          mv go /usr/local
+          export PATH="$PATH:/usr/local/go/bin"
+      else
+          echo "Could not find link to latest GoLang!"
+          return 1
+      fi
   fi
 }
 mailhog_setup() {

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -528,21 +528,15 @@ phpfpm_setup() {
 }
 
 go_setup() {
-  if [[ ! -e /usr/local/bin/mailhog ]]; then
-      local DOWNLOADS_PAGE=$(curl --silent "https://golang.org/dl/")
-      local DOWNLOADS_RE="https://dl\\.google\\.com/go/go([0-9]\\.[0-9]+)+\\.linux-amd64\\.tar\\.gz"
-
-      if [[ $DOWNLOADS_PAGE =~ $DOWNLOADS_RE ]]; then
-          echo " * Installing GoLang ${BASH_REMATCH[1]}"
-          curl -so- ${BASH_REMATCH[0]} | tar zxvf -
-          mv go /usr/local
-          export PATH="$PATH:/usr/local/go/bin"
-      else
-          echo "Could not find link to latest GoLang!"
-          return 1
-      fi
+  if [[ ! -e /usr/local/go/bin/go ]]; then
+      echo " * Installing GoLang 1.10.3"
+      curl -so- https://dl.google.com/go/go1.10.3.linux-amd64.tar.gz | tar zxvf -
+      mv go /usr/local
+      export PATH="$PATH:/usr/local/go/bin"
+      export GOPATH=/home/vagrant/gocode
   fi
 }
+
 mailhog_setup() {
 
   if [[ -f "/etc/init/mailcatcher.conf" ]]; then


### PR DESCRIPTION
Currently, Go is installed twice: through `apt` (where we get v1.2.1, which is too old for MailHog), and then through a tarball (where we get v1.10.3). This PR removes the `golang-go` package from the list and updates the tarball to v1.11. I could not find a way to avoid getting the source and tests, unfortunately—when I tried excluding them in the `tar` command, compiling MailHog failed.

In addition, nvm is currently installed by cloning the repository. This is the normal method, but it pulls in a host of unnecessary files, including test files whose names end in dots, which are a nuisance to deal with on Windows. This PR switches the `script` install method so that only the three files necessary are downloaded.