### PR TITLE
Fixes xdebug log creation

### DIFF
--- a/config/homebin/xdebug_on
+++ b/config/homebin/xdebug_on
@@ -1,8 +1,8 @@
 #!/bin/bash
 sudo phpenmod xdebug
 
-find /etc/init.d/ -name "php*-fpm" -exec bash -c 'sudo service "$(basename "$0")" restart' {} \;
+find /etc/init.d/ -name "php*-fpm" -exec bash -c 'echo "Restarting $(basename "$0" ) " && sudo service "$(basename "$0")" restart' {} \;
 
 # Ensure the log file for xdebug is group writeable.
-sudo touch /var/log/xdebug-remote.log
-sudo chmod 664 /var/log/xdebug-remote.log
+sudo touch /var/log/php/xdebug-remote.log
+sudo chmod 664 /var/log/php/xdebug-remote.log


### PR DESCRIPTION
## Summary:

Updates the `xdebug_on` script to touch/chmod the right file ( it moved ) and output more info about what it's doing

## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant **v2.2.4** and VirtualBox **v6.0.8** on **MacOS**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [ ] I've updated the changelog
 - [x] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
