### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The online documentation contains more detailed [installation instructions](http
 
 ## Minimum System requirements
 
-* [Vagrant](https://www.vagrantup.com) 2.2.4+
-* [Virtualbox](https://www.virtualbox.org) 5.2+
+* [Vagrant](https://www.vagrantup.com) 2.2.6 or below.
+* [Virtualbox](https://www.virtualbox.org) 6.0.x or below.
 * 8GB+ of RAM
 * Virtualisation ( VT-X ) enabled in the BIOS ( Windows/Linux )
 * Hyper-V turned off ( Windows )


### PR DESCRIPTION
A lot of documentation is incorrect and extremely confusing for fresh installers/new users of VM. 
If fresh install downloads VB 6.1.x [Windows], VVV sets default provider to Hyper-V instead of VB, even if the Windows OS is compatible with Hyper-V.

The only way of being aware that VB 6.1.x is incompatible is by adding --provider=virtualbox at the end of vagrant up, to which we will receive the error explaining that it only is compatible with 6.0 and below. There is no documentation of this.
