### PR TITLE
Auto-move db backups folder

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -130,6 +130,13 @@ if File.file?(File.join(vagrant_dir, 'vvv-custom.yml')) == false then
   FileUtils.cp( File.join(vagrant_dir, 'vvv-config.yml'), File.join(vagrant_dir, 'vvv-custom.yml') )
 end
 
+old_db_backup_dir = File.join(vagrant_dir, 'database/backups/' )
+new_db_backup_dir = File.join(vagrant_dir, 'database/sql/backups/' )
+if ( File.directory?( old_db_backup_dir ) == true ) && ( File.directory?( new_db_backup_dir ) == false ) then
+  puts "Moving db backup directory into database/sql/backups"
+  FileUtils.mv( old_db_backup_dir, new_db_backup_dir )
+end
+
 vvv_config_file = File.join(vagrant_dir, 'vvv-custom.yml')
 
 vvv_config = YAML.load_file(vvv_config_file)

--- a/database/sql/backups/readme.txt
+++ b/database/sql/backups/readme.txt
@@ -1,5 +1,0 @@
-SQL files created with mysqldump should be stored in database/backups so that they are automatically imported as the Vagrant VM boots up.
-
-For this to work properly, databases should be created in your database/init-custom.sql file as explained in database/init-custom.sql.sample.
-
-Once these original files have been imported, they will exist in database/data as the actual mysql data directory and will not need to be reimported on the next vagrant up.


### PR DESCRIPTION
## Summary:

move backups from the old location to the new location when the new location doesnt exist but the old one does


## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant **v2.2.4** and VirtualBox **v6.0.6** on **MacOS**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [ ] I've updated the changelog
 - [x] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
