### PR TITLE
removed /var/log/ for Microsoft Hyper-V, no need

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ permalink: /docs/en-US/changelog/
  - Fixes to newline substitution in the splash screen and some rearrangement
  - MySQL binary logging is now disabled
  - Synced folder permission fixes for VMWare
+ - Removed `/var/log` for Microsoft Hyper-V
 
 ## 3.1.1 ( 2019 August 6th )
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -674,7 +674,6 @@ SCRIPT
     v.vmname = File.basename(vagrant_dir) + "_" + (Digest::SHA256.hexdigest vagrant_dir)[0..10]
 
     override.vm.synced_folder "www/", "/srv/www", :owner => "vagrant", :group => "www-data", :mount_options => [ "dir_mode=0775", "file_mode=0774" ]
-    override.vm.synced_folder "log/", "/var/log", :owner => "vagrant", :mount_options => []
 
     if use_db_share == true then
       # Map the MySQL Data folders on to mounted folders so it isn't stored inside the VM


### PR DESCRIPTION
## Summary:

<!-- what does it add/fix/change/remove? -->
We have fixed where the /var/log was still available when using Hyper-V, so we removed it, and works now with no issues with MariaDB. 
## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant **2.2.6** and HyperV on **Windows 10 Pro**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [x] I've updated the changelog
 - [x] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
