### PR TITLE
contributor box flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ permalink: /docs/en-US/changelog/
  * Added a `vagrant_provision` and `vagrant_provision_custom` script to the homebin folder that run post-provision
  * Improved the messaging to tell the user at the end of a `vagrant up` or `vagrant provision` that it was succesful
  * The VVV install path is now in the splash screen, making it easier to debug GH issues
+ * Added a `wordcamp_contributor_day_box` flag to the `vm_config` section of `vvv-config.yml` so that contributor day setup scripts are simpler
 
 ## 2.5.1 ( 14th January 2019 )
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,54 +37,10 @@ end
 if ENV['VVV_SKIP_LOGO'] then
   show_logo = false
 end
+
+# Show the initial splash screen
+
 if show_logo then
-
-  platform = 'platform-' + Vagrant::Util::Platform.platform + ' '
-  if Vagrant::Util::Platform.windows? then
-    platform = platform + 'windows '
-    if Vagrant::Util::Platform.wsl? then
-      platform = platform + 'wsl '
-    end
-    if Vagrant::Util::Platform.msys? then
-      platform = platform + 'msys '
-    end
-    if Vagrant::Util::Platform.cygwin? then
-      platform = platform + 'cygwin '
-    end
-    if Vagrant::Util::Platform.windows_hyperv_enabled? then
-      platform = platform + 'HyperV-Enabled '
-    end
-    if Vagrant::Util::Platform.windows_hyperv_admin? then
-      platform = platform + 'HyperV-Admin '
-    end
-    if Vagrant::Util::Platform.windows_admin? then
-      platform = platform + 'HasWinAdminPriv '
-    end
-  else
-
-    if ENV['SHELL'] then
-      platform = platform + "shell:" + ENV['SHELL'] + ' '
-    end
-    if Vagrant::Util::Platform.systemd? then
-      platform = platform + 'systemd '
-    end
-  end
-
-  if Vagrant.has_plugin?('vagrant-hostsupdater') then
-    platform = platform + 'vagrant-hostsupdater '
-  end
-
-  if Vagrant.has_plugin?('vagrant-vbguest') then
-    platform = platform + 'vagrant-vbguest '
-  end
-
-  if Vagrant::Util::Platform.fs_case_sensitive? then
-    platform = platform + 'CaseSensitiveFS '
-  end
-  if ! Vagrant::Util::Platform.terminal_supports_colors? then
-    platform = platform + 'NoColour '
-  end
-
   git_or_zip = "zip-no-vcs"
   branch = ''
   if File.directory?("#{vagrant_dir}/.git") then
@@ -93,22 +49,16 @@ if show_logo then
     branch = branch.chomp("\n"); # remove trailing newline so it doesnt break the ascii art
   end
 
