### PR TITLE
Put the path in the splash screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ permalink: /docs/en-US/changelog/
  * Autoset the locale inside the virtual machine to avoid errors in the console
  * Added a `vagrant_provision` and `vagrant_provision_custom` script to the homebin folder that run post-provision
  * Improved the messaging to tell the user at the end of a `vagrant up` or `vagrant provision` that it was succesful
+ * The VVV install path is now in the splash screen, making it easier to debug GH issues
 
 ## 2.5.1 ( 14th January 2019 )
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -98,9 +98,9 @@ if show_logo then
 #{red}\\ V#{green}\\ V#{blue}\\ V / #{red}Varying #{green}Vagrant #{blue}Vagrants
 #{red} \\_/#{green}\\_/#{blue}\\_/  #{purple}v#{version}#{creset}-#{branch_c}#{git_or_zip}#{branch}
 
-#{yellow}Platform:   #{yellow}#{platform}
-#{green}Vagrant:    #{green}#{Vagrant::VERSION}
-#{blue}VirtualBox: #{blue}#{virtualbox_version()}
+#{yellow}Platform:     #{yellow}#{platform}
+#{green}Vagrant:      #{green}v#{Vagrant::VERSION},	#{blue}VirtualBox: #{blue}v#{virtualbox_version()}
+#{purple}VVV Path: "#{vagrant_dir}"
 
 #{docs}Docs:       #{url}https://varyingvagrantvagrants.org/
 #{docs}Contribute: #{url}https://github.com/varying-vagrant-vagrants/vvv

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -98,9 +98,9 @@ if show_logo then
 #{red}\\ V#{green}\\ V#{blue}\\ V / #{red}Varying #{green}Vagrant #{blue}Vagrants
 #{red} \\_/#{green}\\_/#{blue}\\_/  #{purple}v#{version}#{creset}-#{branch_c}#{git_or_zip}#{branch}
 
-#{yellow}Platform:     #{yellow}#{platform}
-#{green}Vagrant:      #{green}v#{Vagrant::VERSION},	#{blue}VirtualBox: #{blue}v#{virtualbox_version()}
-#{purple}VVV Path: "#{vagrant_dir}"
+#{yellow}Platform:   #{yellow}#{platform}
+#{green}Vagrant:    #{green}v#{Vagrant::VERSION},	#{blue}VirtualBox: #{blue}v#{virtualbox_version()}
+#{purple}VVV Path:   "#{vagrant_dir}"
 
 #{docs}Docs:       #{url}https://varyingvagrantvagrants.org/
 #{docs}Contribute: #{url}https://github.com/varying-vagrant-vagrants/vvv


### PR DESCRIPTION
## Summary:

closes #1750

rearranges the splash a little to fit in the install path, and puts v's before the version numbers. I moved the VBox version up onto the same line as the vagrant version so it occupies the same space

Before:

<img width="585" alt="Screenshot 2019-04-01 at 11 21 42" src="https://user-images.githubusercontent.com/58855/55320963-5fb0bf80-5470-11e9-87b5-b87d1130c66a.png">


After:

<img width="574" alt="Screenshot 2019-04-01 at 11 23 14" src="https://user-images.githubusercontent.com/58855/55321076-a7374b80-5470-11e9-8a0a-a6c1b87f0b1c.png">


## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant **vXX** and VirtualBox **v6** on **MacOS**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [x] I've updated the changelog
 - [x] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
