### PR TITLE
Adjust the syntax of if statements calling the is_utility_installed script

### DIFF
--- a/config/homebin/tideways_on
+++ b/config/homebin/tideways_on
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [[ ! $(is_utility_installed core tideways) ]]; then
+if ! is_utility_installed core tideways; then
   echo "Tideways is not installed"
   exit 0
 fi

--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -73,7 +73,7 @@ function vvv_provision_site_nginx() {
   fi
   sed -i "s#{upstream}#${NGINX_UPSTREAM}#" "/etc/nginx/custom-sites/${DEST_NGINX_FILE}"
 
-  if [[ $(/srv/config/homebin/is_utility_installed core tls-ca) ]]; then
+  if /srv/config/homebin/is_utility_installed core tls-ca; then
     sed -i "s#{vvv_tls_cert}#ssl_certificate /srv/certificates/${VVV_SITE_NAME}/dev.crt;#" "/etc/nginx/custom-sites/${DEST_NGINX_FILE}"
     sed -i "s#{vvv_tls_key}#ssl_certificate_key /srv/certificates/${VVV_SITE_NAME}/dev.key;#" "/etc/nginx/custom-sites/${DEST_NGINX_FILE}"
   else

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -893,7 +893,7 @@ cleanup_vvv(){
   sed -n '/# vvv-auto$/!p' /etc/hosts > /tmp/hosts
   echo "127.0.0.1 vvv # vvv-auto" >> "/etc/hosts"
   echo "127.0.0.1 vvv.test # vvv-auto" >> "/etc/hosts"
-  if [[ $(is_utility_installed core tideways) ]]; then
+  if is_utility_installed core tideways; then
     echo "127.0.0.1 tideways.vvv.test # vvv-auto" >> "/etc/hosts"
     echo "127.0.0.1 xhgui.vvv.test # vvv-auto" >> "/etc/hosts"
   fi


### PR DESCRIPTION

## Summary:

Addresses problem with SSL certificates not being correctly added into Nginx site configs described in issue #2072. 

## Checks

<!--  Have you: -->

* [x] I've tested this PR with Vagrant **v2.2.7** and VirtualBox **v6.0.16r135674** on **Windows 8.1**
* [x] This PR is for the `develop` branch not the `master` branch.
* [ ] I've updated the changelog.
* [x] This PR is complete and ready for review.
 
 <!-- don't forget to fill out the bolded parts -->
