### PR TITLE
Revert auto_trace as disabled

### DIFF
--- a/config/php-config/xdebug.ini
+++ b/config/php-config/xdebug.ini
@@ -6,7 +6,7 @@ zend_extension=xdebug.so
 ; Type: boolean, Default value: 0
 ; When this setting is set to on, the tracing of function calls will be enabled just before the
 ; script is run. This makes it possible to trace code in the auto_prepend_file.
-xdebug.auto_trace = 1
+xdebug.auto_trace = 0
 
 ; xdebug.collect_includes
 ; Type: boolean, Default value: 1


### PR DESCRIPTION
As #1866 it is better to revert this value because we will avoid that tideways and xdebug run together.