### PR TITLE
Revert "added the pcov PHP extension to the core provisioner"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ permalink: /docs/en-US/changelog/
 ### Enhancements
 
 * Improvements to the ruby code in the vagrant file
-* Added the pcov PHP extension to speed up coverage tests in PHPUnit
 
 ### Bug Fixes
 

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -163,14 +163,13 @@ apt_package_install_list=(
   php-ssh2
   php-xdebug
   php-yaml
-  php-pcov
   php7.2-bcmath
   php7.2-curl
   php7.2-gd
-  php7.2-imap
-  php7.2-json
   php7.2-mbstring
   php7.2-mysql
+  php7.2-imap
+  php7.2-json
   php7.2-soap
   php7.2-xml
   php7.2-zip


### PR DESCRIPTION
Reverts Varying-Vagrant-Vagrants/VVV#2054

`php-pcov` is causing issues that prevent PHP FPM from starting, reverting until the cause is identified