### PR TITLE
Fix site provision update after forced update

### DIFF
--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -83,6 +83,7 @@ if [[ false != "${REPO}" ]]; then
   else
     echo -e "\nUpdating ${SITE}..."
     cd ${VM_DIR}
+    noroot git reset origin/${BRANCH} --hard -q
     noroot git pull origin ${BRANCH} -q
     noroot git checkout ${BRANCH} -q
   fi


### PR DESCRIPTION
## Summary:

Allow custom site provisioner update after a git push force

## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant **v2.2.2** and VirtualBox **v5.2.18** on **Ubuntu 18.10**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [ ] I've updated the changelog
 - [x] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
