### PR TITLE
Fixes #1859: Allow users to run db_backup manually regardless if `general.db_backup` is true or false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is primarily a reliability update. Note that updating to v3.1 requires a `v
  - The vagrant box can now be overriden using the `box` parameter in `vvv-custom.yml` under the `vm_config` section. This requires a `vagrant destroy` followed by a `vagrant up --provision` to recreate the VM using the new box
  - The main provisioner now only fetches the apt keys once rather than on every key check
  - The TTY fix shell provisioner and the `/vagrant` setup shell provisioner were merged for a minor reduction in provisioning time.
+ - Allow `db_backup` script to be run manually regardless if automatic DB backups are disabled
 
 ### Bug Fixes
 

--- a/config/homebin/db_backup
+++ b/config/homebin/db_backup
@@ -1,32 +1,18 @@
 #!/bin/bash
 #
-
-# First lets check if backups are turned on or off
-
-VVV_CONFIG=/vagrant/vvv-config.yml
-if [[ -f /vagrant/vvv-custom.yml ]]; then
-	VVV_CONFIG=/vagrant/vvv-custom.yml
-fi
-
-run_backups=`cat ${VVV_CONFIG} | shyaml get-value general.db_backup 2> /dev/null`
-
-if [[ $run_backups != "False" ]]
-then
-
-	# Create individual SQL files for each database. These files
-	# are imported automatically during an initial provision if
-	# the databases exist per the import-sql.sh process.
-	mkdir -p /srv/database/backups
-	echo "Performing Database Backups"
-	mysql --user="root" --password="root" -e 'show databases' | \
-	grep -v -F "information_schema" | \
-	grep -v -F "performance_schema" | \
-	grep -v -F "mysql" | \
-	grep -v -F "test" | \
-	grep -v -F "Database" | \
-	while read dbname;
-	do
-		echo "Backing up Database $dbname..."
-		mysqldump -uroot -proot "$dbname" > /srv/database/backups/"$dbname".sql && echo "Database $dbname backed up...";
-	done
-fi
+# Create individual SQL files for each database. These files
+# are imported automatically during an initial provision if
+# the databases exist per the import-sql.sh process.
+mkdir -p /srv/database/backups
+echo "Performing Database Backups"
+mysql --user="root" --password="root" -e 'show databases' | \
+grep -v -F "information_schema" | \
+grep -v -F "performance_schema" | \
+grep -v -F "mysql" | \
+grep -v -F "test" | \
+grep -v -F "Database" | \
+while read dbname;
+do
+    echo "Backing up Database $dbname..."
+    mysqldump -uroot -proot "$dbname" > /srv/database/backups/"$dbname".sql && echo "Database $dbname backed up...";
+done

--- a/config/homebin/vagrant_destroy
+++ b/config/homebin/vagrant_destroy
@@ -11,5 +11,17 @@ if [[ -f /srv/config/homebin/vagrant_destroy_custom ]]; then
 	echo "Executing vagrant_destroy_custom"
 	/srv/config/homebin/vagrant_destroy_custom
 else
-	/srv/config/homebin/db_backup
+    # Load vvv-config.yml
+    VVV_CONFIG=/vagrant/vvv-config.yml
+    if [[ -f /vagrant/vvv-custom.yml ]]; then
+        VVV_CONFIG=/vagrant/vvv-custom.yml
+    fi
+
+    # Check if backups are turned on or off
+    run_backups=`cat ${VVV_CONFIG} | shyaml get-value general.db_backup 2> /dev/null`
+
+    if [[ $run_backups != "False" ]]
+    then
+	    /srv/config/homebin/db_backup
+    fi
 fi

--- a/config/homebin/vagrant_halt
+++ b/config/homebin/vagrant_halt
@@ -11,5 +11,17 @@ if [[ -f /srv/config/homebin/vagrant_halt_custom ]]; then
 	echo "Executing vagrant_halt_custom"
 	/srv/config/homebin/vagrant_halt_custom
 else
-	/srv/config/homebin/db_backup
+    # Load vvv-config.yml
+    VVV_CONFIG=/vagrant/vvv-config.yml
+    if [[ -f /vagrant/vvv-custom.yml ]]; then
+        VVV_CONFIG=/vagrant/vvv-custom.yml
+    fi
+
+    # Check if backups are turned on or off
+    run_backups=`cat ${VVV_CONFIG} | shyaml get-value general.db_backup 2> /dev/null`
+
+    if [[ $run_backups != "False" ]]
+    then
+	    /srv/config/homebin/db_backup
+    fi
 fi

--- a/config/homebin/vagrant_suspend
+++ b/config/homebin/vagrant_suspend
@@ -11,5 +11,17 @@ if [[ -f /srv/config/homebin/vagrant_suspend_custom ]]; then
 	echo "Executing vagrant_suspend_custom"
 	/srv/config/homebin/vagrant_suspend_custom
 else
-	/srv/config/homebin/db_backup
+    # Load vvv-config.yml
+    VVV_CONFIG=/vagrant/vvv-config.yml
+    if [[ -f /vagrant/vvv-custom.yml ]]; then
+        VVV_CONFIG=/vagrant/vvv-custom.yml
+    fi
+
+    # Check if backups are turned on or off
+    run_backups=`cat ${VVV_CONFIG} | shyaml get-value general.db_backup 2> /dev/null`
+
+    if [[ $run_backups != "False" ]]
+    then
+	    /srv/config/homebin/db_backup
+    fi
 fi


### PR DESCRIPTION
## Summary:

<!-- what does it add/fix/change/remove? -->
Currently, any calls to the `db_backup` shell script are aborted due to the conditional check in this script. The documentation for the flag in vvv-config.yml speaks only to whether or not the DBs should be backed up during vagrant box state changes so I believe this conditional check should be pulled up to the vagrant_halt, vagrant_suspend, and vagrant_destroy shell scripts. This would allow users to manually backup databases using this convenient script without having to reprovision the box with the setting changed.

## Checks

<!--  Have you: -->
 - [X] I've tested this PR with Vagrant **v3.1.0** and VirtualBox **v2.2.4** on **OS X Mojave 10.4**
 - [X] This PR is for the `develop` branch not the `master` branch
 - [X] I've updated the changelog
 - [X] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
