### PR TITLE
Update Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -326,9 +326,16 @@ if show_logo then
     platform = platform + 'shared_db_folder_default '
   end
 
-  splashsecond = <<-HEREDOC
+  if vvv_config['vm_config']['provider'] == 'virtualbox' then
+    virtualbox_version = virtualbox_version()
+  else
+    virtualbox_version = "N/A"
+  end
+
+splashsecond = <<-HEREDOC
 #{yellow}Platform:   #{yellow}#{platform}
-#{green}Vagrant:    #{green}v#{Vagrant::VERSION},	#{blue}VirtualBox: #{blue}v#{virtualbox_version()}
+#{green}Vagrant:    #{green}v#{Vagrant::VERSION}
+#{blue}VirtualBox: #{blue}v#{virtualbox_version}
 #{purple}VVV Path:   "#{vagrant_dir}"
 
 #{docs}Docs:       #{url}https://varyingvagrantvagrants.org/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -333,10 +333,8 @@ if show_logo then
   end
 
 splashsecond = <<-HEREDOC
-#{yellow}Platform:   #{yellow}#{platform}
-#{green}Vagrant:    #{green}v#{Vagrant::VERSION}
-#{blue}VirtualBox: #{blue}v#{virtualbox_version}
-#{purple}VVV Path:   "#{vagrant_dir}"
+#{yellow}Platform: #{yellow}#{platform}, #{purple}VVV Path: "#{vagrant_dir}"
+#{green}Vagrant: #{green}v#{Vagrant::VERSION}, #{blue}VirtualBox: #{blue}v#{virtualbox_version}
 
 #{docs}Docs:       #{url}https://varyingvagrantvagrants.org/
 #{docs}Contribute: #{url}https://github.com/varying-vagrant-vagrants/vvv


### PR DESCRIPTION
## Summary:

With this fix we can use vvv with hyperv if virtualbox is not installed

## Checks

<!--  Have you: -->
 - [X] I've tested this PR with Vagrant **2.2.5** on **Windows 10 1903**
 - [X] This PR is for the `develop` branch not the `master` branch
 - [ ] I've updated the changelog
 - [X] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
