### PR TITLE
Update WP_CORE_DIR and WP_TESTS_DIR after changes in vvv-config.yml

### DIFF
--- a/config/bash_profile
+++ b/config/bash_profile
@@ -39,9 +39,9 @@ fi
 
 # Set the WP_TESTS_DIR path directory so that we can use phpunit inside
 # plugins almost immediately.
-export WP_TESTS_DIR=/srv/www/wordpress-develop/public_html/tests/phpunit/
+export WP_TESTS_DIR=/srv/www/wordpress-trunk/public_html/tests/phpunit/
 # Set the WP_CORE_DIR path so phpunit tests are run against WP trunk
-export WP_CORE_DIR=/srv/www/wordpress-develop/public_html/src/
+export WP_CORE_DIR=/srv/www/wordpress-trunk/public_html/src/
 
 # add autocomplete for grunt
 eval "$(grunt --completion=bash)"

--- a/config/bash_profile
+++ b/config/bash_profile
@@ -39,9 +39,18 @@ fi
 
 # Set the WP_TESTS_DIR path directory so that we can use phpunit inside
 # plugins almost immediately.
-export WP_TESTS_DIR=/srv/www/wordpress-trunk/public_html/tests/phpunit/
+if [ -d "/srv/www/wordpress-trunk/public_html/tests/phpunit/" ]; then
+    export WP_TESTS_DIR=/srv/www/wordpress-trunk/public_html/tests/phpunit/
+elif [ -d "/srv/www/wordpress-develop/public_html/tests/phpunit/" ]; then
+    export WP_TESTS_DIR=/srv/www/wordpress-develop/public_html/tests/phpunit/
+fi
+
 # Set the WP_CORE_DIR path so phpunit tests are run against WP trunk
-export WP_CORE_DIR=/srv/www/wordpress-trunk/public_html/src/
+if [ -d "/srv/www/wordpress-trunk/public_html/src/" ]; then
+    export WP_CORE_DIR=/srv/www/wordpress-trunk/public_html/src/
+elif [ -d "/srv/www/wordpress-develop/public_html/src/" ]; then
+    export WP_CORE_DIR=/srv/www/wordpress-develop/public_html/src/
+fi
 
 # add autocomplete for grunt
 eval "$(grunt --completion=bash)"


### PR DESCRIPTION
## Summary:
This PR updates the `WP_CORE_DIR` and `WP_TESTS_DIR` variables after the changes made in vvv-config.yml (commit 67c4945ef23f5dfd544cb67f6bdf2e7df90fdf15)

The directory for the development installation changed from `/wordpress-develop` to `/wordpress-trunk`

## Checks

<!--  Have you: -->
 - [X] I've tested this PR with Vagrant **2.2.3** and VirtualBox **5.2.20** on **OSX**
 - [X] This PR is for the `develop` branch not the `master` branch
 - [ ] I've updated the changelog
 - [X] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
