### PR TITLE
Add/boxconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ permalink: /docs/en-US/changelog/
 
 ## 3.1.0 ( TBD 2019 )
 
+### Enhancements
+
+ - The vagrant box can now be overriden using the `box` parameter in `vvv-custom.yml` under the `vm_config` section. This requires a `vagrant destroy` followed by a `vagrant up --provision` to recreate the VM using the new box
+
 ### Bug Fixes
 
  - Fixed an issue with permissions in files copied to the home folder

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -291,9 +291,9 @@ if show_logo then
     end
   end
 
-  if defined? vvv_config['vm_config']['wordcamp_contributor_day_box'] then
-    if vvv_config['vm_config']['wordcamp_contributor_day_box'] == true then
-      platform = platform + 'contributor_day_box '
+  if defined? vvv_config['vm_config']['box'] then
+    if vvv_config['vm_config']['box'] == true then
+      platform = platform + 'box_override:' + vvv_config['vm_config']['box'] +' '
     end
   end
 
@@ -443,6 +443,10 @@ Vagrant.configure("2") do |config|
   # Hyper-V uses a different base box.
   config.vm.provider :hyperv do |v, override|
     override.vm.box = "bento/ubuntu-18.04"
+  end
+
+  if defined? vvv_config['vm_config']['box'] then
+    config.vm.box  = vvv_config['vm_config']['box']
   end
 
   config.vm.hostname = "vvv"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -292,8 +292,9 @@ if show_logo then
   end
 
   if defined? vvv_config['vm_config']['box'] then
-    if vvv_config['vm_config']['box'] == true then
-      platform = platform + 'box_override:' + vvv_config['vm_config']['box'] +' '
+    if vvv_config['vm_config']['box'] != nil then
+      puts "Custom Box: Box overriden via VVV config, this won't take effect until a destroy + reprovision happens"
+      platform = platform + 'box_override:' + vvv_config['vm_config']['box'] + ' '
     end
   end
 
@@ -446,7 +447,9 @@ Vagrant.configure("2") do |config|
   end
 
   if defined? vvv_config['vm_config']['box'] then
-    config.vm.box  = vvv_config['vm_config']['box']
+    if vvv_config['vm_config']['box'] != nil then
+      config.vm.box  = vvv_config['vm_config']['box']
+    end
   end
 
   config.vm.hostname = "vvv"


### PR DESCRIPTION
## Summary:

This lets a user change the box VVV uses by changing there `vvv-custom.yml`  to contain a `box:` parameter like this:


```yaml
vm_config:
  memory: 2048
  cores: 2
  wordcamp_contributor_day_box: false
  box: "ubuntu/bionic64"
```

Note that compatibility of provisioners with the new box isn't guaranteed, and that for this to take effect a `vagrant destroy` followed by a complete provisioning of a fresh new VM is necessary. Some cleanup of vagrant files might be needed too, e.g. the `.vagrant` folder

This is mostly to aid in debugging and testing when working with updates and providers such as hyperV, and for aiding contributor days

Also updates the splash:

<img width="1028" alt="Screenshot 2019-06-08 at 14 26 10" src="https://user-images.githubusercontent.com/58855/59147907-62dca480-89f9-11e9-9575-ddebc12e601c.png">


## Checks

<!--  Have you: -->
 - [ ] I've tested this PR with Vagrant **vXX** and VirtualBox **vXX** on **Operating System**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [x] I've updated the changelog
 - [x] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
