### PR TITLE
[ UPDATE ] changed mention of .dev to .test

### DIFF
--- a/vvv-config.yml
+++ b/vvv-config.yml
@@ -42,7 +42,7 @@ sites:
       - trunk.wordpress.test
 
   # The following commented out site configuration will create a standard WordPress
-  # site in www/example-site/ available at http://my-example-site.dev.
+  # site in www/example-site/ available at http://my-example-site.test.
   # Remember, whitespace is significant! Tabs and spaces mean different things
   #example-site:
   #  repo: https://github.com/Varying-Vagrant-Vagrants/custom-site-template.git


### PR DESCRIPTION
## Summary:
Removes the reference to .dev in the my-example-site comment that starts on line 44.

## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant 2.2.0 and VirtualBox 2.5.22 on macOS Mojave v10.14.1
 - [x] This PR is for the `develop` branch not the `master` branch
 - [ ] I've updated the changelog
 - [x] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
