### PR TITLE
Fix potentially broken nginx_upstream.

### DIFF
--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -78,7 +78,7 @@ function vvv_provision_site_nginx() {
   sed -i "s#{vvv_hosts}#${VVV_HOSTS}#" "/etc/nginx/custom-sites/${DEST_NGINX_FILE}"
 
   if [ 'php' != "${NGINX_UPSTREAM}" ] && [ ! -f "/etc/nginx/upstreams/${NGINX_UPSTREAM}.conf" ]; then
-    echo -e "${YELLOW} * Upstream ${NGINX_UPSTREAM} not found. Defaulting to php.${CRESET}"
+    echo -e "${YELLOW} * Upstream value '${NGINX_UPSTREAM}' doesn't match a valid upstream. Defaulting to 'php'.${CRESET}"
     NGINX_UPSTREAM='php'
   fi
   sed -i "s#{upstream}#${NGINX_UPSTREAM}#" "/etc/nginx/custom-sites/${DEST_NGINX_FILE}"

--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -76,6 +76,11 @@ function vvv_provision_site_nginx() {
   sed -i "s#{vvv_path_to_site}#${VM_DIR}#" "/etc/nginx/custom-sites/${DEST_NGINX_FILE}"
   sed -i "s#{vvv_site_name}#${SITE}#" "/etc/nginx/custom-sites/${DEST_NGINX_FILE}"
   sed -i "s#{vvv_hosts}#${VVV_HOSTS}#" "/etc/nginx/custom-sites/${DEST_NGINX_FILE}"
+
+  if [ 'php' != "${NGINX_UPSTREAM}" ] && [ ! -f "/etc/nginx/upstreams/${NGINX_UPSTREAM}.conf" ]; then
+    echo -e "${YELLOW} * Upstream ${NGINX_UPSTREAM} not found. Defaulting to php.${CRESET}"
+    NGINX_UPSTREAM='php'
+  fi
   sed -i "s#{upstream}#${NGINX_UPSTREAM}#" "/etc/nginx/custom-sites/${DEST_NGINX_FILE}"
 
   if [ -n "$(type -t is_utility_installed)" ] && [ "$(type -t is_utility_installed)" = function ] && $(is_utility_installed core tls-ca); then


### PR DESCRIPTION
This fixes #2028.

Accepts php or any valid upstream in the /etc/nginx/upstreams directory.

Example output:

![image](https://user-images.githubusercontent.com/6192180/71015971-38b81d80-20d3-11ea-9a7f-84c8f500b1df.png)

