### PR TITLE
issue/1780 – Reload vs restart nginx to avoid service burst limits during site provisions

### DIFF
--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -205,6 +205,6 @@ else
   done
 fi
 
-service nginx restart
+service nginx reload
 
 


### PR DESCRIPTION
Updates the site provisioning script to use `service xxx reload`, which isn't subject to the burst limits `service xxx restart` is.

Issue: #1780

 - [x] I've tested this PR with Vagrant **2.2.4** and VirtualBox **5.2.28** on **MacOS 10.14.3**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [ ] I've updated the changelog
 - [x] This PR is complete and ready for review