### PR TITLE
only creates the mysql user and group if it doesnt already exist

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -292,11 +292,22 @@ package_install() {
   echo mariadb-server-10.3 mysql-server/root_password password "root" | debconf-set-selections
   echo mariadb-server-10.3 mysql-server/root_password_again password "root" | debconf-set-selections
 
-  echo -e "\nSetup MySQL configuration file links..."
+  echo -e "\n * Setting up MySQL configuration file links..."
 
-  # Preconfigyre mariadb
-  groupadd -g 115 mysql
-  useradd -u 112 -g mysql -G vboxsf -r mysql
+  # Preconfigure mariadb
+  if grep -q 'mysql' /etc/group; then
+    echo " * mysql group exists"
+  else
+    echo " * creating mysql group"
+    groupadd -g 115 mysql
+  fi
+  
+  if id 112 >/dev/null 2>&1; then
+    echo " * mysql user present"
+  else
+    echo " * adding the mysql user"
+    useradd -u 112 -g mysql -G vboxsf -r mysql
+  fi
   mkdir -p "/etc/mysql/conf.d"
   echo " * Copying /srv/config/mysql-config/vvv-core.cnf to /etc/mysql/conf.d/vvv-core.cnf"
   cp -f "/srv/config/mysql-config/vvv-core.cnf" "/etc/mysql/conf.d/vvv-core.cnf"


### PR DESCRIPTION
## Summary:

This fixes users seeing warnings that the mysql group and user already exists when reprovisioning

## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant **v2.2.4** and VirtualBox **v6.0.6** on **MacOS**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [ ] I've updated the changelog
 - [x] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
