### PR TITLE
Fix a file copy provisioner bug

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -470,8 +470,8 @@ Vagrant.configure("2") do |config|
 
   # Disable the default synced folder to avoid overlapping mounts
   config.vm.synced_folder '.', '/vagrant', disabled: true
-  config.vm.provision "file", source: "version", destination: "/home/vagrant/version"
-  config.vm.provision "file", source: "vvv-custom.yml", destination: "/home/vagrant/vvv-custom.yml"
+  config.vm.provision "file", source: "#{vagrant_dir}/version", destination: "/home/vagrant/version"
+  config.vm.provision "file", source: "#{vagrant_dir}/vvv-custom.yml", destination: "/home/vagrant/vvv-custom.yml"
   $script = <<-SCRIPT
 # cleanup
 rm -rf /vagrant/* 


### PR DESCRIPTION
reference the version and config files to copy into the VM using absolute paths

This fixes copying those files when you provision in a subfolder

## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant **v2.2.4** and VirtualBox **v6.0.6** on **MacOS**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [ ] I've updated the changelog
 - [x] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
