### PR TITLE
Bump the vagrant minimum version

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,6 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby ts=2 sw=2 et:
-Vagrant.require_version ">= 2.1.0"
+Vagrant.require_version ">= 2.1.4"
 require 'yaml'
 require 'fileutils'
 


### PR DESCRIPTION
2.1.3 is a known bad version, so 2.1.4 would be the minimum to avoid that

## Summary:

<!-- what does it add/fix/change/remove? -->

It increases the minimum vagrant version to v2.1.4

## Checks

<!--  Have you: -->
 - [ ] I've tested this PR with Vagrant **vXX** and VirtualBox **vXX** on **Operating System**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [ ] I've updated the changelog
 - [ ] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
