### PR TITLE
Reset color after printing splash (to avoid weird coloring after)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -117,7 +117,7 @@ if show_logo then
     splashfirst = <<-HEREDOC
 \033[1;38;5;196m#{red}__ #{green}__ #{blue}__ __
 #{red}\\ V#{green}\\ V#{blue}\\ V / #{red}Varying #{green}Vagrant #{blue}Vagrants
-#{red} \\_/#{green}\\_/#{blue}\\_/  #{purple}v#{version}#{creset}-#{branch_c}#{git_or_zip}#{branch}
+#{red} \\_/#{green}\\_/#{blue}\\_/  #{purple}v#{version}#{creset}-#{branch_c}#{git_or_zip}#{branch}#{creset}
 
   HEREDOC
   puts splashfirst


### PR DESCRIPTION
## Summary:

Added a simple color reset to avoid branch_c bleeding over to the some other output.