### PR TITLE
add an option to vvv-custom.yml to turn off db shares

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -216,6 +216,10 @@ if ! vvv_config['vm_config'].kind_of? Hash then
   vvv_config['vm_config'] = Hash.new
 end
 
+if ! vvv_config['general'].kind_of? Hash then
+  vvv_config['general'] = Hash.new
+end
+
 defaults = Hash.new
 defaults['memory'] = 2048
 defaults['cores'] = 1
@@ -278,6 +282,26 @@ if show_logo then
     if vvv_config['vm_config']['wordcamp_contributor_day_box'] == true then
       platform = platform + 'contributor_day_box '
     end
+  end
+
+  if defined? vvv_config['vm_config']['wordcamp_contributor_day_box'] then
+    if vvv_config['vm_config']['wordcamp_contributor_day_box'] == true then
+      platform = platform + 'contributor_day_box '
+    else
+      --
+    end
+  else
+    --
+  end
+
+  if defined? vvv_config['general']['db_share_type'] then
+    if vvv_config['vm_config']['db_share_type'] != true then
+      platform = platform + 'shared_db_folder_disabled '
+    else
+      platform = platform + 'shared_db_folder_enabled '
+    end
+  else
+    platform = platform + 'shared_db_folder_default '
   end
 
   splashsecond = <<-HEREDOC
@@ -492,9 +516,19 @@ SCRIPT
   # This directory is used to maintain default database scripts as well as backed
   # up MariaDB/MySQL dumps (SQL files) that are to be imported automatically on vagrant up
   config.vm.synced_folder "database/sql/", "/srv/database"
+  use_db_share = true
 
-  # Map the MySQL Data folders on to mounted folders so it isn't stored inside the VM
-  config.vm.synced_folder "database/data/", "/var/lib/mysql", create: true, owner: 112, group: 115, mount_options: [ "dmode=775", "fmode=664" ]
+  if defined? vvv_config['general']['db_share_type'] then
+    if vvv_config['general']['db_share_type'] != false then
+      use_db_share = true
+    else
+      use_db_share = false
+    end
+  end
+  if use_db_share == true then
+    # Map the MySQL Data folders on to mounted folders so it isn't stored inside the VM
+    config.vm.synced_folder "database/data/", "/var/lib/mysql", create: true, owner: 112, group: 115, mount_options: [ "dmode=775", "fmode=664" ]
+  end
 
   # The Parallels Provider does not understand "dmode"/"fmode" in the "mount_options" as
   # those are specific to Virtualbox. The folder is therefore overridden with one that

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -291,7 +291,7 @@ if show_logo then
   end
 
   if defined? vvv_config['general']['db_share_type'] then
-    if vvv_config['vm_config']['db_share_type'] != true then
+    if vvv_config['general']['db_share_type'] != true then
       platform = platform + 'shared_db_folder_disabled '
     else
       platform = platform + 'shared_db_folder_enabled '

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -287,11 +287,7 @@ if show_logo then
   if defined? vvv_config['vm_config']['wordcamp_contributor_day_box'] then
     if vvv_config['vm_config']['wordcamp_contributor_day_box'] == true then
       platform = platform + 'contributor_day_box '
-    else
-      --
     end
-  else
-    --
   end
 
   if defined? vvv_config['general']['db_share_type'] then


### PR DESCRIPTION
## Summary:

This shouldn't be necessary, but for the moment this lets us turn off the DB shared folder, the raw DB data will be stored inside the VM. This does mean the DB gets destroyed on every box update though.

It also means that toggling this switch and reprovisioning will have strange behaviour

For example:

 - if you provision, then turn it off, you'll get a new set of database files and a clean slate, none of the existing databases will be present, but they'll still be on the host in the database/data folder, they just wont be used
 - If you then switched it off, it'd go back to using the database/data folder, but there would still be a database in the VM that's silenced and innaccessible

## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant **v2.2.4** and VirtualBox **v6.0.6** on **MacOS**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [ ] I've updated the changelog
 - [x] This PR is complete and ready for review
 
This still needs testing

 <!-- don't forget to fill out the bolded parts -->
