### PR TITLE
allow composer to run as root

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -10,6 +10,7 @@
 export DEBIAN_FRONTEND=noninteractive
 export APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
 export COMPOSER_ALLOW_SUPERUSER=1
+export COMPOSER_NO_INTERACTION=1
 
 codename=$(lsb_release --codename | cut -f2)
 if [[ $codename == "trusty" ]]; then

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -9,6 +9,7 @@
 
 export DEBIAN_FRONTEND=noninteractive
 export APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
+export COMPOSER_ALLOW_SUPERUSER=1
 
 codename=$(lsb_release --codename | cut -f2)
 if [[ $codename == "trusty" ]]; then


### PR DESCRIPTION
This silences the composer root warning issue for now, note that with `noroot` composer was failing, hence why it was removed. I'm very open to adding it back in if it can be made to work though

## Checks

<!--  Have you: -->
 - [ ] I've tested this PR with Vagrant **vXX** and VirtualBox **vXX** on **Operating System**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [ ] I've updated the changelog
 - [ ] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
