### PR TITLE
Fix sudo homebin path

### DIFF
--- a/config/bash_aliases
+++ b/config/bash_aliases
@@ -27,10 +27,14 @@ elif [ -d "/srv/www/wordpress-develop/public_html/src/" ]; then
 fi
 
 # PHPCS path
-export PATH="$PATH:/srv/www/phpcs/scripts/"
+if [[ $PATH != *"/srv/www/phpcs/scripts"* ]]; then
+	export PATH="$PATH:/srv/www/phpcs/scripts"
+fi
 
 # Vagrant scripts
-export PATH="$PATH:/srv/config/homebin/"
+if [[ $PATH != *"/srv/config/homebin"* ]]; then
+	export PATH="$PATH:/srv/config/homebin"
+fi
 
 if [ -n "$BASH" ]; then
 	# add autocomplete for grunt

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -25,7 +25,15 @@ sed -i -E \
   -e "s|(.*Defaults.*secure_path.*?\".*?)(\")|\1:/srv/config/homebin\2|" \
   /etc/sudoers
 
-# source bash_aliases before anything else so that PATH is properly configured
+# add homebin to the default environment, clean first and then append at the end
+sed -i -E \
+  -e "s|:/srv/config/homebin||" \
+  -e "s|/srv/config/homebin:||" \
+  -e "s|(.*PATH.*?\".*?)(\")|\1:/srv/config/homebin\2|" \
+  /etc/environment
+
+# source bash_aliases before anything else so that PATH is properly configured on
+# this shell session
 . "/srv/config/bash_aliases"
 
 export DEBIAN_FRONTEND=noninteractive

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -18,12 +18,14 @@ start_seconds="$(date +%s)"
 # fix no tty warnings in provisioner logs
 sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile
 
-# fix commands from homebin not working with sudo, clean first and then append at the end
+# add homebin to secure_path setting for sudo, clean first and then append at the end
 sed -i -E \
   -e "s|:/srv/config/homebin||" \
   -e "s|/srv/config/homebin:||" \
   -e "s|(.*Defaults.*secure_path.*?\".*?)(\")|\1:/srv/config/homebin\2|" \
   /etc/sudoers
+
+# source bash_aliases before anything else so that PATH is properly configured
 . "/srv/config/bash_aliases"
 
 export DEBIAN_FRONTEND=noninteractive

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -18,6 +18,14 @@ start_seconds="$(date +%s)"
 # fix no tty warnings in provisioner logs
 sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile
 
+# fix commands from homebin not working with sudo, clean first and then append at the end
+sed -i -E \
+  -e "s|:/srv/config/homebin||" \
+  -e "s|/srv/config/homebin:||" \
+  -e "s|(.*Defaults.*secure_path.*?\".*?)(\")|\1:/srv/config/homebin\2|" \
+  /etc/sudoers
+. "/srv/config/bash_aliases"
+
 export DEBIAN_FRONTEND=noninteractive
 export APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
 export COMPOSER_ALLOW_SUPERUSER=1
@@ -301,7 +309,6 @@ profile_setup() {
   echo " * Copying /srv/config/bash_aliases                      to $HOME/.bash_aliases"
   rm -f "$HOME/.bash_aliases"
   cp -f "/srv/config/bash_aliases" "$HOME/.bash_aliases"
-  . "$HOME/.bash_aliases"
 
   echo " * Copying /srv/config/vimrc                             to /home/vagrant/.vimrc"
   rm -f "/home/vagrant/.vimrc"


### PR DESCRIPTION
I figured out how to remove the requirement for full paths on the provisioners for using utilities under homebin.

I've added a fix at the beginning of the provisioner which makes the paths available to sudo aswell (by adding the homebin path to the secure_path parameter on `/etc/sudoers`)

Also fixed the PATH additions on bash_aliases so that they don't have a trailing slash, and that we check first if the path we're adding is already included or not.

In order to test this, you can SSH in and do the following:

```
is_utility_installed
sudo is_utility_installed
sudo su
is_utility_installed
```

None of the above commands should throw any errors (after a provision of course since the fix is implemented there)

After this is fixed, I can do a separate PR to remove the full path requirement everywhere.

This is related to #2036 and #2042 and several other issues where the homebin commands didn't work properly as expected.