### PR TITLE
Add support for vagrant-disksize plugin.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -279,6 +279,10 @@ if show_logo then
     platform = platform + 'vagrant-vbguest '
   end
 
+  if Vagrant.has_plugin?('vagrant-disksize') then
+    platform = platform + 'vagrant-disksize '
+  end
+
   if Vagrant::Util::Platform.fs_case_sensitive? then
     platform = platform + 'CaseSensitiveFS '
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -230,6 +230,7 @@ end
 defaults = Hash.new
 defaults['memory'] = 2048
 defaults['cores'] = 1
+defaults['disksize'] = '10GB'
 # This should rarely be overridden, so it's not included in the default vvv-config.yml file.
 defaults['private_network_ip'] = '192.168.50.4'
 
@@ -449,6 +450,21 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.hostname = "vvv"
+
+  # Specify disk size
+  #
+  # If the Vagrant plugin disksize (https://github.com/sprotheroe/vagrant-disksize) is
+  # installed, the following will automatically configure your local machine's disk size
+  # to be the specified size. This plugin only works on VirtualBox.
+  #
+  # Warning: This plugin only resizes up, not down, so don't set this to less than 10GB,
+  # and if you need to downsize, be sure to destroy and reprovision.
+  #
+  if defined?(Vagrant::Disksize)
+    config.vm.provider :virtualbox do |v, override|
+      override.disksize.size = vvv_config['vm_config']['disksize']
+    end
+  end
 
   # Private Network (default)
   #

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -230,12 +230,15 @@ end
 defaults = Hash.new
 defaults['memory'] = 2048
 defaults['cores'] = 1
-defaults['disksize'] = '10GB'
 # This should rarely be overridden, so it's not included in the default vvv-config.yml file.
 defaults['private_network_ip'] = '192.168.50.4'
 
 vvv_config['vm_config'] = defaults.merge(vvv_config['vm_config'])
 vvv_config['hosts'] = vvv_config['hosts'].uniq
+
+if ! vvv_config['vagrant-plugins']
+  vvv_config['vagrant-plugins'] = Hash.new
+end
 
 # Show the second splash screen section
 
@@ -464,9 +467,9 @@ Vagrant.configure("2") do |config|
   # Warning: This plugin only resizes up, not down, so don't set this to less than 10GB,
   # and if you need to downsize, be sure to destroy and reprovision.
   #
-  if defined?(Vagrant::Disksize)
+  if vvv_config['vagrant-plugins']['disksize'] != nil && defined?(Vagrant::Disksize)
     config.vm.provider :virtualbox do |v, override|
-      override.disksize.size = vvv_config['vm_config']['disksize']
+      override.disksize.size = vvv_config['vagrant-plugins']['disksize']
     end
   end
 

--- a/vvv-config.yml
+++ b/vvv-config.yml
@@ -103,6 +103,8 @@ vm_config:
   memory: 2048
   # CPU cores:
   cores: 2
+  # Disk size. Requires plugin vagrant-disksize
+  disksize: 10GB
 
   # this tells VVV to use the prebuilt box copied from the USB drive at contributor days
   # once set to false, do not change back to true, and reprovision

--- a/vvv-config.yml
+++ b/vvv-config.yml
@@ -103,8 +103,6 @@ vm_config:
   memory: 2048
   # CPU cores:
   cores: 2
-  # Disk size. Requires plugin vagrant-disksize
-  disksize: 10GB
 
   # this tells VVV to use the prebuilt box copied from the USB drive at contributor days
   # once set to false, do not change back to true, and reprovision


### PR DESCRIPTION
## Summary:

This adds support (and checks for the availabilty) for the [vagrant-disksize](https://github.com/sprotheroe/vagrant-disksize) plugin.

This will allow to bypass issues related to disk space issues when `db_share_type` is set to false, or if somebody just wants more space.

## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant **v2.2.4** and VirtualBox **v6.0.8** on **macOS**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [ ] I've updated the changelog
 - [x] This PR is complete and ready for review