### PR TITLE
use mapped subfolders for logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ In the near future, we expect to use a box with PHP/etc preinstalled, this will 
  - Prevented provisioning from occurring inside Ubuntu 14 VMs
  - Fixed issues with Nginx restarting too fast and too often
  - Fixed the permissions on the `db_restore` script
+ - The `/var/log` folder is no longer directly mounted, instead the `/var/log/php`, `/var/log/nginx` and `/var/log/memcached` subfolders are mounted. This improves compatibility
 
 ### Removals
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -564,7 +564,9 @@ SCRIPT
   #
   # If a log directory exists in the same directory as your Vagrantfile, a mapped
   # directory inside the VM will be created for some generated log files.
-  config.vm.synced_folder "log/", "/var/log", owner: "root", group: "syslog", mount_options: [ "dmode=777", "fmode=666" ]
+  config.vm.synced_folder "log/memcached", "/var/log/memcached", owner: "root", create: true,  group: "syslog", mount_options: [ "dmode=777", "fmode=666" ]
+  config.vm.synced_folder "log/nginx", "/var/log/nginx", owner: "root", create: true,  group: "syslog", mount_options: [ "dmode=777", "fmode=666" ]
+  config.vm.synced_folder "log/php", "/var/log/php", create: true, owner: "root", group: "syslog", mount_options: [ "dmode=777", "fmode=666" ]
 
   # /srv/www/
   #

--- a/config/memcached-config/memcached.conf
+++ b/config/memcached-config/memcached.conf
@@ -12,7 +12,7 @@
 -d
 
 # Log memcached's output to /var/log/memcached
-logfile /var/log/memcached.log
+logfile /var/log/memcached/memcached.log
 
 # Be verbose
 # -v

--- a/config/php-config/php7.2-custom.ini
+++ b/config/php-config/php7.2-custom.ini
@@ -38,7 +38,7 @@ track_errors = Off
 html_errors = 1
 
 ; Log errors to specified file.
-error_log = /var/log/php7.2_errors.log
+error_log = /var/log/php/php7.2_errors.log
 
 ; Maximum size of POST data that PHP will accept.
 post_max_size = 1024M

--- a/config/php-config/php7.2-fpm.conf
+++ b/config/php-config/php7.2-fpm.conf
@@ -29,7 +29,7 @@ pid = /var/run/php7.2-fpm.pid
 ; in a local file.
 ; Note: the default prefix is /var
 ; Default Value: log/php-fpm.log
-error_log = /var/log/php7.2-fpm.log
+error_log = /var/log/php/php7.2-fpm.log
 
 ; syslog_facility is used to specify what type of program is logging the
 ; message. This lets syslogd specify that messages from different facilities

--- a/config/php-config/xdebug.ini
+++ b/config/php-config/xdebug.ini
@@ -189,7 +189,7 @@ xdebug.remote_host = "192.168.50.1"
 ; If set to a value, it is used as filename to a file to which all remote debugger communications are
 ; logged. The file is always opened in append-mode, and will therefore not be overwritten by default.
 ; There is no concurrency protection available.
-xdebug.remote_log = /var/log/xdebug-remote.log
+xdebug.remote_log = /var/log/php/xdebug-remote.log
 
 ; xdebug.remote_mode
 ; Type: string, Default value: req


### PR DESCRIPTION
## Summary:

Use subfolders for php and memcached instead of the entire /var/logs folder, and map those subfolders rather than the entire logs directory

## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant **v2.2.4** and VirtualBox **v6.0.6** on **MacOS**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [x] I've updated the changelog
 - [x] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
