### PR TITLE
Add php-ldap to provision.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ permalink: /docs/en-US/changelog/
 ### Enhancements
 
 * Improvements to the ruby code in the vagrant file
+* Added php-ldap as standard
 
 ### Bug Fixes
 

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -163,6 +163,7 @@ apt_package_install_list=(
   php-ssh2
   php-xdebug
   php-yaml
+  php-ldap
   php7.2-bcmath
   php7.2-curl
   php7.2-gd


### PR DESCRIPTION
## Summary:
Added php-ldap to provision.sh

## Checks
* [✓] I've tested this PR with Vagrant 2.2.7 and VirtualBox 6.0.16 on macOS 10.15.3
* [✓] This PR is for the `develop` branch not the `master` branch.
* [✓] I've updated the changelog.
* [✓] This PR is complete and ready for review.
