### PR TITLE
built mailhog

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -475,13 +475,16 @@ Vagrant.configure("2") do |config|
   # Note that if you find yourself using a Customfile for anything crazy or specifying
   # different provisioning, then you may want to consider a new Vagrantfile entirely.
   if File.exists?(File.join(vagrant_dir,'Customfile')) then
+    puts "Running Custom Vagrant file with additional vagrant configs at #{File.join(vagrant_dir,'Customfile')}\n\n"
     eval(IO.read(File.join(vagrant_dir,'Customfile')), binding)
+    puts "Finished running Custom Vagrant file with additional vagrant configs, resuming normal vagrantfile execution\n\n"
   end
 
   vvv_config['sites'].each do |site, args|
     if args['allow_customfile'] then
       paths = Dir[File.join(args['local_dir'], '**', 'Customfile')]
       paths.each do |file|
+        puts "Running additional site vagrant customfile at #{file}\n\n"
         eval(IO.read(file), binding)
       end
     end

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -504,12 +504,12 @@ mailhog_setup() {
 
   if [[ ! -e /usr/local/bin/mailhog ]]; then
     echo " * Installing MailHog"
-    curl --silent -o /usr/local/bin/mailhog https://github.com/mailhog/MailHog/releases/download/v1.0.0/MailHog_linux_amd64
+    curl --silent -L -o /usr/local/bin/mailhog https://github.com/mailhog/MailHog/releases/download/v1.0.0/MailHog_linux_amd64
     chmod +x /usr/local/bin/mailhog
   fi
   if [[ ! -e /usr/local/bin/mhsendmail ]]; then
     echo " * Installing MHSendmail"
-    curl --silent -o /usr/local/bin/mhsendmail https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64
+    curl --silent -L -o /usr/local/bin/mhsendmail https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64
     chmod +x /usr/local/bin/mhsendmail
   fi
 

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -334,7 +334,8 @@ tools_install() {
   # COMPOSER
   #
   # Install Composer if it is not yet available.
-  if [[ ! -n "$(noroot composer --version --no-ansi | grep 'Composer version')" ]]; then
+  exists_composer="$(which composer)"
+  if [[ "/usr/local/bin/composer" != "${exists_composer}" ]]; then
     echo "Installing Composer..."
     curl -sS "https://getcomposer.org/installer" | php
     chmod +x "composer.phar"

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -357,6 +357,21 @@ tools_install() {
     COMPOSER_HOME=/usr/local/src/composer noroot composer --no-ansi global update --no-progress --no-interaction
   fi
 
+
+  function install_grunt() {
+    echo "Installing Grunt CLI"
+    npm install -g grunt-cli
+    hack_avoid_gyp_errors & npm install -g grunt-sass; touch /tmp/stop_gyp_hack
+    npm install -g grunt-cssjanus
+    npm install -g grunt-rtlcss
+  }
+  function update_grunt() {
+    echo "Updating Grunt CLI"
+    npm update -g grunt-cli
+    hack_avoid_gyp_errors & npm update -g grunt-sass; touch /tmp/stop_gyp_hack
+    npm update -g grunt-cssjanus
+    npm update -g grunt-rtlcss
+  }
   # Grunt
   #
   # Install or Update Grunt based on current state.  Updates are direct
@@ -378,18 +393,11 @@ tools_install() {
     done
     rm /tmp/stop_gyp_hack
   }
-  if [[ "$(grunt --version)" ]]; then
-    echo "Updating Grunt CLI"
-    npm update -g grunt-cli
-    hack_avoid_gyp_errors & npm update -g grunt-sass; touch /tmp/stop_gyp_hack
-    npm update -g grunt-cssjanus
-    npm update -g grunt-rtlcss
+  exists_grunt="$(which grunt)"
+  if [[ "/usr/bin/grunt" != "${exists_grunt}" ]]; then
+    install_grunt
   else
-    echo "Installing Grunt CLI"
-    npm install -g grunt-cli
-    hack_avoid_gyp_errors & npm install -g grunt-sass; touch /tmp/stop_gyp_hack
-    npm install -g grunt-cssjanus
-    npm install -g grunt-rtlcss
+    update_grunt
   fi
   chown -R vagrant:vagrant /usr/lib/node_modules/
 

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -7,7 +7,7 @@
 # or `vagrant reload` are used. It provides all of the default packages and
 # configurations included with Varying Vagrant Vagrants.
 
-source provision-network-functions.sh
+source /vagrant/provision/provision-network-functions.sh
 
 # By storing the date now, we can calculate the duration of provisioning at the
 # end of this script.

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -7,6 +7,8 @@
 # or `vagrant reload` are used. It provides all of the default packages and
 # configurations included with Varying Vagrant Vagrants.
 
+export DEBIAN_FRONTEND=noninteractive
+
 source /vagrant/provision/provision-network-functions.sh
 
 # By storing the date now, we can calculate the duration of provisioning at the
@@ -502,11 +504,13 @@ mailhog_setup() {
 
   if [[ ! -e /usr/local/bin/mailhog ]]; then
     echo " * Installing MailHog"
-    curl -o /usr/local/bin/mailhog https://github.com/mailhog/MailHog/releases/download/v1.0.0/MailHog_linux_amd64
+    curl --silent -o /usr/local/bin/mailhog https://github.com/mailhog/MailHog/releases/download/v1.0.0/MailHog_linux_amd64
+    chmod +x /usr/local/bin/mailhog
   fi
   if [[ ! -e /usr/local/bin/mhsendmail ]]; then
     echo " * Installing MHSendmail"
-    curl -o /usr/local/bin/mhsendmail https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64
+    curl --silent -o /usr/local/bin/mhsendmail https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64
+    chmod +x /usr/local/bin/mhsendmail
   fi
 
   if [[ ! -e /etc/init/mailhog.conf ]]; then
@@ -631,7 +635,7 @@ php_codesniff() {
   echo -e "\nInstall/Update PHP_CodeSniffer (phpcs), see https://github.com/squizlabs/PHP_CodeSniffer"
   echo -e "\nInstall/Update WordPress-Coding-Standards, sniffs for PHP_CodeSniffer, see https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards"
   cd /vagrant/provision/phpcs
-  noroot composer update --no-ansi --no-autoloader
+  noroot composer update --no-ansi --no-autoloader --no-progress
 
   # Link `phpcbf` and `phpcs` to the `/usr/local/bin` directory
   ln -sf "/srv/www/phpcs/bin/phpcbf" "/usr/local/bin/phpcbf"


### PR DESCRIPTION
## Summary:

Currently MailHog and MHSendmail are built from source, requiring the golang runtime

This removes the golang dependency and downloads the MHSendmail and MailHog built binaries from GitHub instead, which should improve reliability and speed up provisioning.

It also makes a handful of other tweaks to make things a little more verbose, and fixes a sourcing bug

## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant **v2.2.2** and VirtualBox **v6.0** on **MacOS Mojave**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [ ] I've updated the changelog
 - [x] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
