### PR TITLE
Support the Tideways subdomain addition to hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ permalink: /docs/en-US/changelog/
  * VVV will warn the user if no hosts are defined for a site, or if no folder exists for a site
  * Skipping provisioning on a site will now make the site provisioner abort earlier
  * Site provisioners no longer need to use nginx template config files to add TLS keys, they can use `{vvv_tls_cert}` and `{vvv_tls_key}` in `vvv-nginx.conf`
+ * `tideways.vvv.test` is now registered if the experimental tideways xhgui utility is present
 
 ### Deprecations
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -127,7 +127,7 @@ if ! vvv_config['hosts'].kind_of? Hash then
   vvv_config['hosts'] = Array.new
 end
 
-vvv_config['hosts'] += ['vvv.dev']
+vvv_config['hosts'] += ['vvv.dev'] # Deprecated
 vvv_config['hosts'] += ['vvv.test']
 vvv_config['hosts'] += ['vvv.local']
 vvv_config['hosts'] += ['vvv.localhost']
@@ -539,6 +539,9 @@ Vagrant.configure("2") do |config|
       utilities = Hash.new
     end
     utilities.each do |utility|
+        if utility == 'tideways' then
+          vvv_config['hosts'] += ['tideways.vvv.test']
+        end
         config.vm.provision "utility-#{name}-#{utility}",
           type: "shell",
           path: File.join( "provision", "provision-utility.sh" ),

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -102,6 +102,16 @@ apt_package_install_list=(
 
 ### FUNCTIONS
 
+is_utility_installed() {
+  local utilities=`cat ${VVV_CONFIG} | shyaml get-values utilities.${1} 2> /dev/null`
+  for utility in ${utilities}; do
+    if [[ "${utility}" == "${2}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 git_ppa_check() {
   # git
   #
@@ -688,6 +698,9 @@ cleanup_vvv(){
   echo "127.0.0.1 vvv.local # vvv-auto" >> "/etc/hosts"
   echo "127.0.0.1 vvv.localhost # vvv-auto" >> "/etc/hosts"
   echo "127.0.0.1 vvv.test # vvv-auto" >> "/etc/hosts"
+  if [[ is_utility_installed "tideways" ]]; then
+    echo "127.0.0.1 tideways.vvv.test # vvv-auto" >> "/etc/hosts"
+  fi
   mv /tmp/hosts /etc/hosts
 }
 

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -698,7 +698,7 @@ cleanup_vvv(){
   echo "127.0.0.1 vvv.local # vvv-auto" >> "/etc/hosts"
   echo "127.0.0.1 vvv.localhost # vvv-auto" >> "/etc/hosts"
   echo "127.0.0.1 vvv.test # vvv-auto" >> "/etc/hosts"
-  if [[ is_utility_installed "tideways" ]]; then
+  if [[ `is_utility_installed "tideways"` ]]; then
     echo "127.0.0.1 tideways.vvv.test # vvv-auto" >> "/etc/hosts"
   fi
   mv /tmp/hosts /etc/hosts


### PR DESCRIPTION
## Summary:

Related to https://github.com/Varying-Vagrant-Vagrants/vvv-utilities/pull/18 and @Mte90, this adds the `tideways.vvv.test` domain when a utility named tideways is active.

This means that the utility PR will need to:

 - Update the TLS CA to make sure a certificate for this domain gets generated
 - Update its nginx configuration to the new subdomain

Once this is done and merged in, we'll update the `vvv-config.yml` in the following release ( `2.5.2`? `2.6`? ) and advertise that it's available for testing

## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant **v2.2** and VirtualBox **v6** on **MacOS Mojave**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [x] I've updated the changelog
 - [x] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
