### PR TITLE
Change site provision to support multiple hosts in NGINX config

### DIFF
--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -41,7 +41,7 @@ get_config_value() {
 }
 
 get_hosts() {
-  local value=$(shyaml get-values "sites.${SITE_ESCAPED}.hosts" 2> /dev/null < ${VVV_CONFIG})
+  local value=$(shyaml get-values-0 "sites.${SITE_ESCAPED}.hosts" 2> /dev/null < ${VVV_CONFIG} | tr '\0' ' ' | sed 's/ *$//')
   echo "${value:-$@}"
 }
 


### PR DESCRIPTION
## Summary:

Included in this PR is a small change to the `get_hosts()` function in the `provision/provision-site.sh` to allow multiple hosts to be included as part of the `server_name` directive in NGINX. This is useful for testing local installations which need to develop and / or test in tandem with domain mapping capabilities, either that provided in WordPress Core from 4.5 onwards or with a plugin.

It is achieved with the following changes;

* Switching `shyaml get-values` to `shyaml get-values-0` which returns a null-terminated string (to save from any potential confusion around newline characters).
* Piped in to `tr '\0' ' '` which replaces the null character with a space.
* Piped in to `sed 's/ *$//'` to trim the leading / trailing whitespace.

I have tested this with a single host and multiple hosts to ensure that both work as intended.

This permits multiple hosts to be specified in the `config.yml`, example next, without needing to create a `vvv-nginx-custom.conf`.

```yaml
  wordpress-multisite:
    skip_provisioning: false
    repo: https://github.com/Varying-Vagrant-Vagrants/custom-site-template.git
    custom:
      wp_type: subdirectory
    hosts:
      - three.wordpress.test
      - wordpressthree1.test
      - wordpressthree2.test
```

## Checks

* [x] I've tested this PR with Vagrant **v2.2.6** and VirtualBox **v6.0.14 r133895** on **macOS 10.15.1**.
* [x] This PR is for the `develop` branch not the `master` branch.
* [ ] I've updated the changelog.
* [ ] This PR is complete and ready for review.