### PR TITLE
Make bash commands available for root

### DIFF
--- a/config/bash_aliases
+++ b/config/bash_aliases
@@ -27,10 +27,10 @@ elif [ -d "/srv/www/wordpress-develop/public_html/src/" ]; then
 fi
 
 # add autocomplete for grunt
-eval "$(grunt --completion=bash)"
+[ ! type "grunt" > /dev/null 2>&1 ] && eval "$(grunt --completion=bash)"
 
 # add autocomplete for wp-cli
-. /srv/config/wp-cli/wp-completion.bash
+[ -s "/srv/config/wp-cli/wp-completion.bash" ] && . /srv/config/wp-cli/wp-completion.bash
 
 # PHPCS path
 export PATH="$PATH:/srv/www/phpcs/scripts/"

--- a/config/bash_aliases
+++ b/config/bash_aliases
@@ -26,12 +26,6 @@ elif [ -d "/srv/www/wordpress-develop/public_html/src/" ]; then
     export WP_CORE_DIR=/srv/www/wordpress-develop/public_html/src/
 fi
 
-# add autocomplete for grunt
-[ ! type "grunt" > /dev/null 2>&1 ] && eval "$(grunt --completion=bash)"
-
-# add autocomplete for wp-cli
-[ -s "/srv/config/wp-cli/wp-completion.bash" ] && . /srv/config/wp-cli/wp-completion.bash
-
 # PHPCS path
 export PATH="$PATH:/srv/www/phpcs/scripts/"
 
@@ -40,4 +34,13 @@ export PATH="$PATH:/srv/config/homebin/"
 
 # nvm path
 export NVM_DIR="/srv/config/nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" # This loads nvm
+
+if [ -n "$BASH" ]; then
+	[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" # This loads nvm
+
+	# add autocomplete for grunt
+	[ ! type "grunt" > /dev/null 2>&1 ] && eval "$(grunt --completion=bash)"
+
+	# add autocomplete for wp-cli
+	[ -s "/srv/config/wp-cli/wp-completion.bash" ] && . /srv/config/wp-cli/wp-completion.bash
+fi

--- a/config/bash_aliases
+++ b/config/bash_aliases
@@ -5,3 +5,39 @@
 # provisioning is finished. This allows for various scripts and configurations to
 # be available to us.
 #
+
+# set PATH so it includes user's private bin if it exists
+if [ -d "$HOME/bin" ] ; then
+    PATH="$HOME/bin:$PATH"
+fi
+
+# Set the WP_TESTS_DIR path directory so that we can use phpunit inside
+# plugins almost immediately.
+if [ -d "/srv/www/wordpress-trunk/public_html/tests/phpunit/" ]; then
+    export WP_TESTS_DIR=/srv/www/wordpress-trunk/public_html/tests/phpunit/
+elif [ -d "/srv/www/wordpress-develop/public_html/tests/phpunit/" ]; then
+    export WP_TESTS_DIR=/srv/www/wordpress-develop/public_html/tests/phpunit/
+fi
+
+# Set the WP_CORE_DIR path so phpunit tests are run against WP trunk
+if [ -d "/srv/www/wordpress-trunk/public_html/src/" ]; then
+    export WP_CORE_DIR=/srv/www/wordpress-trunk/public_html/src/
+elif [ -d "/srv/www/wordpress-develop/public_html/src/" ]; then
+    export WP_CORE_DIR=/srv/www/wordpress-develop/public_html/src/
+fi
+
+# add autocomplete for grunt
+eval "$(grunt --completion=bash)"
+
+# add autocomplete for wp-cli
+. /srv/config/wp-cli/wp-completion.bash
+
+# PHPCS path
+export PATH="$PATH:/srv/www/phpcs/scripts/"
+
+# Vagrant scripts
+export PATH="$PATH:/srv/config/homebin/"
+
+# nvm path
+export NVM_DIR="/srv/config/nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" # This loads nvm

--- a/config/bash_profile
+++ b/config/bash_profile
@@ -31,39 +31,3 @@ if [ -n "$BASH_VERSION" ]; then
         . "$HOME/.bash_prompt"
     fi
 fi
-
-# set PATH so it includes user's private bin if it exists
-if [ -d "$HOME/bin" ] ; then
-    PATH="$HOME/bin:$PATH"
-fi
-
-# Set the WP_TESTS_DIR path directory so that we can use phpunit inside
-# plugins almost immediately.
-if [ -d "/srv/www/wordpress-trunk/public_html/tests/phpunit/" ]; then
-    export WP_TESTS_DIR=/srv/www/wordpress-trunk/public_html/tests/phpunit/
-elif [ -d "/srv/www/wordpress-develop/public_html/tests/phpunit/" ]; then
-    export WP_TESTS_DIR=/srv/www/wordpress-develop/public_html/tests/phpunit/
-fi
-
-# Set the WP_CORE_DIR path so phpunit tests are run against WP trunk
-if [ -d "/srv/www/wordpress-trunk/public_html/src/" ]; then
-    export WP_CORE_DIR=/srv/www/wordpress-trunk/public_html/src/
-elif [ -d "/srv/www/wordpress-develop/public_html/src/" ]; then
-    export WP_CORE_DIR=/srv/www/wordpress-develop/public_html/src/
-fi
-
-# add autocomplete for grunt
-eval "$(grunt --completion=bash)"
-
-# add autocomplete for wp-cli
-. /srv/config/wp-cli/wp-completion.bash
-
-# PHPCS path
-export PATH="$PATH:/srv/www/phpcs/scripts/"
-
-# Vagrant scripts
-export PATH="$PATH:/srv/config/homebin/"
-
-# nvm path
-export NVM_DIR="/srv/config/nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" # This loads nvm

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -293,6 +293,11 @@ profile_setup() {
   rm -f "/home/vagrant/.bash_aliases"
   noroot cp -f "/srv/config/bash_aliases" "/home/vagrant/.bash_aliases"
 
+  echo " * Copying /srv/config/bash_aliases                      to $HOME/.bash_aliases"
+  rm -f "$HOME/.bash_aliases"
+  cp -f "/srv/config/bash_aliases" "$HOME/.bash_aliases"
+  . "$HOME/.bash_aliases"
+
   echo " * Copying /srv/config/vimrc                             to /home/vagrant/.vimrc"
   rm -f "/home/vagrant/.vimrc"
   noroot cp -f "/srv/config/vimrc" "/home/vagrant/.vimrc"


### PR DESCRIPTION
This fixes #2041 .

I've done research on how all the profiles are set up in Ubuntu, and Linux in general.

Here is the information that has been the most helpful for me:

https://unix.stackexchange.com/a/29811

I've also considered things on this answer:
https://askubuntu.com/a/866169

I've decided to move PATH changes, and overall autocomplete initialization to bash_aliases, which is executed in most shell types. Also copying the aliases (not the profile) to the root folder now to run on root.

I've tested this and works with no problem.