### PR TITLE
add php74 to the default config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ title: Changelog
 permalink: /docs/en-US/changelog/
 ---
 
+## 3.2.0 ( 2019 )
+
+### Enhancements
+
+ - Improved output of `xdebug_on` and `xdebug_off`
+ - Updated the default config to reference PHP 7.4 support
+ - webgrind is now provisioned using composer
+ - Added support for the vagrant-disksize plugin if available
+
+### Bug Fixes
+
+ - Fixed cloning site provisioners into empty directories
+ - Enabled MailHog for all PHP versions
+ - Removed trailing spaces from all provisioner files and configs
+ - `my.cnf` is now readable by the vagrant user
+ - Fixes to newline substitution in the splash screen and some rearrangement
+ - MySQL binary logging is now disabled
+
 ## 3.1.1 ( 2019 August 6th )
 
 This is a quick update that changes a default parameter when undefined. In VVV 2 the database was stored inside the VM, and in VVV 3 we put it in a shared folder. This didn't work for some people, so we added a config option to disable this. If this option wasn't set, VVV would use the shared folder.

--- a/config/homebin/xdebug_off
+++ b/config/homebin/xdebug_off
@@ -1,6 +1,12 @@
 #!/bin/bash
+echo "Disabling XDebug if it's present"
 sudo phpdismod xdebug
+
+echo "Enabling tideways_xhprof and xhgui if installed"
 sudo phpenmod tideways_xhprof
 sudo phpenmod xhgui
 
+echo "Restarting PHP FPM's"
 find /etc/init.d/ -name "php*-fpm" -exec bash -c 'sudo service "$(basename "$0")" restart' {} \;
+
+echo "XDebug is turned off"

--- a/config/homebin/xdebug_on
+++ b/config/homebin/xdebug_on
@@ -1,10 +1,15 @@
 #!/bin/bash
+echo "Disabling tideways_xhprof/xhgui if present"
 sudo phpdismod tideways_xhprof
 sudo phpdismod xhgui
+echo "Enabling XDebug"
 sudo phpenmod xdebug
 
 find /etc/init.d/ -name "php*-fpm" -exec bash -c 'echo "Restarting $(basename "$0" ) " && sudo service "$(basename "$0")" restart' {} \;
 
 # Ensure the log file for xdebug is group writeable.
+echo "Making sure log/php/xdebug-remote.log is readable and present"
 sudo touch /var/log/php/xdebug-remote.log
 sudo chmod 664 /var/log/php/xdebug-remote.log
+
+echo "XDebug enabled! Note that XDebug doesn't always support the newest version of PHP immediatley, check the XDebug site for more details"

--- a/vvv-config.yml
+++ b/vvv-config.yml
@@ -103,6 +103,7 @@ utilities:
     #- php71
     #- php72
     #- php73
+    #- php74
 
 # vm_config controls how Vagrant provisions the virtual machine, and can be used to
 # increase the memory given to VVV and the number of CPU cores.


### PR DESCRIPTION
## Summary:

php 7.4 support got merged into the utilities repo, so anybody with VVV 3.0+ can use it, this PR just makes it a little nicer, quality of life stuff

## Checks

<!--  Have you: -->
 - [ ] I've tested this PR with Vagrant **vXX** and VirtualBox **vXX** on **Operating System**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [ ] I've updated the changelog
 - [ ] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
