### PR TITLE
Changed db_share_type checks and defaults

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -549,13 +549,13 @@ SCRIPT
   # This directory is used to maintain default database scripts as well as backed
   # up MariaDB/MySQL dumps (SQL files) that are to be imported automatically on vagrant up
   config.vm.synced_folder "database/sql/", "/srv/database"
-  use_db_share = true
+  use_db_share = false
 
   if defined? vvv_config['general']['db_share_type'] then
-    if vvv_config['general']['db_share_type'] != false then
-      use_db_share = true
-    else
+    if vvv_config['general']['db_share_type'] != true then
       use_db_share = false
+    else
+      use_db_share = true
     end
   end
   if use_db_share == true then


### PR DESCRIPTION
Changed how the db_share_type was checked, and set its default value if undefined, to off

We know that off always works, so lets switch to that by default and avoid the support hassle for end users at the same time. Decisions not options! They can always opt into it in future

Additionally, the splash screen checked if the value was true, or anything else. The actual conditional checked if it was false, or anything else. Now both check if it's true or anything else for consistency

## Checks

<!--  Have you: -->
 - [ ] I've tested this PR with Vagrant **vXX** and VirtualBox **vXX** on **Operating System**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [ ] I've updated the changelog
 - [ ] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->


@TODO: Update the changelog before merge as this might cause issues for users who use the shared folder and run `develop`. We should also update this PR with a message telling people the value is undefined and what VVV is going to do by default and how to change it