### PR TITLE
give vagrant user ownership over profile files rather than root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ title: Changelog
 permalink: /docs/en-US/changelog/
 ---
 
+## 3.1.0 ( TBD 2019 )
+
+### Bug Fixes
+
+ - Fixed an issue with permissions in files copied to the home folder
+
 ## 3.0.0 ( 17 May 2019 )
 
 This version moves to an Ubuntu 18.04 box. It also moves the database data directory to a mounted folder. This means you can destroy and rebuild the VM without loss, but it also means **a `vagrant destroy` is necessary to update**. **Be sure to back up database tables you need beforehand**.

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -246,32 +246,38 @@ cleanup_terminal_splash() {
 profile_setup() {
   # Copy custom dotfiles and bin file for the vagrant user from local
   echo " * Copying /srv/config/bash_profile                      to /home/vagrant/.bash_profile"
-  cp "/srv/config/bash_profile" "/home/vagrant/.bash_profile"
+  rm -f "/home/vagrant/.bash_profile"
+  noroot cp -f "/srv/config/bash_profile" "/home/vagrant/.bash_profile"
 
   echo " * Copying /srv/config/bash_aliases                      to /home/vagrant/.bash_aliases"
-  cp "/srv/config/bash_aliases" "/home/vagrant/.bash_aliases"
+  rm -f "/home/vagrant/.bash_aliases"
+  noroot cp -f "/srv/config/bash_aliases" "/home/vagrant/.bash_aliases"
 
   echo " * Copying /srv/config/vimrc                             to /home/vagrant/.vimrc"
-  cp "/srv/config/vimrc" "/home/vagrant/.vimrc"
+  rm -f "/home/vagrant/.vimrc"
+  noroot cp -f "/srv/config/vimrc" "/home/vagrant/.vimrc"
 
   if [[ ! -d "/home/vagrant/.subversion" ]]; then
-    mkdir -p "/home/vagrant/.subversion"
+    noroot mkdir -p "/home/vagrant/.subversion"
   fi
 
   echo " * Copying /srv/config/subversion-servers                to /home/vagrant/.subversion/servers"
-  cp "/srv/config/subversion-servers" "/home/vagrant/.subversion/servers"
+  rm -f /home/vagrant/.subversion/servers
+  noroot cp "/srv/config/subversion-servers" "/home/vagrant/.subversion/servers"
 
   echo " * Copying /srv/config/subversion-config                 to /home/vagrant/.subversion/config"
-  cp "/srv/config/subversion-config" "/home/vagrant/.subversion/config"
+  rm -f /home/vagrant/.subversion/config
+  noroot cp "/srv/config/subversion-config" "/home/vagrant/.subversion/config"
 
   # If a bash_prompt file exists in the VVV config/ directory, copy to the VM.
   if [[ -f "/srv/config/bash_prompt" ]]; then
     echo " * Copying /srv/config/bash_prompt to /home/vagrant/.bash_prompt"
-    cp "/srv/config/bash_prompt" "/home/vagrant/.bash_prompt"
+    rm -f /home/vagrant/.bash_prompt
+    noroot cp "/srv/config/bash_prompt" "/home/vagrant/.bash_prompt"
   fi
 
   echo " * Copying /srv/config/ssh_known_hosts to /etc/ssh/ssh_known_hosts"
-  cp -f /srv/config/ssh_known_hosts /etc/ssh/ssh_known_hosts
+ cp -f /srv/config/ssh_known_hosts /etc/ssh/ssh_known_hosts
 }
 
 not_installed() {

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -244,6 +244,8 @@ cleanup_terminal_splash() {
 }
 
 profile_setup() {
+  echo " * Setting ownership of files in /home/vagrant to vagrant"
+  chown -R vagrant:vagrant /home/vagrant/
   # Copy custom dotfiles and bin file for the vagrant user from local
   echo " * Copying /srv/config/bash_profile                      to /home/vagrant/.bash_profile"
   rm -f "/home/vagrant/.bash_profile"
@@ -343,9 +345,10 @@ package_install() {
   echo postfix postfix/mailname string vvv | debconf-set-selections
 
   # Provide our custom apt sources before running `apt-get update`
-  ln -sf /srv/config/apt-source-append.list /etc/apt/sources.list.d/vvv-sources.list
-  echo "Linked custom apt sources"
-
+  echo " * Copying custom apt sources"
+  cp -f /srv/config/apt-source-append.list /etc/apt/sources.list.d/vvv-sources.list
+  
+  echo " * Checking Apt Keys"
   if [[ ! $( apt-key list | grep 'NodeSource') ]]; then
     # Retrieve the NodeJS signing key from nodesource.com
     echo "Applying NodeSource NodeJS signing key..."


### PR DESCRIPTION
## Summary:

This avoids warnings when running vagrant ssh for some users

## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant **v2.2.4** and VirtualBox **v6.0.8** on **MacOS**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [x] I've updated the changelog
 - [x] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
