### PR TITLE
DB Share HyperV/Parallels Provider Fixes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -539,17 +539,17 @@ SCRIPT
   if use_db_share == true then
     # Map the MySQL Data folders on to mounted folders so it isn't stored inside the VM
     config.vm.synced_folder "database/data/", "/var/lib/mysql", create: true, owner: 112, group: 115, mount_options: [ "dmode=775", "fmode=664" ]
-  end
 
-  # The Parallels Provider does not understand "dmode"/"fmode" in the "mount_options" as
-  # those are specific to Virtualbox. The folder is therefore overridden with one that
-  # uses corresponding Parallels mount options.
-  config.vm.provider :parallels do |v, override|
-    override.vm.synced_folder "database/data/", "/var/lib/mysql", create: true, owner: "mysql", group: "mysql", :mount_options => []
-  end
-  # Neither does the HyperV provider
-  config.vm.provider :hyperv do |v, override|
-    override.vm.synced_folder "database/data/", "/var/lib/mysql", create: true, owner: "mysql", group: "mysql", :mount_options => []
+    # The Parallels Provider does not understand "dmode"/"fmode" in the "mount_options" as
+    # those are specific to Virtualbox. The folder is therefore overridden with one that
+    # uses corresponding Parallels mount options.
+    config.vm.provider :parallels do |v, override|
+      override.vm.synced_folder "database/data/", "/var/lib/mysql", create: true, owner: 112, group: 115, :mount_options => []
+    end
+    # Neither does the HyperV provider
+    config.vm.provider :hyperv do |v, override|
+      override.vm.synced_folder "database/data/", "/var/lib/mysql", create: true, owner: 112, group: 115, :mount_options => []
+    end
   end
 
   # /srv/config/


### PR DESCRIPTION
## Summary:

The database share was setup for VirtualBox, but didn't take into account HyperV or Parallels

## Checks

<!--  Have you: -->
 - [ ] I've tested this PR with Vagrant **vXX** and VirtualBox **vXX** on **Operating System**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [x] I've updated the changelog
 - [x] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
