### PR TITLE
Optional db backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ permalink: /docs/en-US/changelog/
 
  * Updated PHPMemcachedadmin from v1.2.2.1 to v1.2.3
  * A new `db_backup` option was added to `vvv-custom.yml`
+ * A new `db_restore` option was added to skip the initial import
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ title: Changelog
 permalink: /docs/en-US/changelog/
 ---
 
+## 2.5.0 ( January 2019 )
+
+### Enhancements
+
+ * Updated PHPMemcachedadmin from v1.2.2.1 to v1.2.3
+ * A new `db_backup` option was added to `vvv-custom.yml`
+
+### Bug Fixes
+
+ * Updated the GPG key for packagecloud.io
+
+
 ## 2.4.0 ( 2018 October 2th )
 
 ### Enhancements

--- a/config/homebin/db_backup
+++ b/config/homebin/db_backup
@@ -1,13 +1,31 @@
 #!/bin/bash
 #
-# Create individual SQL files for each database. These files
-# are imported automatically during an initial provision if
-# the databases exist per the import-sql.sh process.
-echo "Performing Database Backups"
-mysql --user="root" --password="root" -e 'show databases' | \
-grep -v -F "information_schema" | \
-grep -v -F "performance_schema" | \
-grep -v -F "mysql" | \
-grep -v -F "test" | \
-grep -v -F "Database" | \
-while read dbname; do mysqldump -uroot -proot "$dbname" > /srv/database/backups/"$dbname".sql && echo "Database $dbname backed up..."; done
+
+# First lets check if backups are turned on or off
+
+VVV_CONFIG=/vagrant/vvv-config.yml
+if [[ -f /vagrant/vvv-custom.yml ]]; then
+	VVV_CONFIG=/vagrant/vvv-custom.yml
+fi
+
+local run_backups=`cat ${VVV_CONFIG} | shyaml get-value general.db_backup 2> /dev/null`
+
+if [[ $run_backups != "False" ]] then;
+
+	# Create individual SQL files for each database. These files
+	# are imported automatically during an initial provision if
+	# the databases exist per the import-sql.sh process.
+	mkdir -p /srv/database/backups
+	echo "Performing Database Backups"
+	mysql --user="root" --password="root" -e 'show databases' | \
+	grep -v -F "information_schema" | \
+	grep -v -F "performance_schema" | \
+	grep -v -F "mysql" | \
+	grep -v -F "test" | \
+	grep -v -F "Database" | \
+	while read dbname;
+	do
+		echo "Backing up Database $dbname..."
+		mysqldump -uroot -proot "$dbname" > /srv/database/backups/"$dbname".sql && echo "Database $dbname backed up...";
+	done
+fi

--- a/config/homebin/db_backup
+++ b/config/homebin/db_backup
@@ -8,9 +8,10 @@ if [[ -f /vagrant/vvv-custom.yml ]]; then
 	VVV_CONFIG=/vagrant/vvv-custom.yml
 fi
 
-local run_backups=`cat ${VVV_CONFIG} | shyaml get-value general.db_backup 2> /dev/null`
+run_backups=`cat ${VVV_CONFIG} | shyaml get-value general.db_backup 2> /dev/null`
 
-if [[ $run_backups != "False" ]] then;
+if [[ $run_backups != "False" ]]
+then
 
 	# Create individual SQL files for each database. These files
 	# are imported automatically during an initial provision if

--- a/database/import-sql.sh
+++ b/database/import-sql.sh
@@ -23,9 +23,10 @@ if [[ -f /vagrant/vvv-custom.yml ]]; then
 	VVV_CONFIG=/vagrant/vvv-custom.yml
 fi
 
-local run_restore=`cat ${VVV_CONFIG} | shyaml get-value general.db_restore 2> /dev/null`
+run_restore=`cat ${VVV_CONFIG} | shyaml get-value general.db_restore 2> /dev/null`
 
-if [[ $run_restore == "False" ]] then;
+if [[ $run_restore == "False" ]]
+then
 	echo "Skipping DB import script\n"
 	exit;
 fi

--- a/database/import-sql.sh
+++ b/database/import-sql.sh
@@ -18,6 +18,18 @@
 #
 # Let's begin...
 
+VVV_CONFIG=/vagrant/vvv-config.yml
+if [[ -f /vagrant/vvv-custom.yml ]]; then
+	VVV_CONFIG=/vagrant/vvv-custom.yml
+fi
+
+local run_restore=`cat ${VVV_CONFIG} | shyaml get-value general.db_restore 2> /dev/null`
+
+if [[ $run_restore == "False" ]] then;
+	echo "Skipping DB import script\n"
+	exit;
+fi
+
 # Move into the newly mapped backups directory, where mysqldump(ed) SQL files are stored
 printf "\nStart MariaDB Database Import\n"
 cd /srv/database/backups/

--- a/provision/phpcs/composer.json
+++ b/provision/phpcs/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "oomphinc/composer-installers-extender": "^1.1",
         "wp-coding-standards/wpcs": "*",
-        "automattic/vipwpcs": "dev-master",
+        "automattic/vipwpcs": "*",
         "phpcompatibility/php-compatibility": "*",
         "phpcompatibility/phpcompatibility-paragonie": "*",
         "phpcompatibility/phpcompatibility-wp": "*"

--- a/vvv-config.yml
+++ b/vvv-config.yml
@@ -91,3 +91,5 @@ vm_config:
 general:
   # Backup the databases to the database/backups subfolder on halt/suspend/destroy, set to false to disable
   db_backup: true
+  # Import the databases if they're missing from backups
+  db_restore: true

--- a/vvv-config.yml
+++ b/vvv-config.yml
@@ -7,7 +7,11 @@
 
 #
 # IMPORTANT, if you change this file, you have to reprovision,  no exceptions
+# Do this by running either this command:
 # vagrant reload --provision
+# 
+# Or, if your machine is already turned on:
+# vagrant provision
 #
 
 # These are your websites, and their names map on to the folders they're
@@ -64,11 +68,12 @@ utilities:
     - phpmyadmin # Web based database client
     - webgrind # PHP Debugging
     - trusted-hosts # GitHub etc
-    - tls-ca # SSL
+    - tls-ca # SSL/TLS certificates
     #- php56
     #- php70
     #- php71
     #- php72
+    #- php73
 
 # vm_config controls how Vagrant provisions the virtual machine, and can be used to
 # increase the memory given to VVV and the number of CPU cores. For WP core development
@@ -81,3 +86,8 @@ vm_config:
   memory: 2048
   cores: 2
   # provider: vmware_workstation
+
+# General VVV options
+general:
+  # Backup the databases to the database/backups subfolder on halt/suspend/destroy, set to false to disable
+  db_backup: true


### PR DESCRIPTION
## Summary:

Database backups take a long time for some people, so this provides an easier method of disabling them.

It also makes a handful of other tweaks, updating the `vvv-config.yaml` and changelog to surface the changes, a slightly more verbose backup script, and a tweak to the VIP Coding standard PHPCS inclusion

## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant **vXX** and VirtualBox **vXX** on **Operating System**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [x] I've updated the changelog
 - [x] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
