### PR TITLE
Enable mailhog on all PHP instances

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -764,7 +764,7 @@ services_restart() {
   phpdismod xdebug
 
   # Enable PHP mailcatcher sendmail settings by default
-  phpenmod mailhog
+  phpenmod -s fpm mailhog
 
   # Restart all php-fpm versions
   find /etc/init.d/ -name "php*-fpm" -exec bash -c 'sudo service "$(basename "$0")" restart' {} \;

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -763,7 +763,7 @@ services_restart() {
   # Disable PHP Xdebug module by default
   phpdismod xdebug
 
-  # Enable PHP mailcatcher sendmail settings by default
+  # Enable PHP MailHog sendmail settings by default
   phpenmod -s fpm mailhog
 
   # Restart all php-fpm versions


### PR DESCRIPTION
## Summary:

Fixes #1953 

## Checks

 - [x] I've tested this PR with Vagrant **v3.1.1** and VirtualBox **v6.0.12** on **macOS 10.15**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [ ] I've updated the changelog
 - [x] This PR is complete and ready for review

