### PR TITLE
attempt to pipe all site provisioner output to the log files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ permalink: /docs/en-US/changelog/
  - Updated the default config to reference PHP 7.4 support
  - webgrind is now provisioned using composer
  - Added support for the vagrant-disksize plugin if available
+ - Site provisioner output is now piped to the log file to simplify the terminal output. Errors should still be sent to the terminal
 
 ### Bug Fixes
 

--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -147,13 +147,21 @@ if [[ ! -d ${VM_DIR} ]]; then
   echo "Error: The ${VM_DIR} folder does not exist, there is nothing to provision for the '${SITE}' site!"
 fi
 
+function vvv_run_site_template_script() {
+  echo "Found ${2} at ${1}/${1}"
+  echo "Script output will be logged to: ${logfile}"
+  ( cd "${DIR}" && source $1  2>&1 | tee -a $logfile )
+  echo "${2} has completed with return code: ${?}"
+}
+
 # Look for site setup scripts
+echo "Searching for site template provisioner, vvv-init.sh"
 if [[ -f "${VM_DIR}/.vvv/vvv-init.sh" ]]; then
-  ( cd "${VM_DIR}/.vvv" && source vvv-init.sh )
+  vvv_run_site_template_script "vvv-init.sh" "${VM_DIR}/.vvv"
 elif [[ -f "${VM_DIR}/provision/vvv-init.sh" ]]; then
-  ( cd "${VM_DIR}/provision" && source vvv-init.sh )
+  vvv_run_site_template_script "vvv-init.sh" "${VM_DIR/provision}"
 elif [[ -f "${VM_DIR}/vvv-init.sh" ]]; then
-  ( cd "${VM_DIR}" && source vvv-init.sh )
+  vvv_run_site_template_script "vvv-init.sh" "${VM_DIR}"
 else
   echo "Warning: A site provisioner was not found at .vvv/vvv-init.conf provision/vvv-init.conf or vvv-init.conf, searching 3 folders down, please be patient..."
   SITE_INIT_SCRIPTS=$(find ${VM_DIR} -maxdepth 3 -name 'vvv-init.conf');
@@ -162,7 +170,7 @@ else
   else
     for SITE_INIT_SCRIPT in $SITE_INIT_SCRIPTS; do
       DIR="$(dirname "$SITE_INIT_SCRIPT")"
-      ( cd "${DIR}" &&  source vvv-init.sh )
+      vvv_run_site_template_script "vvv-init.sh" "${DIR}"
     done
   fi
 fi

--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -111,7 +111,7 @@ if [[ true == $SKIP_PROVISIONING ]]; then
   return
 fi
 
-echo -e "${BLUE}Running provisioner for site ${SITE}${CRESET}"
+echo -e "${GREEN}Running provisioner for site ${SITE}${CRESET}"
 
 if [[ false != "${REPO}" ]]; then
   if [[ -d ${VM_DIR} ]] && [[ ! -z "$(ls -A ${VM_DIR})" ]]; then
@@ -148,10 +148,10 @@ if [[ ! -d ${VM_DIR} ]]; then
 fi
 
 function vvv_run_site_template_script() {
-  echo "Found ${2} at ${1}/${1}"
+  echo "Found ${1} at ${2}/${1}"
   echo "Script output will be logged to: ${logfile}"
-  ( cd "${DIR}" && source $1  2>&1 | tee -a $logfile )
-  echo "${2} has completed with return code: ${?}"
+  ( cd "${2}" && source "${1}" >> $logfile )
+  echo "${2}/${1} has completed with return code: ${?}"
 }
 
 # Look for site setup scripts
@@ -159,7 +159,7 @@ echo "Searching for site template provisioner, vvv-init.sh"
 if [[ -f "${VM_DIR}/.vvv/vvv-init.sh" ]]; then
   vvv_run_site_template_script "vvv-init.sh" "${VM_DIR}/.vvv"
 elif [[ -f "${VM_DIR}/provision/vvv-init.sh" ]]; then
-  vvv_run_site_template_script "vvv-init.sh" "${VM_DIR/provision}"
+  vvv_run_site_template_script "vvv-init.sh" "${VM_DIR}/provision"
 elif [[ -f "${VM_DIR}/vvv-init.sh" ]]; then
   vvv_run_site_template_script "vvv-init.sh" "${VM_DIR}"
 else


### PR DESCRIPTION
## Summary:

This attempts to pipe all site template provisioning to the log file, bypassing the terminal, needs testing and polish

## Checks

<!--  Have you: -->
 - [ ] I've tested this PR with Vagrant **vXX** and VirtualBox **vXX** on **Operating System**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [x] I've updated the changelog
 - [ ] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
