### PR TITLE
only provision hosts for active sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ permalink: /docs/en-US/changelog/
 
 ### Bug Fixes
 
- * 
+ * Sites that set `skip_provision` to true no longer have their hosts added
 
 ### Deprecations
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -148,14 +148,15 @@ vvv_config['sites'].each do |site, args|
 
   vvv_config['sites'][site] = defaults.merge(args)
 
-  site_host_paths = Dir.glob(Array.new(4) {|i| vvv_config['sites'][site]['local_dir'] + '/*'*(i+1) + '/vvv-hosts'})
+  if ! vvv_config['sites'][site]['skip_provisioning'] then
+    site_host_paths = Dir.glob(Array.new(4) {|i| vvv_config['sites'][site]['local_dir'] + '/*'*(i+1) + '/vvv-hosts'})
+    vvv_config['sites'][site]['hosts'] += site_host_paths.map do |path|
+      lines = File.readlines(path).map(&:chomp)
+      lines.grep(/\A[^#]/)
+    end.flatten
 
-  vvv_config['sites'][site]['hosts'] += site_host_paths.map do |path|
-    lines = File.readlines(path).map(&:chomp)
-    lines.grep(/\A[^#]/)
-  end.flatten
-
-  vvv_config['hosts'] += vvv_config['sites'][site]['hosts']
+    vvv_config['hosts'] += vvv_config['sites'][site]['hosts']
+  end
   vvv_config['sites'][site].delete('hosts')
 end
 


### PR DESCRIPTION
## Summary:

<!-- what does it add/fix/change/remove? -->

Fixes #1663 by only provisioning a site if `skip_provisioning` is set to `false`

## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant **v2.2** and VirtualBox **v5.2.18** on **MacOS Mojave**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [x] I've updated the changelog
 - [x] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
