### PR TITLE
change ownership from root to vagrant for /vagrant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This is primarily a reliability update. Note that updating to v3.1 requires a `v
  - Node v11 is now auto-downgraded to Node v10
  - Fixed Database SSH access from the host by enabling password authentication in `/etc/ssh/sshd_config`
  - Added code to remove NVM
+ - Change Permission folder `/vagrant` from root to vagrant
 
 ## 3.0.0 ( 17 May 2019 )
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -524,6 +524,9 @@ cp -f /home/vagrant/vvv-custom.yml /vagrant
 # symlink the certificates folder for older site templates compat
 ln -s /srv/certificates /vagrant/certificates
 sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile
+
+# change ownership for /vagrant folder
+sudo chown -R vagrant:vagrant /vagrant
 SCRIPT
 
   config.vm.provision "initial-setup", type: "shell" do |s|


### PR DESCRIPTION
## Summary:

<!-- what does it add/fix/change/remove? -->

## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant **2.2.4** and VirtualBox **6.0.8** on **LInux**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [x] I've updated the changelog
 - [x] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->

The ownership should be now be `vagrant`
`drwxr-xr-x   2 vagrant vagrant  4096 Jun 29 22:15 vagrant`