### PR TITLE
Enables password SSH auth, fixes #1867

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This is primarily a reliability update. Note that updating to v3.1 requires a `v
  - `xdebug_on` and `xdebug_off` now toggle Tideways so that XDebug and Tideways are never running at the same time
  - Switched to Node v10 by default to fix compatibility issues with the WP Core build scripts
  - Runs the npm commands in the main provisioner under the vagrant user
+ - Fixed Database SSH access from the host by enabling password authentication in `/etc/ssh/sshd_config`
 
 ## 3.0.0 ( 17 May 2019 )
 

--- a/config/sshd_config
+++ b/config/sshd_config
@@ -1,0 +1,124 @@
+#	$OpenBSD: sshd_config,v 1.101 2017/03/14 07:19:07 djm Exp $
+
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# This sshd was compiled with PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+# The strategy used for options in the default sshd_config shipped with
+# OpenSSH is to specify options with their default value where
+# possible, but leave them commented.  Uncommented options override the
+# default value.
+
+#Port 22
+#AddressFamily any
+#ListenAddress 0.0.0.0
+#ListenAddress ::
+
+#HostKey /etc/ssh/ssh_host_rsa_key
+#HostKey /etc/ssh/ssh_host_ecdsa_key
+#HostKey /etc/ssh/ssh_host_ed25519_key
+
+# Ciphers and keying
+#RekeyLimit default none
+
+# Logging
+#SyslogFacility AUTH
+#LogLevel INFO
+
+# Authentication:
+
+#LoginGraceTime 2m
+#PermitRootLogin prohibit-password
+#StrictModes yes
+#MaxAuthTries 6
+#MaxSessions 10
+
+#PubkeyAuthentication yes
+
+# Expect .ssh/authorized_keys2 to be disregarded by default in future.
+#AuthorizedKeysFile	.ssh/authorized_keys .ssh/authorized_keys2
+
+#AuthorizedPrincipalsFile none
+
+#AuthorizedKeysCommand none
+#AuthorizedKeysCommandUser nobody
+
+# For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
+#HostbasedAuthentication no
+# Change to yes if you don't trust ~/.ssh/known_hosts for
+# HostbasedAuthentication
+#IgnoreUserKnownHosts no
+# Don't read the user's ~/.rhosts and ~/.shosts files
+#IgnoreRhosts yes
+
+# To disable tunneled clear text passwords, change to no here!
+PasswordAuthentication yes
+#PermitEmptyPasswords no
+
+# Change to yes to enable challenge-response passwords (beware issues with
+# some PAM modules and threads)
+ChallengeResponseAuthentication no
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+#KerberosGetAFSToken no
+
+# GSSAPI options
+#GSSAPIAuthentication no
+#GSSAPICleanupCredentials yes
+#GSSAPIStrictAcceptorCheck yes
+#GSSAPIKeyExchange no
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the ChallengeResponseAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via ChallengeResponseAuthentication may bypass
+# the setting of "PermitRootLogin without-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and ChallengeResponseAuthentication to 'no'.
+UsePAM yes
+
+#AllowAgentForwarding yes
+#AllowTcpForwarding yes
+#GatewayPorts no
+X11Forwarding yes
+#X11DisplayOffset 10
+#X11UseLocalhost yes
+#PermitTTY yes
+PrintMotd no
+#PrintLastLog yes
+#TCPKeepAlive yes
+#UseLogin no
+#PermitUserEnvironment no
+#Compression delayed
+#ClientAliveInterval 0
+#ClientAliveCountMax 3
+#UseDNS no
+#PidFile /var/run/sshd.pid
+#MaxStartups 10:30:100
+#PermitTunnel no
+#ChrootDirectory none
+#VersionAddendum none
+
+# no default banner path
+#Banner none
+
+# Allow client to pass locale environment variables
+AcceptEnv LANG LC_*
+
+# override default of no subsystems
+Subsystem	sftp	/usr/lib/openssh/sftp-server
+
+# Example of overriding settings on a per-user basis
+#Match User anoncvs
+#	X11Forwarding no
+#	AllowTcpForwarding no
+#	PermitTTY no
+#	ForceCommand cvs server
+UseDNS no
+GSSAPIAuthentication no

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -285,7 +285,7 @@ profile_setup() {
   cp -f /srv/config/ssh_known_hosts /etc/ssh/ssh_known_hosts
   echo " * Enabling SSH Password Authentication for database applications"
   echo "PasswordAuthentication yes" >> /etc/ssh/sshd_config
-  systemctl restart ssh
+  systemctl reload ssh
 }
 
 not_installed() {

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -282,7 +282,9 @@ profile_setup() {
   fi
 
   echo " * Copying /srv/config/ssh_known_hosts to /etc/ssh/ssh_known_hosts"
- cp -f /srv/config/ssh_known_hosts /etc/ssh/ssh_known_hosts
+  cp -f /srv/config/ssh_known_hosts /etc/ssh/ssh_known_hosts
+  echo " * Enabling SSH Password Authentication for database applications"
+  echo "PasswordAuthentication yes" >> /etc/ssh/sshd_config
 }
 
 not_installed() {

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -283,8 +283,9 @@ profile_setup() {
 
   echo " * Copying /srv/config/ssh_known_hosts to /etc/ssh/ssh_known_hosts"
   cp -f /srv/config/ssh_known_hosts /etc/ssh/ssh_known_hosts
-  echo " * Enabling SSH Password Authentication for database applications"
-  echo "PasswordAuthentication yes" >> /etc/ssh/sshd_config
+  echo " * Copying /srv/config/sshd_config to /etc/ssh/sshd_config"
+  cp -f /srv/config/sshd_config /etc/ssh/sshd_config
+  echo " * Reloading SSH Daemon"
   systemctl reload ssh
 }
 

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -285,6 +285,7 @@ profile_setup() {
   cp -f /srv/config/ssh_known_hosts /etc/ssh/ssh_known_hosts
   echo " * Enabling SSH Password Authentication for database applications"
   echo "PasswordAuthentication yes" >> /etc/ssh/sshd_config
+  systemctl restart ssh
 }
 
 not_installed() {


### PR DESCRIPTION
## Summary:

<!-- what does it add/fix/change/remove? -->

This attempts to fix #1867

To test, run:

```sh
git checkout origin fix/dbssh
vagrant provision
```

Then attempt to connect to the database from an SQL client on the host

## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant **v2.2.4** and VirtualBox **v6.0.8** on **MacOS**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [x] I've updated the changelog
 - [x] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
