### PR TITLE
Site provisioner optimisations and TLS keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,24 @@ permalink: /docs/en-US/changelog/
 
 ## 2.5.0 ( January 2019 )
 
+2.5 Brings a major bug fix, and some performance improvements to provisioning
+
 ### Enhancements
 
  * Updated PHPMemcachedadmin from v1.2.2.1 to v1.2.3
  * A new `db_backup` option was added to `vvv-custom.yml`
  * A new `db_restore` option was added to skip the initial import
+ * MailHog is now installed from a prebuilt binary instead of being built from source, speeding up initial provision
+ * VVV will now explicitly check for vvv-hosts in the .vvv and provision subfolders and skip searching 3 folders down if they're found
+ * Additional warnings and messages were added to aid with debugging site provisioners
+ * VVV will warn the user if no hosts are defined for a site, or if no folder exists for a site
+ * Skipping provisioning on a site will now make the site provisioner abort earlier
+ * Site provisioners no longer need to use nginx template config files to add TLS keys, they can use `{vvv_tls_cert}` and `{vvv_tls_key}` in `vvv-nginx.conf`
+
+### Deprecations
+
+ * Loading vvv-hosts is now skipped if hosts are defined in the VVV configuration file
+ * GoLang was removed from the provisioner
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ permalink: /docs/en-US/changelog/
 
  * Updated the GPG key for packagecloud.io
  * Updated the site provisioning script to fix WordPress Meta Environment failure (WordPress/meta-environment#122)
+ * Continue if the vagrant up and reload triggers failed
 
 ## 2.4.0 ( 2018 October 2th )
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -593,6 +593,7 @@ Vagrant.configure("2") do |config|
   config.trigger.after :up do |trigger|
     trigger.name = "VVV Post-Up"
     trigger.run_remote = { inline: "/vagrant/config/homebin/vagrant_up" }
+    trigger.on_error = :continue
   end
   config.trigger.before :reload do |trigger|
     trigger.name = "VVV Pre-Reload"
@@ -602,6 +603,7 @@ Vagrant.configure("2") do |config|
   config.trigger.after :reload do |trigger|
     trigger.name = "VVV Post-Reload"
     trigger.run_remote = { inline: "/vagrant/config/homebin/vagrant_up" }
+    trigger.on_error = :continue
   end
   config.trigger.before :halt do |trigger|
     trigger.name = "VVV Pre-Halt"

--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -80,16 +80,16 @@ function vvv_provision_site_nginx() {
 }
 
 function vvv_provision_hosts_file() {
-  hostfile = $1
-  while read hostfile; do
+  HOSTFILE=$1
+  while read HOSTFILE; do
     while IFS='' read -r line || [ -n "$line" ]; do
       if [[ "#" != ${line:0:1} ]]; then
         if [[ -z "$(grep -q "^127.0.0.1 $line$" /etc/hosts)" ]]; then
           echo "127.0.0.1 $line # vvv-auto" >> "/etc/hosts"
-          echo " * Added $line from $hostfile"
+          echo " * Added $line from $HOSTFILE"
         fi
       fi
-    done < "$hostfile"
+    done < "$HOSTFILE"
   done
 }
 

--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -64,6 +64,14 @@ function vvv_provision_site_nginx() {
   sed -i "s#{vvv_site_name}#$SITE#" "/etc/nginx/custom-sites/${DEST_NGINX_FILE}"
   sed -i "s#{vvv_hosts}#$VVV_HOSTS#" "/etc/nginx/custom-sites/${DEST_NGINX_FILE}"
   sed -i "s#{upstream}#$NGINX_UPSTREAM#" "/etc/nginx/custom-sites/${DEST_NGINX_FILE}"
+  
+  if [ -n "$(type -t is_utility_installed)" ] && [ "$(type -t is_utility_installed)" = function ] && `is_utility_installed core tls-ca`; then
+    sed -i "s#{vvv_tls_cert}#ssl_certificate /vagrant/certificates/${VVV_SITE_NAME}/dev.crt;#" "/etc/nginx/custom-sites/${DEST_NGINX_FILE}"
+    sed -i "s#{vvv_tls_key}#ssl_certificate_key /vagrant/certificates/${VVV_SITE_NAME}/dev.key;#" "/etc/nginx/custom-sites/${DEST_NGINX_FILE}"
+  else
+    sed -i "s#{vvv_tls_cert}##" "/etc/nginx/custom-sites/${DEST_NGINX_FILE}"
+    sed -i "s#{vvv_tls_key}##" "/etc/nginx/custom-sites/${DEST_NGINX_FILE}"
+  fi
 
   # Resolve relative paths since not supported in Nginx root.
   while grep -sqE '/[^/][^/]*/\.\.' "/etc/nginx/custom-sites/${DEST_NGINX_FILE}"; do
@@ -71,8 +79,23 @@ function vvv_provision_site_nginx() {
   done
 }
 
+function vvv_provision_hosts_file() {
+  hostfile = $1
+  while read hostfile; do
+    while IFS='' read -r line || [ -n "$line" ]; do
+      if [[ "#" != ${line:0:1} ]]; then
+        if [[ -z "$(grep -q "^127.0.0.1 $line$" /etc/hosts)" ]]; then
+          echo "127.0.0.1 $line # vvv-auto" >> "/etc/hosts"
+          echo " * Added $line from $hostfile"
+        fi
+      fi
+    done < "$hostfile"
+  done
+}
+
 if [[ true == $SKIP_PROVISIONING ]]; then
-    REPO=false
+  echo "Skipping provisioning of ${SITE}"
+  return
 fi
 
 if [[ false != "${REPO}" ]]; then
@@ -94,69 +117,87 @@ else
   fi
 fi
 
-if [[ false == "${SKIP_PROVISIONING}" ]]; then
-  
-  if [[ -d ${VM_DIR} ]]; then
-    # Look for site setup scripts
-    if [[ -f "${VM_DIR}/.vvv/vvv-init.sh" ]]; then
-      ( cd "${VM_DIR}/.vvv" && source vvv-init.sh )
-    elif [[ -f "${VM_DIR}/provision/vvv-init.sh" ]]; then
-      ( cd "${VM_DIR}/provision" && source vvv-init.sh )
-    elif [[ -f "${VM_DIR}/vvv-init.sh" ]]; then
-      ( cd "${VM_DIR}" && source vvv-init.sh )
+if [[ -d ${VM_DIR} ]]; then
+  # Look for site setup scripts
+  if [[ -f "${VM_DIR}/.vvv/vvv-init.sh" ]]; then
+    ( cd "${VM_DIR}/.vvv" && source vvv-init.sh )
+  elif [[ -f "${VM_DIR}/provision/vvv-init.sh" ]]; then
+    ( cd "${VM_DIR}/provision" && source vvv-init.sh )
+  elif [[ -f "${VM_DIR}/vvv-init.sh" ]]; then
+    ( cd "${VM_DIR}" && source vvv-init.sh )
+  else
+    echo "Warning: A site provisioner was not found at .vvv/vvv-init.conf provision/vvv-init.conf or vvv-init.conf, searching 3 folders down, please be patient..."
+    SITE_INIT_SCRIPTS=$(find ${VM_DIR} -maxdepth 3 -name 'vvv-init.conf');
+    if [[ -z $SITE_INIT_SCRIPTS ]] ; then
+      echo "Warning: No site provisioner was found, VVV could not perform any scripted setup that might install software for this site"
     else
-      find ${VM_DIR} -maxdepth 3 -name 'vvv-init.sh' -print0 | while read -d $'\0' SITE_CONFIG_FILE; do
-        DIR="$(dirname "$SITE_CONFIG_FILE")"
-        (
-        cd "$DIR"
-        source vvv-init.sh
-        )
+      for SITE_INIT_SCRIPT in $SITE_INIT_SCRIPTS; do
+        DIR="$(dirname "$SITE_INIT_SCRIPT")"
+        ( cd "${DIR}" &&  source vvv-init.sh )
       done
     fi
+  fi
 
-    # Look for Nginx vhost files, symlink them into the custom sites dir
-    if [[ -f "${VM_DIR}/.vvv/vvv-nginx.conf" ]]; then
-      vvv_provision_site_nginx $SITE "${VM_DIR}/.vvv/vvv-nginx.conf"
-    elif [[ -f "${VM_DIR}/provision/vvv-nginx.conf" ]]; then
-      vvv_provision_site_nginx $SITE "${VM_DIR}/provision/vvv-nginx.conf"
-    elif [[ -f "${VM_DIR}/vvv-nginx.conf" ]]; then
-      vvv_provision_site_nginx $SITE "${VM_DIR}/vvv-nginx.conf"
+  # Look for Nginx vhost files, symlink them into the custom sites dir
+  if [[ -f "${VM_DIR}/.vvv/vvv-nginx.conf" ]]; then
+    vvv_provision_site_nginx $SITE "${VM_DIR}/.vvv/vvv-nginx.conf"
+  elif [[ -f "${VM_DIR}/provision/vvv-nginx.conf" ]]; then
+    vvv_provision_site_nginx $SITE "${VM_DIR}/provision/vvv-nginx.conf"
+  elif [[ -f "${VM_DIR}/vvv-nginx.conf" ]]; then
+    vvv_provision_site_nginx $SITE "${VM_DIR}/vvv-nginx.conf"
+  else
+    echo "Warning: An nginx config was not found at .vvv/vvv-nginx.conf provision/vvv-nginx.conf or vvv-nginx.conf, searching 3 folders down, please be patient..."
+    NGINX_CONFIGS=$(find ${VM_DIR} -maxdepth 3 -name 'vvv-nginx.conf');
+    if [[ -z $NGINX_CONFIGS ]] ; then
+      echo "Warning: No nginx config was found, VVV will not know how to serve this site"
     else
-      NGINX_CONFIGS=$(find ${VM_DIR} -maxdepth 3 -name 'vvv-nginx.conf');
-      if [[ -z $NGINX_CONFIGS ]] ; then
-        echo "Warning: No nginx config was found, VVV will not know how to serve this site"
+      for SITE_CONFIG_FILE in $NGINX_CONFIGS; do
+        vvv_provision_site_nginx $SITE $SITE_CONFIG_FILE
+      done
+    fi
+  fi
+
+  # Parse any vvv-hosts file located in the site repository for domains to
+  # be added to the virtual machine's host file so that it is self aware.
+  #
+  # Domains should be entered on new lines.
+  echo "Adding domains to the virtual machine's /etc/hosts file..."
+  hosts=`cat ${VVV_CONFIG} | shyaml get-values sites.${SITE_ESCAPED}.hosts 2> /dev/null`
+  if [ ${#hosts[@]} -eq 0 ]; then
+    echo "No hosts were found in the VVV config, falling back to vvv-hosts"
+    if [[ -f "${VM_DIR}/.vvv/vvv-hosts" ]]; then
+      echo "Found a .vvv/vvv-hosts file"
+      vvv_provision_hosts_file $SITE "${VM_DIR}/.vvv/vvv-hosts"
+    elif [[ -f "${VM_DIR}/provision/vvv-hosts" ]]; then
+      echo "Found a provision/vvv-hosts file"
+      vvv_provision_hosts_file $SITE "${VM_DIR}/provision/vvv-hosts"
+    elif [[ -f "${VM_DIR}/vvv-hosts" ]]; then
+      echo "Found a vvv-hosts file"
+      vvv_provision_hosts_file $SITE "${VM_DIR}/vvv-hosts"
+    else
+      echo "Searching subfolders 4 levels down for a vvv-hosts file ( this can be skipped by using ./vvv-hosts, .vvv/vvv-hosts, or provision/vvv-hosts"
+      HOST_FILES=$(find ${VM_DIR} -maxdepth 4 -name 'vvv-hosts');
+      if [[ -z $HOST_FILES ]] ; then
+        echo "Warning: No vvv-hosts file was found, and no hosts were defined in the vvv config, this site may be inaccessible"
       else
-        for SITE_CONFIG_FILE in $NGINX_CONFIGS; do
-          vvv_provision_site_nginx $SITE $SITE_CONFIG_FILE
+        for HOST_FILE in $HOST_FILES; do
+          vvv_provision_hosts_file $HOST_FILE
         done
       fi
     fi
-
-    # Parse any vvv-hosts file located in the site repository for domains to
-    # be added to the virtual machine's host file so that it is self aware.
-    #
-    # Domains should be entered on new lines.
-    echo "Adding domains to the virtual machine's /etc/hosts file..."
-    find ${VM_DIR} -maxdepth 4 -name 'vvv-hosts' | \
-    while read hostfile; do
-      while IFS='' read -r line || [ -n "$line" ]; do
-        if [[ "#" != ${line:0:1} ]]; then
-          if [[ -z "$(grep -q "^127.0.0.1 $line$" /etc/hosts)" ]]; then
-            echo "127.0.0.1 $line # vvv-auto" >> "/etc/hosts"
-            echo " * Added $line from $hostfile"
-          fi
-        fi
-      done < "$hostfile"
-    done
-
+  else
+    echo "Adding hosts from the VVV config entry"
     for line in `cat ${VVV_CONFIG} | shyaml get-values sites.${SITE_ESCAPED}.hosts 2> /dev/null`; do
       if [[ -z "$(grep -q "^127.0.0.1 $line$" /etc/hosts)" ]]; then
-      echo "127.0.0.1 $line # vvv-auto" >> "/etc/hosts"
-      echo " * Added $line from ${VVV_CONFIG}"
-    fi
+        echo "127.0.0.1 $line # vvv-auto" >> "/etc/hosts"
+        echo " * Added $line from ${VVV_CONFIG}"
+      fi
     done
-
-    service nginx restart
   fi
+
+  service nginx restart
+else
+  echo "Error: The ${VM_DIR} folder does not exist, and no repo was specified in the config file, there is nothing to provision for this site!"
 fi
+
 


### PR DESCRIPTION
## Summary:

This attempts to optimise site provisioning by doing several things:

 - Adds the `{vvv_tls_cert}` and `{vvv_tls_key}` so that site provisioners don't have to always copy paste the same chunk of code in their provisioners
 - Optimise the `vvv-hosts` part so that it doesn't look for them if their are hosts in the config, and so that it then checks common places first
 - Massively bumps up the number of warnings and error messages that could be shown for cases when things go wrong that weren't handled previously
 - Moves hosts file parsing into its own function
 - Simplified skip provision by returning early so that half the file can be moved over 1 indent for easier reading

## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant **v2.2** and VirtualBox **v6** on **MacOS Mojave**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [x] I've updated the changelog
 - [x] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
