### PR TITLE
use the v10 nodesource apt source and install Node

### DIFF
--- a/config/apt-source-append.list
+++ b/config/apt-source-append.list
@@ -19,8 +19,8 @@ deb [arch=amd64,i386] http://mirrors.coreix.net/mariadb/repo/10.3/ubuntu bionic 
 deb-src http://mirrors.coreix.net/mariadb/repo/10.3/ubuntu bionic main
 
 # Provides Node.js
-deb https://deb.nodesource.com/node_11.x bionic main
-deb-src https://deb.nodesource.com/node_11.x bionic main
+deb https://deb.nodesource.com/node_10.x bionic main
+deb-src https://deb.nodesource.com/node_10.x bionic main
 
 # git lfs (large file storage plugin for git)
 deb https://packagecloud.io/github/git-lfs/ubuntu/ bionic main


### PR DESCRIPTION
## Summary:
Switch to the v10 nodesource packages instead of 11, core needs 10 not 11

## Checks

<!--  Have you: -->
 - [ ] I've tested this PR with Vagrant **vXX** and VirtualBox **vXX** on **Operating System**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [ ] I've updated the changelog
 - [ ] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
