### PR TITLE
Removed noroot from the site provisioners git commands

### DIFF
--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -102,7 +102,7 @@ if [[ false != "${REPO}" ]]; then
   # Clone or pull the site repository
   if [[ ! -d ${VM_DIR}/.git ]]; then
     echo -e "\nDownloading ${SITE}, git cloning from ${REPO}"
-    noroot git clone --recursive --branch ${BRANCH} ${REPO} ${VM_DIR} -q
+    git clone --recursive --branch ${BRANCH} ${REPO} ${VM_DIR} -q
     if [ $? -eq 0 ]; then
       echo "Site Template clone succesful"
     else
@@ -113,9 +113,9 @@ if [[ false != "${REPO}" ]]; then
   else
     echo -e "\nUpdating ${SITE}..."
     cd ${VM_DIR}
-    noroot git reset origin/${BRANCH} --hard -q
-    noroot git pull origin ${BRANCH} -q
-    noroot git checkout ${BRANCH} -q
+    git reset origin/${BRANCH} --hard -q
+    git pull origin ${BRANCH} -q
+    git checkout ${BRANCH} -q
   fi
 else
   echo "The site: '${SITE}' does not have a site template, assuming custom provision/vvv-init.sh and provision/vvv-nginx.conf"


### PR DESCRIPTION
## Summary:

Like https://github.com/Varying-Vagrant-Vagrants/VVV/commit/66255db193e651ddc27aff948c6ec3d0e8b8bb09#diff-f50dd38f9eac292b9fd1f9f36ccd8aa2 this tries to fix an issue some users have when cloning site templates

Related to https://github.com/Varying-Vagrant-Vagrants/VVV/issues/1764

## Checks

<!--  Have you: -->
 - [ ] I've tested this PR with Vagrant **vXX** and VirtualBox **vXX** on **Operating System**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [ ] I've updated the changelog
 - [ ] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
