### PR TITLE
Fixes #1669

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ permalink: /docs/en-US/changelog/
  * Updated the GPG key for packagecloud.io
  * Updated the site provisioning script to fix WordPress Meta Environment failure (WordPress/meta-environment#122)
  * Continue if the vagrant up and reload triggers failed
+ * Nginx and MySQL restarting is no longer done via a provisioner, this fixes contributor day issues when using `--no-provision` leading to nginx and mysql being unavailable. This is done via the `config/homebin/vagrant_up` script
 
 ## 2.4.0 ( 2018 October 2th )
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -574,13 +574,6 @@ Vagrant.configure("2") do |config|
     config.vm.provision "post", type: "shell", path: File.join( "provision", "provision-post.sh" )
   end
 
-  # Always start MariaDB/MySQL on boot, even when not running the full provisioner
-  # (run: "always" support added in 1.6.0)
-  if vagrant_version >= "1.6.0"
-    config.vm.provision :shell, inline: "sudo service mysql restart", run: "always"
-    config.vm.provision :shell, inline: "sudo service nginx restart", run: "always"
-  end
-
   # Vagrant Triggers
   #
   # We run various scripts on Vagrant state changes like `vagrant up`, `vagrant halt`,

--- a/config/homebin/vagrant_up
+++ b/config/homebin/vagrant_up
@@ -11,3 +11,6 @@ if [[ -f /vagrant/config/homebin/vagrant_up_custom ]]; then
 	echo "Executing vagrant_up_custom"
 	/vagrant/config/homebin/vagrant_up_custom
 fi
+
+sudo service nginx restart
+sudo service mysql restart


### PR DESCRIPTION
## Summary:

Restart nginx in a trigger rather than a provisioner so that when a contributor day user uses `vagrant up --no-provision` it doesn't break things

## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant **v2.2** and VirtualBox **v6** on **MacOS Mojave**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [x] I've updated the changelog
 - [x] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
