### PR TITLE
don't recurse when checking sites, fixes #2101

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ permalink: /docs/en-US/changelog/
 * Fixes an issue with the ntpsec package by removing it
 * Fixed the use of dots in site names breaking provisioning
 * Always set the database root user password to avoid having the default invalid password on fresh installs
+* Don't spider and recurse domains when checking for network connections
 
 ## 3.2.0 ( 2019 Nov 5th )
 

--- a/provision/provision-network-functions.sh
+++ b/provision/provision-network-functions.sh
@@ -37,7 +37,7 @@ check_network_connection_to_host() {
   # If 3 attempts with a timeout of 5 seconds are not successful,
   # then we'll skip a few things further in provisioning rather
   # than create a bunch of errors.
-  if [[ "$(wget --tries=3 --timeout=10 --spider --recursive --level=2 "${url}" 2>&1 | grep 'connected')" ]]; then
+  if [[ "$(wget --tries=3 --timeout=10 --level=2 "${url}" 2>&1 | grep 'connected')" ]]; then
     echo -e "${GREEN} * Succesful Network connection to ${url} detected...${CRESET}"
     return 0
   fi


### PR DESCRIPTION
## Summary:

Brings a big performance improvement to the new checks, specifically wordpress.org domain checking.

## Checks

* [x] I've tested this PR with Vagrant **vXX** and VirtualBox **vXX** on **Operating System**
* [x] This PR is for the `develop` branch not the `master` branch.
* [x] I've updated the changelog.
* [x] This PR is complete and ready for review.
 