### PR TITLE
Post-up/Provision splash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ permalink: /docs/en-US/changelog/
  * Autoset the locale inside the virtual machine to avoid errors in the console
  * Added a `vagrant_provision` and `vagrant_provision_custom` script to the homebin folder that run post-provision
  * Improved the messaging to tell the user at the end of a `vagrant up` or `vagrant provision` that it was succesful
+ * Added friendly splashes at the end of vagrant up and provision to make it obvious to end users when they've finished
 
 ## 2.5.1 ( 14th January 2019 )
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -605,6 +605,10 @@ Vagrant.configure("2") do |config|
     trigger.run_remote = { inline: "/vagrant/config/homebin/vagrant_up" }
     trigger.on_error = :continue
   end
+  config.trigger.before :provision do |trigger|
+    trigger.info = "༼ つ ◕_◕ ༽つ Provisioning can take a few minutes, go make a cup of tea and sit back. If you only wanted to turn VVV on, use vagrant up"
+    trigger.on_error = :continue
+  end
   config.trigger.after :provision do |trigger|
     trigger.name = "VVV Post-Provision"
     trigger.run_remote = { inline: "/vagrant/config/homebin/vagrant_provision" }

--- a/config/homebin/vagrant_provision
+++ b/config/homebin/vagrant_provision
@@ -19,6 +19,10 @@ if [[ -f /vagrant/config/homebin/vagrant_provision_custom ]]; then
 	/vagrant/config/homebin/vagrant_provision_custom
 fi
 
+echo "Restarting Nginx and MySQL"
+sudo service nginx restart
+sudo service mysql restart
+
 green="\033[01;32m"
 echo ""
 echo -e "${green}         yay  "

--- a/config/homebin/vagrant_provision
+++ b/config/homebin/vagrant_provision
@@ -19,4 +19,12 @@ if [[ -f /vagrant/config/homebin/vagrant_provision_custom ]]; then
 	/vagrant/config/homebin/vagrant_provision_custom
 fi
 
-echo "Congratulations! Provisioning has Finished Thanks for using VVV, visit http://vvv.test to see your sites listed"
+green="\033[01;32m"
+echo ""
+echo -e "${green}         yay  "
+echo -e "${green}   ▄▀▀▀▄▄▄▄▄▄▄▀▀▀▄                __ __ __ __"
+echo -e "${green}   █▒▒░░░░░░░░░▒▒█    Thanks for  \ V\ V\ V /"
+echo -e "${green}    █░░█░░░░░█░░█     using        \_/\_/\_/"
+echo -e "${green} ▄▄  █░░░▀█▀░░░█  ▄▄ "
+echo -e "${green}█░░█ ▀▄░░░░░░░▄▀ █░░█ Provisioning has finished! Visit http://vvv.test"
+echo -e "\033[0m"

--- a/config/homebin/vagrant_up
+++ b/config/homebin/vagrant_up
@@ -19,4 +19,12 @@ echo "Restarting Nginx and MySQL"
 sudo service nginx restart
 sudo service mysql restart
 
-echo "Congratulations! Thanks for using VVV, visit http://vvv.test to see your sites listed"
+green="\033[01;32m"
+echo ""
+echo -e "${green}         yay  "
+echo -e "${green}   ▄▀▀▀▄▄▄▄▄▄▄▀▀▀▄                __ __ __ __"
+echo -e "${green}   █▒▒░░░░░░░░░▒▒█    Thanks for  \ V\ V\ V /"
+echo -e "${green}    █░░█░░░░░█░░█     using        \_/\_/\_/"
+echo -e "${green} ▄▄  █░░░▀█▀░░░█  ▄▄ "
+echo -e "${green}█░░█ ▀▄░░░░░░░▄▀ █░░█ Vagrant Up has finished! Visit http://vvv.test"
+echo -e "\033[0m"


### PR DESCRIPTION
## Summary:

closes #1752

Sometimes users aren't sure if things finished succesfully, and the end of a provision just looks like more output that abruptly stopped. We tried adding a short message but I don't believe it's enough, so I put much more in:

<img width="704" alt="Screenshot 2019-04-01 at 11 54 35" src="https://user-images.githubusercontent.com/58855/55323259-7fe37d00-5476-11e9-8270-1328c55a41ea.png">
<img width="1195" alt="Screenshot 2019-04-01 at 11 55 14" src="https://user-images.githubusercontent.com/58855/55323261-807c1380-5476-11e9-8445-60f4ca8bd050.png">


## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant **v2.2.3** and VirtualBox **v6** on **MacOS**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [x] I've updated the changelog
 - [x] This PR is complete and ready for review

I did encounter an issue where `vagrant_provision` couldn't be ran by vagrant with a permission denied error, I'm unsure why though as I've only modified the contents of the file in an existing instance, and `vagrant_up` worked fine
 
 <!-- don't forget to fill out the bolded parts -->
