### PR TITLE
Adjusted default permissions for vmware using umask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ permalink: /docs/en-US/changelog/
  - `my.cnf` is now readable by the vagrant user
  - Fixes to newline substitution in the splash screen and some rearrangement
  - MySQL binary logging is now disabled
+ - Synced folder permission fixes for VMWare
 
 ## 3.1.1 ( 2019 August 6th )
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -697,16 +697,16 @@ SCRIPT
   # those are specific to Virtualbox. The folder is therefore overridden with one that
   # uses corresponding VMware mount options.
   config.vm.provider :vmware_desktop do |v, override|
-    override.vm.synced_folder "www/", "/srv/www", owner: "vagrant", group: "www-data", :mount_options => []
+    override.vm.synced_folder "www/", "/srv/www", owner: "vagrant", group: "www-data", :mount_options => [ "umask=002"  ]
 
-    override.vm.synced_folder "log/memcached", "/var/log/memcached", owner: "root", create: true,  group: "syslog", mount_options: []
-    override.vm.synced_folder "log/nginx", "/var/log/nginx", owner: "root", create: true,  group: "syslog", mount_options: []
-    override.vm.synced_folder "log/php", "/var/log/php", create: true, owner: "root", group: "syslog", mount_options: []
-    override.vm.synced_folder "log/provisioners", "/var/log/provisioners", create: true, owner: "root", group: "syslog", mount_options: []
+    override.vm.synced_folder "log/memcached", "/var/log/memcached", owner: "root", create: true,  group: "syslog", mount_options: [ "umask=000" ]
+    override.vm.synced_folder "log/nginx", "/var/log/nginx", owner: "root", create: true,  group: "syslog", mount_options: [ "umask=000" ]
+    override.vm.synced_folder "log/php", "/var/log/php", create: true, owner: "root", group: "syslog", mount_options: [ "umask=000" ]
+    override.vm.synced_folder "log/provisioners", "/var/log/provisioners", create: true, owner: "root", group: "syslog", mount_options: [ "umask=000" ]
 
     vvv_config['sites'].each do |site, args|
       if args['local_dir'] != File.join(vagrant_dir, 'www', site) then
-        override.vm.synced_folder args['local_dir'], args['vm_dir'], owner: "vagrant", group: "www-data", :mount_options => []
+        override.vm.synced_folder args['local_dir'], args['vm_dir'], owner: "vagrant", group: "www-data", :mount_options => [ "umask=002" ]
       end
     end
   end


### PR DESCRIPTION
## Summary:

This uses `umask` to attempt to replicate the default permissions set in VirtualBox as closely as possible. Some are identical, a couple have slightly different file permissions because of how `umask` works, but it doesn't seem to be causing any issues on my end so far.

This should hopefully resolve #1974 

## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant 2.2.5 and VMware Workstation 15.5.0 build-14665864 on Ubuntu 18.04.3 
 - [x] This PR is for the `develop` branch not the `master` branch
 - [x] I've updated the changelog
 - [x] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
