### PR TITLE
Replace Mailcatcher with Mailhog in `README.md`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ VVV is built on a Ubuntu 14.04 LTS (Trusty) base VM and provisions the server wi
 1. [PHPUnit](https://phpunit.de/)
 1. [Composer](https://github.com/composer/composer)
 1. [NodeJs](https://nodejs.org/) v10
-1. [Mailcatcher](http://mailcatcher.me/)
+1. [Mailhog](https://github.com/mailhog/MailHog)
 
 For a more comprehensive list, please see the [list of installed packages](https://varyingvagrantvagrants.org/docs/en-US/installed-packages/).
 


### PR DESCRIPTION
## Summary:

New installations of VVV will install Mailhog, not Mailcatcher. The project's README file should reflect this.

## Checks
 - [x] I've tested this PR with Vagrant **v2.2.2** and VirtualBox **v5.2.22** on **macOS**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [x] I've updated the changelog (actually, I've made the README match the Changelog. ;)
 - [x] This PR is complete and ready for review