### PR TITLE
Generate .rnd file if it doesn't exist.

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -614,6 +614,11 @@ tools_install() {
 
 nginx_setup() {
   # Create an SSL key and certificate for HTTPS support.
+  if [[ ! -e /root/.rnd ]]; then
+    echo " * Generating Random Number for cert generation..."
+    vvvgenrnd="$(openssl rand -out /root/.rnd -hex 256 2>&1)"
+    echo "$vvvgenrnd"
+  fi
   if [[ ! -e /etc/nginx/server-2.1.0.key ]]; then
     echo " * Generating Nginx server private key..."
     vvvgenrsa="$(openssl genrsa -out /etc/nginx/server-2.1.0.key 2048 2>&1)"


### PR DESCRIPTION
This fixes an issue with the latest box (and also a couple of versions before), which didn't have a proper /root/.rnd file which is necessary for generating a certificate.

Seems to address #2072 , right now tls-ca is working for me without the change in syntax proposed in #2073 .

I got this error while provisioning from scratch with 3.2.0 and 3.3.0 with the latest box.

```
 * Sign the certificate using the above private key...
Can't load /root/.rnd into RNG
139738907833408:error:2406F079:random number generator:RAND_load_file:Cannot open file:../crypto/rand/randfile.c:98:Filename=/root/.rnd
```