### PR TITLE
Fix failure bear not working properly.

### DIFF
--- a/config/homebin/vagrant_up
+++ b/config/homebin/vagrant_up
@@ -27,7 +27,7 @@ EYE="${CYAN}█${RED}"
 URL="\033[4;38;5;3m"
 
 mkdir -p /vagrant/failed_provisioners
-if [ "$(ls -A /vagrant/failed_provisioners/)" ]; then
+if [ -z "$(ls -A /vagrant/failed_provisioners/)" ]; then
 	echo -e "${GREEN}"
 	echo -e "${GREEN}         yay  "
 	echo -e "${GREEN} ✧ ▄▀▀▀▄▄▄▄▄▄▄▀▀▀▄ ✧              __ __ __ __"


### PR DESCRIPTION
I did a clean provision, no errors on any logs. SSHd in and there was nothing on /vagrant/failed_provisioners.

So i noticed that we needed to use the `-z` flag to check if the `ls` is empty or not.