### PR TITLE
Try to fix WIndows VBox version ???

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ permalink: /docs/en-US/changelog/
  * Added a `vagrant_provision` and `vagrant_provision_custom` script to the homebin folder that run post-provision
  * Improved the messaging to tell the user at the end of a `vagrant up` or `vagrant provision` that it was succesful
 
+### Bug Fixes
+
+ * Improved detection of VirtualBox path to avoid `???` version numbers in the VVV splash
+
 ## 2.5.1 ( 14th January 2019 )
 
 2.5 Brings a major bug fix, and some performance improvements to provisioning

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,15 +4,78 @@ Vagrant.require_version ">= 2.1.4"
 require 'yaml'
 require 'fileutils'
 
+def virtualbox_path()
+
+    if Vagrant::Util::Platform.windows? || Vagrant::Util::Platform.cygwin?
+        @vboxmanage_path = Vagrant::Util::Which.which("VBoxManage")
+
+        # On Windows, we use the VBOX_INSTALL_PATH environmental
+        # variable to find VBoxManage.
+        if !@vboxmanage_path && (ENV.key?("VBOX_INSTALL_PATH") ||
+          ENV.key?("VBOX_MSI_INSTALL_PATH"))
+
+          # Get the path.
+          path = ENV["VBOX_INSTALL_PATH"] || ENV["VBOX_MSI_INSTALL_PATH"]
+
+          # There can actually be multiple paths in here, so we need to
+          # split by the separator ";" and see which is a good one.
+          path.split(";").each do |single|
+            # Make sure it ends with a \
+            single += "\\" if !single.end_with?("\\")
+
+            # If the executable exists, then set it as the main path
+            # and break out
+            vboxmanage = "#{single}VBoxManage.exe"
+            if File.file?(vboxmanage)
+              @vboxmanage_path = Vagrant::Util::Platform.cygwin_windows_path(vboxmanage)
+              break
+            end
+          end
+        end
+
+        # If we still don't have one, try to find it using common locations
+        drive = ENV["SYSTEMDRIVE"] || "C:"
+        [
+          "#{drive}/Program Files/Oracle/VirtualBox",
+          "#{drive}/Program Files (x86)/Oracle/VirtualBox",
+          "#{ENV["PROGRAMFILES"]}/Oracle/VirtualBox"
+        ].each do |maybe|
+          path = File.join(maybe, "VBoxManage.exe")
+          if File.file?(path)
+            @vboxmanage_path = path
+            break
+          end
+        end
+        elsif Vagrant::Util::Platform.wsl?
+        if !Vagrant::Util::Platform.wsl_windows_access?
+          raise Vagrant::Errors::WSLVirtualBoxWindowsAccessError
+        end
+        @vboxmanage_path = Vagrant::Util::Which.which("VBoxManage") || Vagrant::Util::Which.which("VBoxManage.exe")
+        if !@vboxmanage_path
+          # If we still don't have one, try to find it using common locations
+          drive = "/mnt/c"
+          [
+            "#{drive}/Program Files/Oracle/VirtualBox",
+            "#{drive}/Program Files (x86)/Oracle/VirtualBox"
+          ].each do |maybe|
+            path = File.join(maybe, "VBoxManage.exe")
+            if File.file?(path)
+              @vboxmanage_path = path
+              break
+            end
+          end
+        end
+    end
+
+    # Fall back to hoping for the PATH to work out
+    @vboxmanage_path ||= "VBoxManage"
+    return vboxmanage_path
+end
 
 def virtualbox_version()
-    vboxmanage = Vagrant::Util::Which.which("VBoxManage") || Vagrant::Util::Which.which("VBoxManage.exe")
-    if vboxmanage != nil
-        s = Vagrant::Util::Subprocess.execute(vboxmanage, '--version')
-        return s.stdout.strip!
-    else
-        return 'unknown'
-    end
+    vboxmanage = virtualbox_path()
+    s = Vagrant::Util::Subprocess.execute(vboxmanage, '--version')
+    return s.stdout.strip!
 end
 
 vagrant_dir = File.expand_path(File.dirname(__FILE__))

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ require 'yaml'
 require 'fileutils'
 
 def virtualbox_path()
-
+    @vboxmanage_path = nil
     if Vagrant::Util::Platform.windows? || Vagrant::Util::Platform.cygwin?
         @vboxmanage_path = Vagrant::Util::Which.which("VBoxManage")
 
@@ -69,7 +69,7 @@ def virtualbox_path()
 
     # Fall back to hoping for the PATH to work out
     @vboxmanage_path ||= "VBoxManage"
-    return vboxmanage_path
+    return @vboxmanage_path
 end
 
 def virtualbox_version()


### PR DESCRIPTION
adds a virtualbox_path function to the vagrant file to help locate virtualbox on Windows

## Summary:

This tries to close #1753 by replacing the naive check for VBoxManage with the one Vagrant itself uses so that it works better on Windows. Currently it only works in Windows if `VBoxManage` is in `PATH` which isn't true for most users

## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant **v2.2.3** and VirtualBox **v6** on **MacOS**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [x] I've updated the changelog
 - [x] This PR is complete and ready for review
 

Still needs testing on Windows to confirm it does what it says, but I can confirm nothing is changed under MacOS
 <!-- don't forget to fill out the bolded parts -->
