### PR TITLE
use the full path to is_utility_installed in the site provisioner

### DIFF
--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -73,7 +73,7 @@ function vvv_provision_site_nginx() {
   fi
   sed -i "s#{upstream}#${NGINX_UPSTREAM}#" "/etc/nginx/custom-sites/${DEST_NGINX_FILE}"
 
-  if [[ $(is_utility_installed core tls-ca) ]]; then
+  if [[ $(/srv/config/homebin/is_utility_installed core tls-ca) ]]; then
     sed -i "s#{vvv_tls_cert}#ssl_certificate /srv/certificates/${VVV_SITE_NAME}/dev.crt;#" "/etc/nginx/custom-sites/${DEST_NGINX_FILE}"
     sed -i "s#{vvv_tls_key}#ssl_certificate_key /srv/certificates/${VVV_SITE_NAME}/dev.key;#" "/etc/nginx/custom-sites/${DEST_NGINX_FILE}"
   else


### PR DESCRIPTION
## Summary:

Fixes a problem in the site provisioner

## Checks

<!--  Have you: -->

* [x] I've tested this PR with Vagrant **v2.2.6** and VirtualBox **v6** on **MacOS**
* [x] This PR is for the `develop` branch not the `master` branch.
* [ ] I've updated the changelog.
* [x] This PR is complete and ready for review.
 
 <!-- don't forget to fill out the bolded parts -->
