### PR TITLE
Apt-get adjustments

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -251,9 +251,9 @@ package_install() {
     apt-key add /vagrant/config/apt-keys/mariadb.key
   fi
 
-  if [[ ! $( apt-key list | grep 'packagecloud ops') ]]; then
+  if [[ ! $( apt-key list | grep 'git-lfs') ]]; then
     # Apply the PackageCloud signing key which signs git lfs
-    echo "Applying the PackageCloud signing key..."
+    echo "Applying the PackageCloud Git-LFS signing key..."
     apt-key add /vagrant/config/apt-keys/git-lfs.key
   fi
 
@@ -263,7 +263,7 @@ package_install() {
 
   # Install required packages
   echo "Installing apt-get packages..."
-  if ! apt-get -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confnew install --fix-missing --fix-broken ${apt_package_install_list[@]}; then
+  if ! apt-get -y --force-yes -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confnew install --fix-missing --fix-broken ${apt_package_install_list[@]}; then
     apt-get clean
     return 1
   fi


### PR DESCRIPTION
## Summary:

Changes the git-lfs apt key check and adds the --force-yes parameter to the apt-get install

This should add the key for existing users not just fresh installs, though it's unlikely they'll see any difference as the packagecloud issue doesn't impact them

## Checks

<!--  Have you: -->
 - [ ] I've tested this PR with Vagrant **vXX** and VirtualBox **vXX** on **Operating System**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [ ] I've updated the changelog
 - [ ] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
