### PR TITLE
Install PHPCompatibilityWP PHPCS Standard

### DIFF
--- a/provision/phpcs/composer.json
+++ b/provision/phpcs/composer.json
@@ -12,7 +12,9 @@
         "oomphinc/composer-installers-extender": "^1.1",
         "wp-coding-standards/wpcs": "*",
         "automattic/vipwpcs": "dev-master",
-        "wimg/php-compatibility": "*"
+        "phpcompatibility/php-compatibility": "*",
+        "phpcompatibility/phpcompatibility-paragonie": "*",
+        "phpcompatibility/phpcompatibility-wp": "*"
     },
     "extra": {
         "installer-types": ["library", "phpcodesniffer-standard"],
@@ -20,7 +22,9 @@
             "/srv/www/phpcs/": ["squizlabs/php_codesniffer"],
             "/srv/www/phpcs/CodeSniffer/Standards/WordPress/": ["wp-coding-standards/wpcs"],
             "/srv/www/phpcs/CodeSniffer/Standards/VIP-Coding-Standards/": ["automattic/vipwpcs"],
-            "/srv/www/phpcs/CodeSniffer/Standards/PHPCompatibility/": ["wimg/php-compatibility"]
+            "/srv/www/phpcs/CodeSniffer/Standards/PHPCompatibility/": ["phpcompatibility/php-compatibility"],
+            "/srv/www/phpcs/CodeSniffer/Standards/PHPCompatibilityParagonie/": ["phpcompatibility/phpcompatibility-paragonie"],
+            "/srv/www/phpcs/CodeSniffer/Standards/PHPCompatibilityWP/": ["phpcompatibility/phpcompatibility-wp"]
         }
     },
     "config": {

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -22,7 +22,7 @@ start_seconds="$(date +%s)"
 apt_package_install_list=(
   # Please avoid apostrophes in these comments - they break vim syntax
   # highlighting.
-  # 
+  #
   software-properties-common
 
   # PHP7
@@ -274,7 +274,7 @@ package_install() {
 
   # Clean up apt caches
   apt-get clean
-  
+
   return 0
 }
 
@@ -441,7 +441,7 @@ nginx_setup() {
     mkdir "/etc/nginx/custom-sites/"
   fi
   rsync -rvzh --delete "/srv/config/nginx-config/sites/" "/etc/nginx/custom-sites/"
-  
+
   if [[ ! -d "/etc/nginx/custom-utilities" ]]; then
     mkdir "/etc/nginx/custom-utilities/"
   fi
@@ -507,9 +507,9 @@ mailhog_setup() {
 
   if [[ ! -e /usr/local/bin/mailhog ]]; then
     export GOPATH=/home/vagrant/gocode
-    
+
     echo " * Fetching MailHog and MHSendmail"
-    
+
     noroot mkdir -p /home/vagrant/gocode
     noroot /usr/local/go/bin/go get github.com/mailhog/MailHog
     noroot /usr/local/go/bin/go get github.com/mailhog/mhsendmail
@@ -647,7 +647,7 @@ php_codesniff() {
   ln -sf "/srv/www/phpcs/bin/phpcs" "/usr/local/bin/phpcs"
 
   # Install the standards in PHPCS
-  phpcs --config-set installed_paths ./CodeSniffer/Standards/WordPress/,./CodeSniffer/Standards/VIP-Coding-Standards/,./CodeSniffer/Standards/PHPCompatibility/
+  phpcs --config-set installed_paths ./CodeSniffer/Standards/WordPress/,./CodeSniffer/Standards/VIP-Coding-Standards/,./CodeSniffer/Standards/PHPCompatibility/,./CodeSniffer/Standards/PHPCompatibilityParagonie/,./CodeSniffer/Standards/PHPCompatibilityWP/
   phpcs --config-set default_standard WordPress-Core
   phpcs -i
 }


### PR DESCRIPTION
## Summary:

<!-- what does it add/fix/change/remove? -->
Adds PHPCompatibilityWP PHPCS Standard

## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant **v2.2.2** and VirtualBox **v5.2.18** on **MacOS v10.14.2**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [ ] I've updated the changelog
 - [ ] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->

PS: Sorry for the whitespace diffs, I'm not sure how to remove those once committed.