### PR TITLE
Vagrant VVV commands

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -882,11 +882,10 @@ class VVVScripts < Vagrant.plugin(2, :command)
   end
 
   def execute
-      puts "#{$yellow}Executing #{$red}#{ARGV[1]}#{$creset}\n\n"
-      Vagrant.configure("2") do |config|
-        config.vm.provision "shell", keep_color: true, run: 'always', path: "/srv/config/homebin/#{ARGV[1]}"
-      end
-    0
+    with_target_vms(nil, single_target: true) do |vm|
+      @env.ui.output "#{$yellow}Executing #{$red}#{ARGV[1]}#{$creset}\n"
+      vm.action(:ssh_run, ssh_run_command: "/srv/config/homebin/#{ARGV[1]}" )
+    end
   end
 end
 
@@ -896,11 +895,10 @@ class VVVCommand < Vagrant.plugin(2, :command)
   end
 
   def execute
-      puts "#{$yellow}Executing in #{$red}#{ARGV[1]} #{$yellow}: #{$red}#{ARGV[2]}#{$creset}\n\n"
-      Vagrant.configure("2") do |config|
-        config.vm.provision "shell", keep_color: true, run: 'always', path: "/srv/www/#{ARGV[1]}/public_html; #{ARGV[2]}"
-      end
-    0
+    with_target_vms(nil, single_target: true) do |vm|
+      @env.ui.output "#{$yellow}Executing in #{$red}#{ARGV[1]} #{$yellow}: #{$red}#{ARGV[2]}#{$creset}\n"
+      vm.action(:ssh_run, ssh_run_command: "cd /srv/www/#{ARGV[1]}/public_html; #{ARGV[2]}")
+    end
   end
 end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -256,6 +256,9 @@ if ! vvv_config['vagrant-plugins']
   vvv_config['vagrant-plugins'] = Hash.new
 end
 
+# Create a global variable to use in functions and classes
+$vvv_config = vvv_config
+
 # Show the second splash screen section
 
 if show_logo then
@@ -895,9 +898,16 @@ class VVVCommand < Vagrant.plugin(2, :command)
   end
 
   def execute
+    vm_dir = "/srv/www/#{ARGV[1]}/public_html"
+    $vvv_config['sites'].each do |site, args|
+      if site == ARGV[1]
+        vm_dir = args['vm_dir']
+      end
+    end
+
     with_target_vms(nil, single_target: true) do |vm|
       @env.ui.output "#{$yellow}Executing in #{$red}#{ARGV[1]}#{$yellow}: #{$red}#{ARGV[2]}#{$creset}\n"
-      vm.action(:ssh_run, ssh_run_command: "cd /srv/www/#{ARGV[1]}/public_html; #{ARGV[2]}")
+      vm.action(:ssh_run, ssh_run_command: "cd #{$vm_dir}; #{ARGV[2]}")
     end
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -896,7 +896,7 @@ class VVVCommand < Vagrant.plugin(2, :command)
 
   def execute
     with_target_vms(nil, single_target: true) do |vm|
-      @env.ui.output "#{$yellow}Executing in #{$red}#{ARGV[1]} #{$yellow}: #{$red}#{ARGV[2]}#{$creset}\n"
+      @env.ui.output "#{$yellow}Executing in #{$red}#{ARGV[1]}#{$yellow}: #{$red}#{ARGV[2]}#{$creset}\n"
       vm.action(:ssh_run, ssh_run_command: "cd /srv/www/#{ARGV[1]}/public_html; #{ARGV[2]}")
     end
   end


### PR DESCRIPTION
Added 2 new commands and fix #1967 and #1531.

```
vagrant command wordpress-develop "ls -l"
```
To see the list of files inside that folder  but can be used for other stuff (grunt watch).

Instead `vagrant script xdebug_on` will execute that script.
