### PR TITLE
Update provision/provision-site.sh to fix WordPress Meta Environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ permalink: /docs/en-US/changelog/
 ### Bug Fixes
 
  * Updated the GPG key for packagecloud.io
-
+ * Updated the site provisioning script to fix WordPress Meta Environment failure (WordPress/meta-environment#122)
 
 ## 2.4.0 ( 2018 October 2th )
 

--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -123,7 +123,7 @@ if [[ false == "${SKIP_PROVISIONING}" ]]; then
       vvv_provision_site_nginx $SITE "${VM_DIR}/vvv-nginx.conf"
     else
       NGINX_CONFIGS=$(find ${VM_DIR} -maxdepth 3 -name 'vvv-nginx.conf');
-      if [[ -z $results ]] ; then
+      if [[ -z $NGINX_CONFIGS ]] ; then
         echo "Warning: No nginx config was found, VVV will not know how to serve this site"
       else
         for SITE_CONFIG_FILE in $NGINX_CONFIGS; do


### PR DESCRIPTION
## Summary:

Previous commits have broken the WordPress-Meta-Environment (seemingly introduced in b13c455f). Reference to a variable that doesn't exist needs to be renamed to the correct variable name.

Fixes WordPress/meta-environment#122

## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant **v2.2.3** and VirtualBox **v5.2.18_Ubuntu r123745** on **Ubuntu 18.10**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [x] I've updated the changelog
 - [x] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
