### PR TITLE
Fix message shown when vvv-custom.yml is copied

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -104,7 +104,7 @@ STARS
 end
 
 if File.file?(File.join(vagrant_dir, 'vvv-custom.yml')) == false then
-  puts "#{yellow}IMPORTANT: Copying #{red}vvv-config.yml#{yellow} to #{green}vvv-custom.yml#{yellow}, make all modifications to #{green}vvv-custom.yml#{yellow} in future#{creset}\n\n"
+  puts "#{yellow}Copying #{red}vvv-config.yml#{yellow} to #{green}vvv-custom.yml#{yellow}\nIMPORTANT NOTE: Make all modifications to #{green}vvv-custom.yml#{yellow} in future so that they are not lost when VVV updates.#{creset}\n\n"
   FileUtils.cp( File.join(vagrant_dir, 'vvv-config.yml'), File.join(vagrant_dir, 'vvv-custom.yml') )
 end
 
@@ -223,7 +223,7 @@ Vagrant.configure("2") do |config|
     v.customize ["modifyvm", :id, "--cpus", vvv_config['vm_config']['cores']]
     v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
     v.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
-    
+
     # see https://github.com/hashicorp/vagrant/issues/7648
     v.customize ['modifyvm', :id, '--cableconnected1', 'on']
 


### PR DESCRIPTION
## Summary:

When vagrant up is run the first time, it makes a copy of vvv-config.yml to vvv-custom.yml and shows the a message (as shown in image 1). This message is confusing as it talks about the action of VVV and also has suggestion that users should use vvv-custom.yml.

<img width="950" alt="image1" src="https://user-images.githubusercontent.com/4047909/46835255-3bcac600-cdcb-11e8-875a-8ea683d00369.png">

This commit changes that message to be more clear (as shown in image 2) by separating the action of VVV and suggestion for the user in 2 different lines. The suggestion also has an explanation on why changes should be made on vvv-custom.yml instead of vvv-config.yml.

<img width="1054" alt="image2" src="https://user-images.githubusercontent.com/4047909/46835272-471df180-cdcb-11e8-9f2a-59f63feac485.png">

## Checks

 - [ ] I've tested this PR with Vagrant 2.1.5 and VirtualBox 5.2.18r124319 on MacOS 10.14 (18A391)
 - [ ] This PR is for the `develop` branch not the `master` branch
 - [ ] This PR is complete and ready for review


