### PR TITLE
removed 3 dashboard domains in favour of vvv.test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ title: Changelog
 permalink: /docs/en-US/changelog/
 ---
 
-## 2.6.0 ( TBD )
+## 2.7.0 ( TBD )
+
+### Removals
+
+ - The deprecated domains `vvv.dev`, `vvv.local`, and `vvv.localhost`, were removed, the dashboard lives at `vvv.test`.
+
+## 2.6.0 ( 2nd April 2019 )
 
 ### Enhancements
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -142,10 +142,7 @@ if ! vvv_config['hosts'].kind_of? Hash then
   vvv_config['hosts'] = Array.new
 end
 
-vvv_config['hosts'] += ['vvv.dev'] # Deprecated
 vvv_config['hosts'] += ['vvv.test']
-vvv_config['hosts'] += ['vvv.local']
-vvv_config['hosts'] += ['vvv.localhost']
 
 vvv_config['sites'].each do |site, args|
   if args.kind_of? String then


### PR DESCRIPTION
## Summary:

We've been pushing people to `vvv.test` for a while, it's time we acted on our deprecations and streamlined. Decisions not options right? This way it's less confusing for new users where the dashboard lives

related to some discussion in #1762 that revealed potential sources of confusion for users

As an aside, it looks like `http://vvv` is possible and it gets added to the hosts file, but VVV doesn't do this itself. I  believe the hostsupdater plugin is doing this. I don't know how to remove it at the moment but I'd like to if possible

## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant **v2.2.3** and VirtualBox **v6** on **MacOS**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [x] I've updated the changelog
 - [x] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
