### PR TITLE
Disable the vbguest plugin and bump minimum vagrant version to 2.2.4

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,6 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby ts=2 sw=2 et:
-Vagrant.require_version ">= 2.1.4"
+Vagrant.require_version ">= 2.2.4"
 require 'yaml'
 require 'fileutils'
 
@@ -384,6 +384,11 @@ Vagrant.configure("2") do |config|
       else
         config.vagrant.plugins = ["vagrant-hostsupdater"]
       end
+  end
+
+  # The vbguest plugin has issues for some users, so we're going to disable it for now
+  if Vagrant.has_plugin?("vagrant-vbguest")
+    config.vbguest.auto_update = false  
   end
 
   # SSH Agent Forwarding


### PR DESCRIPTION
## Summary:

This fixes an issue some users had on provisioning VVV 3, it also bumps the minimum version of Vagrant to the latest ( v2.2.4 )

## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant **v2.2.4** and VirtualBox **v6.0.6** on **MacOS**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [ ] I've updated the changelog
 - [x] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
