### PR TITLE
Abort if git clone fails, and improve messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ permalink: /docs/en-US/changelog/
 
 ## 2.7.0 ( TBD )
 
+### Enhancements
+
+ - If cloning a git repo to create a new site fails, VVV will halt provisioning and warn the user
+
 ### Removals
 
  - The deprecated domains `vvv.dev`, `vvv.local`, and `vvv.localhost`, were removed, the dashboard lives at `vvv.test`.


### PR DESCRIPTION
## Summary:

It adjusts the site provisioner script so that if the `git clone` fails, it aborts and tells the user. It also adjusts the other messages, and simplifies the logic at the end of the script

## Checks

<!--  Have you: -->
 - [ ] I've tested this PR with Vagrant **v2.2.3** and VirtualBox **v6** on **MacOS**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [x] I've updated the changelog
 - [x] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
