### PR TITLE
fix for auto_prepend_file

### DIFF
--- a/config/php-config/xdebug.ini
+++ b/config/php-config/xdebug.ini
@@ -6,7 +6,7 @@ zend_extension=xdebug.so
 ; Type: boolean, Default value: 0
 ; When this setting is set to on, the tracing of function calls will be enabled just before the
 ; script is run. This makes it possible to trace code in the auto_prepend_file.
-xdebug.auto_trace = 0
+xdebug.auto_trace = 1
 
 ; xdebug.collect_includes
 ; Type: boolean, Default value: 1


### PR DESCRIPTION
xDebug require an option enabled to work without issues with auto_prepend_file parameter.

ref: https://xdebug.org/docs/all_settings

Fix: #1855 