### PR TITLE
make sure xdebug OR tideways is enabled, never both

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ This is primarily a reliability update. Note that updating to v3.1 requires a `v
  - Fixes the site provisioner attempting to clone site templates into existing sites when a site template is added to a site that didn't have one before, but has already provisioned ( it will note that this happened but won't clone the template )
  - Removed some references to Go
  - Fixed symlink issues with apt source files by copying instead
+ - `xdebug_on` and `xdebug_off` now toggle Tideways so that XDebug and Tideways are never running at the same time
+ - Switched to Node v10 by default to fix compatibility issues with the WP Core build scripts
 
 ## 3.0.0 ( 17 May 2019 )
 

--- a/config/homebin/xdebug_off
+++ b/config/homebin/xdebug_off
@@ -1,5 +1,6 @@
 #!/bin/bash
 sudo phpdismod xdebug
 sudo phpenmod tideways_xhprof
+sudo phpenmod xhgui
 
 find /etc/init.d/ -name "php*-fpm" -exec bash -c 'sudo service "$(basename "$0")" restart' {} \;

--- a/config/homebin/xdebug_off
+++ b/config/homebin/xdebug_off
@@ -1,4 +1,5 @@
 #!/bin/bash
 sudo phpdismod xdebug
+sudo phpenmod tideways_xhprof
 
 find /etc/init.d/ -name "php*-fpm" -exec bash -c 'sudo service "$(basename "$0")" restart' {} \;

--- a/config/homebin/xdebug_on
+++ b/config/homebin/xdebug_on
@@ -1,5 +1,6 @@
 #!/bin/bash
 sudo phpdismod tideways_xhprof
+sudo phpdismod xhgui
 sudo phpenmod xdebug
 
 find /etc/init.d/ -name "php*-fpm" -exec bash -c 'echo "Restarting $(basename "$0" ) " && sudo service "$(basename "$0")" restart' {} \;

--- a/config/homebin/xdebug_on
+++ b/config/homebin/xdebug_on
@@ -1,4 +1,5 @@
 #!/bin/bash
+sudo phpdismod tideways_xhprof
 sudo phpenmod xdebug
 
 find /etc/init.d/ -name "php*-fpm" -exec bash -c 'echo "Restarting $(basename "$0" ) " && sudo service "$(basename "$0")" restart' {} \;


### PR DESCRIPTION
## Summary:

Make sure xdebug is on OR tideways, but never both related to #1866 

## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant **v2.2.4** and VirtualBox **v6.0.8** on **MacOS**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [x] I've updated the changelog
 - [x] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
