### PR TITLE
Utility hosts

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -536,6 +536,21 @@ Vagrant.configure("2") do |config|
       end
   end
 
+  vvv_config['utilities'].each do |name, utilities|
+    if ! utilities.kind_of? Array then
+      utilities = Hash.new
+    end
+    utilities.each do |utility|
+      # load the vvv-hosts file
+      utility_hosts_file = File.join(vagrant_dir, "provision/resources/#{name}/#{utility}/vvv-hosts")
+      if File.exist? utility_hosts_file then
+        File.readlines(utility_hosts_file).map do |line|
+          vvv_config['hosts'] += [ line ]
+        end
+      end
+    end
+  end
+
   vvv_config['sites'].each do |site, args|
     if args['skip_provisioning'] === false then
       config.vm.provision "site-#{site}",


### PR DESCRIPTION
read in vvv-hosts files inside enabled utilities so that they can add hosts, WIP

## Summary:

<!-- what does it add/fix/change/remove? -->

This allows utilities to define a `vvv-hosts` file that gets included

## Checks

<!--  Have you: -->
 - [ ] I've tested this PR with Vagrant **v2.2.0** and VirtualBox **v5.2.18** on **MacOS**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [ ] I've updated the changelog
 - [ ] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
