### PR TITLE
Mounted folder fixes for Parallels, and shared DB support for Parallels and VMWare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ permalink: /docs/en-US/changelog/
  - Fixes to newline substitution in the splash screen and some rearrangement
  - MySQL binary logging is now disabled
  - Synced folder permission fixes for VMWare
+ - Shared DB mounts are now mounted on Parallels and VMWare
+ - Fixed `/var/log` being mounted on Parallels and VMWare
 
 ## 3.1.1 ( 2019 August 6th )
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -657,7 +657,16 @@ SCRIPT
   # uses corresponding Parallels mount options.
   config.vm.provider :parallels do |v, override|
     override.vm.synced_folder "www/", "/srv/www", :owner => "www-data", :mount_options => []
-    override.vm.synced_folder "log/", "/var/log", :owner => "vagrant", :mount_options => []
+
+    override.vm.synced_folder "log/memcached", "/var/log/memcached", owner: "root", create: true,  group: "syslog", mount_options: []
+    override.vm.synced_folder "log/nginx", "/var/log/nginx", owner: "root", create: true,  group: "syslog", mount_options: []
+    override.vm.synced_folder "log/php", "/var/log/php", create: true, owner: "root", group: "syslog", mount_options: []
+    override.vm.synced_folder "log/provisioners", "/var/log/provisioners", create: true, owner: "root", group: "syslog", mount_options: []
+
+    if use_db_share == true then
+      # Map the MySQL Data folders on to mounted folders so it isn't stored inside the VM
+      override.vm.synced_folder "database/data/", "/var/lib/mysql", create: true, owner: 112, group: 115, mount_options: []
+    end
 
     vvv_config['sites'].each do |site, args|
       if args['local_dir'] != File.join(vagrant_dir, 'www', site) then
@@ -703,6 +712,11 @@ SCRIPT
     override.vm.synced_folder "log/nginx", "/var/log/nginx", owner: "root", create: true,  group: "syslog", mount_options: [ "umask=000" ]
     override.vm.synced_folder "log/php", "/var/log/php", create: true, owner: "root", group: "syslog", mount_options: [ "umask=000" ]
     override.vm.synced_folder "log/provisioners", "/var/log/provisioners", create: true, owner: "root", group: "syslog", mount_options: [ "umask=000" ]
+
+    if use_db_share == true then
+      # Map the MySQL Data folders on to mounted folders so it isn't stored inside the VM
+      override.vm.synced_folder "database/data/", "/var/lib/mysql", create: true, owner: 112, group: 115, mount_options: [ "umask=000" ]
+    end
 
     vvv_config['sites'].each do |site, args|
       if args['local_dir'] != File.join(vagrant_dir, 'www', site) then


### PR DESCRIPTION
## Summary:

Fixed the mounted folders for logs for parallels, and shared db folder mounts, also updated vmware accordingly.

Note that the shared DB folder mounts may not work, but they're prone to issues as is and it's off by default, so no change there

## Checks

<!--  Have you: -->
 - [ ] I've tested this PR with Vagrant **vXX** and VirtualBox **vXX** on **Operating System**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [x] I've updated the changelog
 - [x] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
