### PR TITLE
Tomjn default nginx blocks folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ permalink: /docs/en-US/changelog/
  * Updated Node v6 to Node v10
  * The default site config has been improved to clear up confusion over the difference between the site template and the develop site template
  * Utilities can now place nginx config files in `/etc/nginx/custom-utilities/` during provisioning
+ * The default Nginx config can now be extended with files in `/etc/nginx/dashboard-extensions/` during provisioning
  * The message VVV showed when copying `vvv-config.yml` to `vvv-custom.yml` was a tad confusing, it's been improved
 
 ### Bug Fixes

--- a/config/nginx-config/sites/default.conf
+++ b/config/nginx-config/sites/default.conf
@@ -11,6 +11,8 @@ server {
     root         /srv/www/default;
     server_name  vvv.dev vvv.test vvv.local vvv.localhost;
 
+    include /etc/nginx/custom-dashboard-extensions/*.conf;
+
     location / {
         index index.php;
         try_files $uri $uri/ /index.php$is_args$args;

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -501,7 +501,12 @@ nginx_setup() {
   if [[ ! -d "/etc/nginx/custom-utilities" ]]; then
     mkdir "/etc/nginx/custom-utilities/"
   fi
-  rm -rf /etc/nginx/custom-utilities/*
+
+  if [[ ! -d "/etc/nginx/custom-dashboard-extensions" ]]; then
+    mkdir "/etc/nginx/custom-dashboard-extensions/"
+  fi
+
+  rm -rf /etc/nginx/custom-{dashboard-extensions,utilities}/*
 
   echo " * Copied /srv/config/nginx-config/nginx.conf           to /etc/nginx/nginx.conf"
   echo " * Copied /srv/config/nginx-config/nginx-wp-common.conf to /etc/nginx/nginx-wp-common.conf"


### PR DESCRIPTION
## Summary:

<!-- what does it add/fix/change/remove? -->

Allows the default nginx config to be extended

## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant **v2.2.0** and VirtualBox **v5.2.18** on **MacOS Mojave**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [x] I've updated the changelog
 - [x] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
