### PR TITLE
replace the escaping on site names so that they work agan with dots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ permalink: /docs/en-US/changelog/
 
 * Installs the ntp date packages and starts the ntp service to fix time drift on sleep
 * Fixes an issue with the ntpsec package by removing it
+* Fixed the use of dots in site names breaking provisioning
 
 ## 3.2.0 ( 2019 )
 

--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 SITE=$1
-SITE_ESCAPED=$(echo "${SITE}" | sed 's/\./\\\\./g')
+SITE_ESCAPED="${SITE//./\\.}"
 REPO=$2
 BRANCH=$3
 VM_DIR=$4


### PR DESCRIPTION
## Summary:

Switches to the faster/simpler bash based string substitution

<!-- what does it add/fix/change/remove? -->

## Checks

<!--  Have you: -->

* [x] I've tested this PR with Vagrant **vXX** and VirtualBox **vXX** on **Operating System**
* [x] This PR is for the `develop` branch not the `master` branch.
* [x] I've updated the changelog.
* [x] This PR is complete and ready for review.
 
 <!-- don't forget to fill out the bolded parts -->
