### PR TITLE
switch to apt for ack-grep installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,7 @@ permalink: /docs/en-US/changelog/
 
 # Changelog
 
-## Unreleased
-
-### Enhancements
-
-* Run rubocop on Vagrantfile in a move towards more idiomatic ruby
-
-## 3.3.0 ( 2020 )
+## 3.3.1 ( 2020 )
 
 ### Enhancements
 
@@ -22,7 +16,8 @@ permalink: /docs/en-US/changelog/
 * Checks the default password for MySQL root user during provision
 * Improved the provider examples in `default-config.yml`
 * Improved network checks to test more domains
-
+* ack-grep is now installed via `apt` rather than `beyondgrep.com`
+* Run rubocop on Vagrantfile in a move towards more idiomatic ruby
 
 ### Bug Fixes
 

--- a/provision/provision-network-functions.sh
+++ b/provision/provision-network-functions.sh
@@ -54,7 +54,6 @@ network_check() {
     "https://wordpress.org"
     "https://github.com"
     "https://raw.githubusercontent.com"
-    "https://beyondgrep.com"
     "https://getcomposer.org"
   )
   declare -a failed_hosts=()

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -504,17 +504,6 @@ tools_install() {
   echo " * Installing/updating npm-check-updates..."
   npm_config_loglevel=error npm install -g npm-check-updates
 
-  # ack-grep
-  #
-  # Install ack-rep directory from the version hosted at beyondgrep.com as the
-  # PPAs for Ubuntu Precise are not available yet.
-  if [[ -f /usr/bin/ack ]]; then
-    echo " * ack-grep already installed"
-  else
-    echo " * Installing ack-grep as ack"
-    curl -s https://beyondgrep.com/ack-2.16-single-file > "/usr/bin/ack" && chmod +x "/usr/bin/ack"
-  fi
-
   echo " * Making sure the composer cache is not owned by root"
   mkdir -p /usr/local/src/composer
   mkdir -p /usr/local/src/composer/cache


### PR DESCRIPTION
## Summary:

This fixes #2098 by installing `ack-grep` via `apt`

<!-- what does it add/fix/change/remove? -->

## Checks

<!--  Have you: -->

* [x] I've tested this PR with Vagrant **vXX** and VirtualBox **vXX** on **Operating System**
* [x] This PR is for the `develop` branch not the `master` branch.
* [x] I've updated the changelog.
* [x] This PR is complete and ready for review.
 
 <!-- don't forget to fill out the bolded parts -->
