### PR TITLE
Fix typo

### DIFF
--- a/config/homebin/xdebug_on
+++ b/config/homebin/xdebug_on
@@ -12,4 +12,4 @@ echo "Making sure log/php/xdebug-remote.log is readable and present"
 sudo touch /var/log/php/xdebug-remote.log
 sudo chmod 664 /var/log/php/xdebug-remote.log
 
-echo "XDebug enabled! Note that XDebug doesn't always support the newest version of PHP immediatley, check the XDebug site for more details"
+echo "XDebug enabled! Note that XDebug doesn't always support the newest version of PHP immediately, check the XDebug site for more details"


### PR DESCRIPTION
## Summary:

<!-- what does it add/fix/change/remove? -->
* Fix a typo on the output message when activating the XDebug.

## Checks

<!--  Have you: -->
 - [x] I've tested this PR with Vagrant **3.2.0** and VirtualBox **6.0.14** on **MacOS Catalina**
 - [x] This PR is for the `develop` branch not the `master` branch
 - [ ] I've updated the changelog
 - [x] This PR is complete and ready for review
 
 <!-- don't forget to fill out the bolded parts -->
