### PR TITLE
Allow to clone provisioner in an empty directory.

### DIFF
--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -107,7 +107,7 @@ if [[ true == $SKIP_PROVISIONING ]]; then
 fi
 
 if [[ false != "${REPO}" ]]; then
-  if [[ -d ${VM_DIR} ]]; then
+  if [[ -d ${VM_DIR} ]] && [[ ! -z "$(ls -A ${VM_DIR})" ]]; then
     if [[ -d ${VM_DIR}/.git ]]; then
     	echo -e "\nUpdating ${SITE} in ${VM_DIR}..."
     	cd ${VM_DIR}


### PR DESCRIPTION
This makes the site provisioner check if the destination folder is not empty (meaning there's potential code there that could get destroyed).

If the folder doesn't exists, or if it's empty, it should allow to clone the repo in no problem.