### PR TITLE
Disable Mysql binary logging

### DIFF
--- a/config/mysql-config/vvv-core.cnf
+++ b/config/mysql-config/vvv-core.cnf
@@ -1,3 +1,2 @@
 [mysqld]
 innodb_use_native_aio = 0
-log_bin = ON


### PR DESCRIPTION
fix #1925

## Summary:

This parameter is useful when we are doing database replications and other things that in a dev instance like that we are not using.
Also can improve the performance as suggested in the ticket itself.
