### PR TITLE
Support for VMware Desktop

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -368,8 +368,8 @@ Vagrant.configure("2") do |config|
     v.cpus = vvv_config['vm_config']['cores']
   end
 
-  # Configuration options for the VMware Fusion provider.
-  config.vm.provider :vmware_fusion do |v|
+  # Configuration options for the VMware Desktop provider.
+  config.vm.provider :vmware_desktop do |v|
     v.vmx["memsize"] = vvv_config['vm_config']['memory']
     v.vmx["numvcpus"] = vvv_config['vm_config']['cores']
   end
@@ -431,14 +431,10 @@ Vagrant.configure("2") do |config|
     override.vm.box = "parallels/ubuntu-18.04"
   end
 
-  # The VMware Fusion Provider uses a different naming scheme.
-  config.vm.provider :vmware_fusion do |v, override|
-    override.vm.box = "puphpet/ubuntu1804-x64"
-  end
-
-  # VMWare Workstation can use the same package as Fusion
-  config.vm.provider :vmware_workstation do |v, override|
-    override.vm.box = "puphpet/ubuntu1804-x64"
+  # The VMware Desktop Provider uses a different naming scheme.
+  config.vm.provider :vmware_desktop do |v, override|
+    override.vm.box = "bento/ubuntu-18.04"
+    v.gui = false
   end
 
   # Hyper-V uses a different base box.


### PR DESCRIPTION
## Summary:

Firstly, this update replaces the vmware_fusion and vmware_workstation provider options with a single vmware_desktop option for both versions of VMware, accepted by the new version of the Vagrant VMware plugin by Hashicorp (https://www.hashicorp.com/blog/introducing-the-vagrant-vmware-desktop-plugin) - requiring replacement of the plugin rather than just an upgrade, as well as installation of the Vagrant VMware Utility. The new plugin will still accept vmware_fusion and vmware_workstation as provider options, however, unifying these will simplify future development of support for the VMware provider.

The new plugin and utility have resolved intermittent issues with starting the vmnet devices on vagrant up.

Secondly, this update replaces the abandoned puphpet/ubuntu1804-x64 box with the bento/ubuntu-18.04 box, for the vmware_desktop provider. It should be noted that NVM and Grunt are missing from this box.

## Checks

<!--  Have you: -->
 - [ ] I've tested this PR with Vagrant v2.2.5 and VMware Fusion 10.1.6 on Mac OSX 10.13.6
 - [ ] This PR is for the `develop` branch not the `master` branch
 - [ ] I've updated the changelog
 - [ ] This PR is complete and ready for review
