### PR TITLE
Change the provisioned at timestamp format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ permalink: /docs/en-US/changelog/
 ### Enhancements
 
 * Improvements to the ruby code in the vagrant file
+* Improved the log folder names from `20200225-182126` to `2020.02.25-18-21-26`
 
 ### Bug Fixes
 

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -35,7 +35,7 @@ rm -f /vagrant/vvv-custom.yml
 rm -f /vagrant/config.yml
 
 touch /vagrant/provisioned_at
-echo $(date "+%Y%m%d-%H%M%S") > /vagrant/provisioned_at
+echo $(date "+%Y.%m.%d_%H-%M-%S") > /vagrant/provisioned_at
 
 date_time=$(cat /vagrant/provisioned_at)
 logfolder="/var/log/provisioners/${date_time}"


### PR DESCRIPTION
## Summary:

Change the provisioned at timestamp format to something more readable, makes the log folder much easier to work with

<!-- what does it add/fix/change/remove? -->

## Checks

<!--  Have you: -->

* [ ] I've tested this PR with Vagrant **vXX** and VirtualBox **vXX** on **Operating System**
* [ ] This PR is for the `develop` branch not the `master` branch.
* [x] I've updated the changelog.
* [ ] This PR is complete and ready for review.
 
 <!-- don't forget to fill out the bolded parts -->
