### PR TITLE
add /g flag for {vvv_site_name} var replacement

### DIFF
--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -61,7 +61,7 @@ function vvv_provision_site_nginx() {
   DIR="$(dirname "$SITE_NGINX_FILE")"
   sed "s#{vvv_path_to_folder}#$DIR#" "$SITE_NGINX_FILE" > "/etc/nginx/custom-sites/${DEST_NGINX_FILE}"
   sed -i "s#{vvv_path_to_site}#$VM_DIR#" "/etc/nginx/custom-sites/${DEST_NGINX_FILE}"
-  sed -i "s#{vvv_site_name}#$SITE#" "/etc/nginx/custom-sites/${DEST_NGINX_FILE}"
+  sed -i "s#{vvv_site_name}#$SITE#g" "/etc/nginx/custom-sites/${DEST_NGINX_FILE}"
   sed -i "s#{vvv_hosts}#$VVV_HOSTS#" "/etc/nginx/custom-sites/${DEST_NGINX_FILE}"
   sed -i "s#{upstream}#$NGINX_UPSTREAM#" "/etc/nginx/custom-sites/${DEST_NGINX_FILE}"
 


### PR DESCRIPTION
## Summary:

It is common to have more than one server name defined via a `server_name` directive; currently, trying to do this in `vvv-nginx.conf` will cause provisioning to fail, as the `/g` flag is not used, so only the first `{vvv_site_name}` gets replaced on a line.

Since the `vvv_provision_site_nginx()` runs after `vvv-init.sh`, it is not possible to fix this in `vvv-init.sh`, as the changes get overridden.

## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant **vXX** and VirtualBox **vXX** on **Operating System**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [ ] I've updated the changelog
 - [x] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
