### PR TITLE
Improve tideways integration

### DIFF
--- a/config/homebin/is_utility_installed
+++ b/config/homebin/is_utility_installed
@@ -1,0 +1,10 @@
+#!/bin/bash
+VVV_CONFIG=/vagrant/config.yml
+
+utilities=$(shyaml get-values "utilities.${1}" 2> /dev/null < ${VVV_CONFIG})
+for utility in ${utilities}; do
+if [[ "${utility}" == "${2}" ]]; then
+  exit 0
+fi
+done
+exit 1

--- a/config/homebin/tideways_off
+++ b/config/homebin/tideways_off
@@ -1,0 +1,14 @@
+#!/bin/bash
+if [[ ! $(is_utility_installed core tideways) ]]; then
+  echo "Tideways is not installed"
+  exit 0
+fi
+
+echo "Enabling tideways_xhprof/xhgui"
+sudo phpdismod tideways_xhprof
+sudo phpdismod xhgui
+
+echo "Restarting PHP FPM's"
+find /etc/init.d/ -name "php*-fpm" -exec bash -c 'sudo service "$(basename "$0")" restart' {} \;
+
+echo "Tideways is turned off"

--- a/config/homebin/tideways_off
+++ b/config/homebin/tideways_off
@@ -4,7 +4,7 @@ if [[ ! $(is_utility_installed core tideways) ]]; then
   exit 0
 fi
 
-echo "Enabling tideways_xhprof/xhgui"
+echo "Disabling tideways_xhprof/xhgui"
 sudo phpdismod tideways_xhprof
 sudo phpdismod xhgui
 

--- a/config/homebin/tideways_on
+++ b/config/homebin/tideways_on
@@ -1,0 +1,17 @@
+#!/bin/bash
+if [[ ! $(is_utility_installed core tideways) ]]; then
+  echo "Tideways is not installed"
+  exit 0
+fi
+
+echo "Disabling XDebug if it's present"
+sudo phpdismod xdebug
+
+echo "Enabling tideways_xhprof/xhgui"
+sudo phpenmod tideways_xhprof
+sudo phpenmod xhgui
+
+echo "Restarting PHP FPM's"
+find /etc/init.d/ -name "php*-fpm" -exec bash -c 'sudo service "$(basename "$0")" restart' {} \;
+
+echo "Tideways enabled!"

--- a/config/homebin/xdebug_off
+++ b/config/homebin/xdebug_off
@@ -2,10 +2,6 @@
 echo "Disabling XDebug if it's present"
 sudo phpdismod xdebug
 
-echo "Enabling tideways_xhprof and xhgui if installed"
-sudo phpenmod tideways_xhprof
-sudo phpenmod xhgui
-
 echo "Restarting PHP FPM's"
 find /etc/init.d/ -name "php*-fpm" -exec bash -c 'sudo service "$(basename "$0")" restart' {} \;
 

--- a/config/homebin/xdebug_on
+++ b/config/homebin/xdebug_on
@@ -1,7 +1,11 @@
 #!/bin/bash
-echo "Disabling tideways_xhprof/xhgui if present"
-sudo phpdismod tideways_xhprof
-sudo phpdismod xhgui
+
+if [[ $(is_utility_installed core tideways) ]]; then
+  echo "Disabling tideways_xhprof/xhgui"
+  sudo phpdismod tideways_xhprof
+  sudo phpdismod xhgui
+fi
+
 echo "Enabling XDebug"
 sudo phpenmod xdebug
 

--- a/config/homebin/xdebug_on
+++ b/config/homebin/xdebug_on
@@ -1,9 +1,6 @@
 #!/bin/bash
-
 if [[ $(is_utility_installed core tideways) ]]; then
-  echo "Disabling tideways_xhprof/xhgui"
-  sudo phpdismod tideways_xhprof
-  sudo phpdismod xhgui
+  tideways_off
 fi
 
 echo "Enabling XDebug"

--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -50,16 +50,6 @@ get_primary_host() {
   echo "${value:-$1}"
 }
 
-is_utility_installed() {
-  local utilities=$(shyaml get-values "utilities.${1}" 2> /dev/null < ${VVV_CONFIG})
-  for utility in ${utilities}; do
-    if [[ "${utility}" == "${2}" ]]; then
-      return 0
-    fi
-  done
-  return 1
-}
-
 function vvv_provision_site_nginx() {
   SITE_NGINX_FILE=$2
   DEST_NGINX_FILE=${SITE_NGINX_FILE//\/srv\/www\//}
@@ -83,7 +73,7 @@ function vvv_provision_site_nginx() {
   fi
   sed -i "s#{upstream}#${NGINX_UPSTREAM}#" "/etc/nginx/custom-sites/${DEST_NGINX_FILE}"
 
-  if [ -n "$(type -t is_utility_installed)" ] && [ "$(type -t is_utility_installed)" = function ] && $(is_utility_installed core tls-ca); then
+  if [[ $(is_utility_installed core tls-ca) ]]; then
     sed -i "s#{vvv_tls_cert}#ssl_certificate /srv/certificates/${VVV_SITE_NAME}/dev.crt;#" "/etc/nginx/custom-sites/${DEST_NGINX_FILE}"
     sed -i "s#{vvv_tls_key}#ssl_certificate_key /srv/certificates/${VVV_SITE_NAME}/dev.key;#" "/etc/nginx/custom-sites/${DEST_NGINX_FILE}"
   else

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -221,18 +221,6 @@ apt_package_install_list=(
 
 ### FUNCTIONS
 
-is_utility_installed() {
-  local utilities=$(shyaml get-values "utilities.${1}" 2> /dev/null < ${VVV_CONFIG})
-  for utility in ${utilities}; do
-    if [[ "${utility}" == "${2}" ]]; then
-      return 0
-    fi
-  done
-  return 1
-}
-
-
-
 git_ppa_check() {
   # git
   #


### PR DESCRIPTION
This avoids some warnings being printed before when tideways was not installed. Eg:

![image](https://user-images.githubusercontent.com/6192180/71289465-f3eaeb80-234b-11ea-865d-35e543145a4e.png)

And also adds specific tideways commands to turn it on or off.

Avoids the problem that was inherent of having tideways installed, that either xdebug or tideways needed to be turned on at any given point.

I've created a new command to check if a utility is installed. It was duplicated across the provisioners, so a command made sense.