### PR TITLE
Redirects non vvv.test default domains to the vvv.test address

### DIFF
--- a/config/nginx-config/sites/default.conf
+++ b/config/nginx-config/sites/default.conf
@@ -6,10 +6,17 @@
 # placed in the /srv/www/default directory are accessible through this IP. It is
 # not intended to run WordPress through this directory.
 server {
+    listen       80;
+    listen       443 ssl;
+    server_name  vvv vvv.dev vvv.local vvv.localhost;
+    return 301 $scheme://vvv.test$request_uri;
+}
+
+server {
     listen       80 default_server;
     listen       443 ssl;
     root         /srv/www/default;
-    server_name  vvv.dev vvv.test vvv.local vvv.localhost;
+    server_name  vvv.test;
 
     include /etc/nginx/custom-dashboard-extensions/*.conf;
 


### PR DESCRIPTION
## Summary:

<!-- what does it add/fix/change/remove? -->
Redirects `vvv` `vvv.dev` etc to `vvv.test`
closes #1869

## Checks

<!--  Have you: -->
 - [ ] I've tested this PR with Vagrant **vXX** and VirtualBox **vXX** on **Operating System**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [ ] I've updated the changelog
 - [ ] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
