### PR TITLE
db import: support db names with hyphens

### DIFF
--- a/database/sql/import-sql.sh
+++ b/database/sql/import-sql.sh
@@ -45,8 +45,8 @@ then
 	pre_dot=${file%%.sql}
 
 	printf " * Creating the ${pre_dot} table if it doesn't already exist, and granting the wp user access"
-	mysql -u root --password=root -e "CREATE DATABASE IF NOT EXISTS ${pre_dot}"
-	mysql -u root --password=root -e "GRANT ALL PRIVILEGES ON ${pre_dot}.* TO wp@localhost IDENTIFIED BY 'wp';"
+	mysql -u root --password=root -e "CREATE DATABASE IF NOT EXISTS \`$pre_dot\`"
+	mysql -u root --password=root -e "GRANT ALL PRIVILEGES ON \`$pre_dot\`.* TO wp@localhost IDENTIFIED BY 'wp';"
 
 	mysql_cmd='SHOW TABLES FROM `'$pre_dot'`' # Required to support hypens in database names
 	db_exist=`mysql -u root -proot --skip-column-names -e "$mysql_cmd"`


### PR DESCRIPTION
## Summary:

<!-- what does it add/fix/change/remove? -->
The import script didn't work when the name of a database contains hyphens (e.g. `my-wp-db`). This change enclose the name with backticks, so names with hyphens are working.

## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant **2.2.4** and VirtualBox **6.0.8 r130347** on **Linux**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [ ] I've updated the changelog
 - [ ] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
