### PR TITLE
Replace expired vmware_workstation provider and add other providers to default-config.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ permalink: /docs/en-US/changelog/
 
 # Changelog
 
+* Updated providers in default-config.yml
+
 ## 3.3.0 ( 2020 )
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ permalink: /docs/en-US/changelog/
 
 # Changelog
 
-* Updated providers in default-config.yml
-
 ## 3.3.0 ( 2020 )
 
 ### Enhancements
@@ -15,6 +13,7 @@ permalink: /docs/en-US/changelog/
 * Improvements to the ruby code in the vagrant file
 * Improved the log folder names from `20200225-182126` to `2020.02.25-18-21-26`
 * Added a `switch_php_debugmod` to replace the `xdebug_on` `tideways_off` style scripts
+* Improved the provider examples in `default-config.yml`
 
 ### Bug Fixes
 

--- a/config/default-config.yml
+++ b/config/default-config.yml
@@ -123,7 +123,7 @@ vm_config:
   # Due to a limitation within Vagrant, the specified provider is only respected on a clean `vagrant up`
   # as Vagrant currently restricts you to one provider per machine
   # https://www.vagrantup.com/docs/providers/basic_usage.html#vagrant-up
-  # provider: vmware_workstation
+  # provider: vmware_desktop
 
 # General VVV options
 general:

--- a/config/default-config.yml
+++ b/config/default-config.yml
@@ -123,6 +123,9 @@ vm_config:
   # Due to a limitation within Vagrant, the specified provider is only respected on a clean `vagrant up`
   # as Vagrant currently restricts you to one provider per machine
   # https://www.vagrantup.com/docs/providers/basic_usage.html#vagrant-up
+  # provider: virtualbox
+  # provider: hyperv
+  # provider: parallels
   # provider: vmware_desktop
 
 # General VVV options


### PR DESCRIPTION
## Summary:
<!-- what does it add/fix/change/remove? -->
vmware_workstation is broken as a provider. It needs to be replaced as an example in the default-config.yml file. vmware_desktop correctly loads the latest bento box  on VMWare Workstation and VMWare Fusion and is platform agnostic.

vmware_desktop brings the provider in line with the current VVV Vagrantfile and the labels on the bento box used by all of the alt providers: https://app.vagrantup.com/bento/boxes/ubuntu-18.04

The other providers are added as a convenience for hyperv and parallels users and virtualbox just to complete the list of optional providers even though currently it would only override itself.

I realize this is virtually identical to the previous pull request but take your pick: The first one corrects only the provider currently listed there. This is more convenient for all alt provider users. Hopefully growing more relevant as Vagrant grows more provider agnostic.

## Checks

<!--  Have you: -->

* [ x] I've tested this PR with Vagrant 2.2.7 and VirtualBox  on **Operating System**
* [ x] This PR is for the `develop` branch not the `master` branch.
* [x ] I've updated the changelog.
* [x ] This PR is complete and ready for review.
 
 <!-- don't forget to fill out the bolded parts -->
