### PR TITLE
Actually abort provision if network issues arise.

### DIFF
--- a/provision/provision-network-functions.sh
+++ b/provision/provision-network-functions.sh
@@ -94,7 +94,7 @@ network_check() {
     echo "Network ifconfig output:"
     echo " "
     ifconfig
-    echo " "
+    echo -e "${RED} "
     echo "Aborting provision. "
     echo "Try provisioning again once network connectivity is restored."
     echo "If that doesn't work, and you're sure you have a strong "
@@ -105,8 +105,7 @@ network_check() {
     echo " "
     echo "https://github.com/Varying-Vagrant-Vagrants/VVV/issues"
     echo " "
-    echo "#################################################################${CRESET}"
-
+    echo -e "${RED}#################################################################${CRESET}"
     return 1
   fi
   echo -e "${GREEN} * Network checks succeeded${CRESET}"

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -940,7 +940,9 @@ echo " * Bash profile setup and directories."
 cleanup_terminal_splash
 profile_setup
 
-network_check
+if ! network_check; then
+  exit 1
+fi
 # Package and Tools Install
 echo " "
 echo " * Main packages check and install."
@@ -966,7 +968,9 @@ echo " * Installing/updating wp-cli and debugging tools"
 wp_cli
 php_codesniff
 
-network_check
+if ! network_check; then
+  exit 1
+fi
 # Time for WordPress!
 echo " "
 


### PR DESCRIPTION
Basically that, on the wording of the messages being displayed it states that provisioning is going to be aborted. So that's what we're going to be doing.

If we exit with code 1, then other provisioners don't run either.