### PR TITLE
Add also grunt (not grunt-cli)

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -490,14 +490,14 @@ tools_install() {
 
   function install_grunt() {
     echo "Installing Grunt CLI"
-    npm install -g grunt-cli
+    npm install -g grunt grunt-cli
     hack_avoid_gyp_errors & npm install -g grunt-sass; touch /tmp/stop_gyp_hack
     npm install -g grunt-cssjanus
     npm install -g grunt-rtlcss
   }
   function update_grunt() {
     echo "Updating Grunt CLI"
-    npm update -g grunt-cli
+    npm update -g grunt grunt-cli
     hack_avoid_gyp_errors & npm update -g grunt-sass; touch /tmp/stop_gyp_hack
     npm update -g grunt-cssjanus
     npm update -g grunt-rtlcss


### PR DESCRIPTION
Grunt != grunt-cli
Grunt-cli is the command line tool and usually grunt is installed in the project itself  but we are installing it globally and we need it globally or on provision we will have this errors with other packages not installed.

![Screenshot_20190613_115831](https://user-images.githubusercontent.com/403283/59423728-026fad80-8dd3-11e9-8a44-fb26dffe0fc1.png)
