### PR TITLE
Vmware workstation2desktop nyml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ permalink: /docs/en-US/changelog/
 
 # Changelog
 
+* Updated config/default-config.yml from vmware_workstation to vmware_desktop to match current VMWare provider in Vagrantfile for MacOS and Windows
+
 ## 3.3.0 ( 2020 )
 
 ### Enhancements

--- a/config/default-config.yml
+++ b/config/default-config.yml
@@ -123,7 +123,7 @@ vm_config:
   # Due to a limitation within Vagrant, the specified provider is only respected on a clean `vagrant up`
   # as Vagrant currently restricts you to one provider per machine
   # https://www.vagrantup.com/docs/providers/basic_usage.html#vagrant-up
-  # provider: vmware_workstation
+  # provider: vmware_desktop
 
 # General VVV options
 general:


### PR DESCRIPTION
## Summary:
Changing the commented out Provider: vmware_workstation to vmware_desktop in the default-config.yml file is essential for VMWare provider support on Macs and PCs. It will save everyone who uses that line time and is good knowledge to pass on to users. It has no drawbacks to anyone. It removes a stumbling block for beginners who may not know that VVV, and new Vagrant Cloud boxes in use by VVV have switched from using vmware_fusion and vmware_workstation, to vmware_desktop for both platforms.

## Checks

* [ x] I've tested this PR with Vagrant v2.2.7 and VirtualBox Version 6.1.4 r136177 (Qt5.6.3) on Mac OS Catalina 10.15.3
* [ x] This PR is for the `develop` branch not the `master` branch.
* [ x] I've updated the changelog.
* [ x] This PR is complete and ready for review.