-  splash = <<-HEREDOC
+    splashfirst = <<-HEREDOC
 \033[1;38;5;196m#{red}__ #{green}__ #{blue}__ __
 #{red}\\ V#{green}\\ V#{blue}\\ V / #{red}Varying #{green}Vagrant #{blue}Vagrants
 #{red} \\_/#{green}\\_/#{blue}\\_/  #{purple}v#{version}#{creset}-#{branch_c}#{git_or_zip}#{branch}
 
-#{yellow}Platform:   #{yellow}#{platform}
-#{green}Vagrant:    #{green}v#{Vagrant::VERSION},	#{blue}VirtualBox: #{blue}v#{virtualbox_version()}
-#{purple}VVV Path:   "#{vagrant_dir}"
-
-#{docs}Docs:       #{url}https://varyingvagrantvagrants.org/
-#{docs}Contribute: #{url}https://github.com/varying-vagrant-vagrants/vvv
-#{docs}Dashboard:  #{url}http://vvv.test#{creset}
-
   HEREDOC
-  puts splash
+  puts splashfirst
 end
+
+# Load the config file before the second section of the splash screen
 
 if File.file?(File.join(vagrant_dir, 'vvv-custom.yml')) == false then
   puts "#{yellow}Copying #{red}vvv-config.yml#{yellow} to #{green}vvv-custom.yml#{yellow}\nIMPORTANT NOTE: Make all modifications to #{green}vvv-custom.yml#{yellow} in future so that they are not lost when VVV updates.#{creset}\n\n"
@@ -211,13 +161,82 @@ defaults['cores'] = 1
 defaults['private_network_ip'] = '192.168.50.4'
 
 vvv_config['vm_config'] = defaults.merge(vvv_config['vm_config'])
+vvv_config['hosts'] = vvv_config['hosts'].uniq
+
+# Show the second splash screen section
+
+if show_logo then
+  platform = 'platform-' + Vagrant::Util::Platform.platform + ' '
+  if Vagrant::Util::Platform.windows? then
+    platform = platform + 'windows '
+    if Vagrant::Util::Platform.wsl? then
+      platform = platform + 'wsl '
+    end
+    if Vagrant::Util::Platform.msys? then
+      platform = platform + 'msys '
+    end
+    if Vagrant::Util::Platform.cygwin? then
+      platform = platform + 'cygwin '
+    end
+    if Vagrant::Util::Platform.windows_hyperv_enabled? then
+      platform = platform + 'HyperV-Enabled '
+    end
+    if Vagrant::Util::Platform.windows_hyperv_admin? then
+      platform = platform + 'HyperV-Admin '
+    end
+    if Vagrant::Util::Platform.windows_admin? then
+      platform = platform + 'HasWinAdminPriv '
+    end
+  else
+
+    if ENV['SHELL'] then
+      platform = platform + "shell:" + ENV['SHELL'] + ' '
+    end
+    if Vagrant::Util::Platform.systemd? then
+      platform = platform + 'systemd '
+    end
+  end
+
+  if Vagrant.has_plugin?('vagrant-hostsupdater') then
+    platform = platform + 'vagrant-hostsupdater '
+  end
+
+  if Vagrant.has_plugin?('vagrant-vbguest') then
+    platform = platform + 'vagrant-vbguest '
+  end
+
+  if Vagrant::Util::Platform.fs_case_sensitive? then
+    platform = platform + 'CaseSensitiveFS '
+  end
+  if ! Vagrant::Util::Platform.terminal_supports_colors? then
+    platform = platform + 'NoColour '
+  end
+
+  if defined? vvv_config['vm_config']['wordcamp_contributor_day_box'] then
+    if vvv_config['vm_config']['wordcamp_contributor_day_box'] == true then
+      platform = platform + 'contributor_day_box '
+    end
+  end
+
+  splashsecond = <<-HEREDOC
+#{yellow}Platform:   #{yellow}#{platform}
+#{green}Vagrant:    #{green}v#{Vagrant::VERSION},	#{blue}VirtualBox: #{blue}v#{virtualbox_version()}
+#{purple}VVV Path:   "#{vagrant_dir}"
+
+#{docs}Docs:       #{url}https://varyingvagrantvagrants.org/
+#{docs}Contribute: #{url}https://github.com/varying-vagrant-vagrants/vvv
+#{docs}Dashboard:  #{url}http://vvv.test#{creset}
+
+  HEREDOC
+  puts splashsecond
+end
 
 if defined? vvv_config['vm_config']['provider'] then
   # Override or set the vagrant provider.
   ENV['VAGRANT_DEFAULT_PROVIDER'] = vvv_config['vm_config']['provider']
 end
 
-vvv_config['hosts'] = vvv_config['hosts'].uniq
+
 
 ENV["LC_ALL"] = "en_US.UTF-8"
 
@@ -299,7 +318,17 @@ Vagrant.configure("2") do |config|
   # This box is provided by Ubuntu vagrantcloud.com and is a nicely sized (332MB)
   # box containing the Ubuntu 14.04 Trusty 64 bit release. Once this box is downloaded
   # to your host computer, it is cached for future use under the specified box name.
+  # 
+  # Note: We would like to update this to a newer box, but a naive update would
+  # destroy everybodies databases, it's not as simple as it first seems
   config.vm.box = "ubuntu/trusty64"
+
+  # If we're at a contributor day, switch the base box to the prebuilt one
+  if defined? vvv_config['vm_config']['wordcamp_contributor_day_box'] then
+    if vvv_config['vm_config']['wordcamp_contributor_day_box'] == true then
+	    config.vm.box  = "vvv/contribute"
+    end
+  end
 
   # The Parallels Provider uses a different naming scheme.
   config.vm.provider :parallels do |v, override|

--- a/vvv-config.yml
+++ b/vvv-config.yml
@@ -81,15 +81,23 @@ utilities:
     #- php73
 
 # vm_config controls how Vagrant provisions the virtual machine, and can be used to
-# increase the memory given to VVV and the number of CPU cores. For WP core development
-# we recommend at least 2GB ( 2048 )
+# increase the memory given to VVV and the number of CPU cores. 
 # It can also be used to override the default provider being used within Vagrant.
-# Due to a limitation within Vagrant, the specified provider is only respected on a clean `vagrant up`
-# as Vagrant currently restricts you to one provider per machine
-# https://www.vagrantup.com/docs/providers/basic_usage.html#vagrant-up
+
 vm_config:
+  # For WP core development we recommend at least 2GB ( 2048 ),
+  # If you have 4GB of RAM, lower this to 768MB or you may encounter issues
   memory: 2048
+  # CPU cores:
   cores: 2
+
+  # this tells VVV to use the prebuilt box copied from the USB drive at contributor days
+  # once set to false, do not change back to true, and reprovision
+  # wordcamp_contributor_day_box: false
+
+  # Due to a limitation within Vagrant, the specified provider is only respected on a clean `vagrant up`
+  # as Vagrant currently restricts you to one provider per machine
+  # https://www.vagrantup.com/docs/providers/basic_usage.html#vagrant-up
   # provider: vmware_workstation
 
 # General VVV options
@@ -98,3 +106,4 @@ general:
   db_backup: true
   # Import the databases if they're missing from backups
   db_restore: true
+


### PR DESCRIPTION
## Summary:

Contributor day setup no longer has to use `sed` to swap the vagrant box, it can be configured via the config file now. This also means users who want to switch away from that box now have an easy path to do so, change the flag to `false` and reprovision

## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant **v2.2.3** and VirtualBox **v6** on **MacOS**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [x] I've updated the changelog
 - [x] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
