### PR TITLE
Always force the root password to its documented default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ permalink: /docs/en-US/changelog/
 
 # Changelog
 
-## 3.3.0 ( WIP )
+## 3.3.0 ( 2020 )
 
 ### Enhancements
 
@@ -17,8 +17,9 @@ permalink: /docs/en-US/changelog/
 * Installs the ntp date packages and starts the ntp service to fix time drift on sleep
 * Fixes an issue with the ntpsec package by removing it
 * Fixed the use of dots in site names breaking provisioning
+* Always set the database root user password to avoid having the default invalid password on fresh installs
 
-## 3.2.0 ( 2019 )
+## 3.2.0 ( 2019 Nov 5th )
 
 ### Enhancements
 

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -761,15 +761,18 @@ mysql_setup() {
     cp "/srv/config/mysql-config/root-my.cnf" "/home/vagrant/.my.cnf"
     chmod 0644 "/home/vagrant/.my.cnf"
     echo " * Copied /srv/config/mysql-config/root-my.cnf          to /home/vagrant/.my.cnf"
+    
+    echo " * Setting the default MariaSQL root password"
+    mysqladmin -u root password root
 
     # MySQL gives us an error if we restart a non running service, which
     # happens after a `vagrant halt`. Check to see if it's running before
     # deciding whether to start or restart.
     if [[ "mysql stop/waiting" == "${exists_mysql}" ]]; then
-      echo " * service mysql start"
+      echo " * Starting the mysql service"
       service mysql start
-      else
-      echo " * service mysql restart"
+    else
+      echo " * Restarting mysql service"
       service mysql restart
     fi
 

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -752,13 +752,13 @@ mysql_setup() {
 
   exists_mysql="$(service mysql status)"
   if [[ "mysql: unrecognized service" != "${exists_mysql}" ]]; then
-    echo -e "\n * Setup MySQL configuration file links..."
+    echo -e "\n * Setting up database configuration file links..."
 
     # Copy mysql configuration from local
     cp "/srv/config/mysql-config/my.cnf" "/etc/mysql/my.cnf"
     echo " * Copied /srv/config/mysql-config/my.cnf               to /etc/mysql/my.cnf"
 
-    cp "/srv/config/mysql-config/root-my.cnf" "/home/vagrant/.my.cnf"
+    cp -f  "/srv/config/mysql-config/root-my.cnf" "/home/vagrant/.my.cnf"
     chmod 0644 "/home/vagrant/.my.cnf"
     echo " * Copied /srv/config/mysql-config/root-my.cnf          to /home/vagrant/.my.cnf"
     
@@ -781,8 +781,9 @@ mysql_setup() {
     # Create the databases (unique to system) that will be imported with
     # the mysqldump files located in database/backups/
     if [[ -f "/srv/database/init-custom.sql" ]]; then
+      echo " * Running custom init-custom.sql under the root user..."
       mysql -u "root" -p"root" < "/srv/database/init-custom.sql"
-      echo -e "\n * Initial custom MySQL scripting..."
+      echo " * init-custom.sql has run"
     else
       echo -e "\n * No custom MySQL scripting found in database/init-custom.sql, skipping..."
     fi

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -762,7 +762,7 @@ mysql_setup() {
     chmod 0644 "/home/vagrant/.my.cnf"
     echo " * Copied /srv/config/mysql-config/root-my.cnf          to /home/vagrant/.my.cnf"
     
-    echo " * Setting the default MariaSQL root password"
+    echo " * Setting the default database password for the root user"
     mysqladmin -u root password root
 
     # MySQL gives us an error if we restart a non running service, which


### PR DESCRIPTION
## Summary:

 Always force the root password to its documented default on provision, fixes #2076, and force copies a MySQL config in case updates need to be made in the future

## Checks

<!--  Have you: -->

* [ ] I've tested this PR with Vagrant **vXX** and VirtualBox **vXX** on **Operating System**
* [x] This PR is for the `develop` branch not the `master` branch.
* [x] I've updated the changelog.
* [ ] This PR is complete and ready for review.
 
 <!-- don't forget to fill out the bolded parts -->
