### PR TITLE
Switch to vagrant-hostmanager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ permalink: /docs/en-US/changelog/
 * Run rubocop on Vagrantfile in a move towards more idiomatic ruby
 * Added new bears to the various vagrant trigger scripts
 * Removed Ubuntu news MOTD
+* Support for vagrant-hostmanager
 
 ### Bug Fixes
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -373,14 +373,14 @@ Vagrant.configure('2') do |config|
   end
 
   # Auto Download Vagrant plugins, supported from Vagrant 2.2.0
-  unless Vagrant.has_plugin?('vagrant-hostmanager')
-    if File.file?(File.join(vagrant_dir, 'vagrant-hostmanager.gem'))
-      system('vagrant plugin install ' + File.join(vagrant_dir, 'vagrant-hostmanager.gem'))
-      File.delete(File.join(vagrant_dir, 'vagrant-hostmanager.gem'))
-      puts "#{yellow}VVV has completed installing the vagrant-hostmanager plugins. Please run the requested command again.#{creset}"
+  unless Vagrant.has_plugin?('vagrant-hostsupdater')
+    if File.file?(File.join(vagrant_dir, 'vagrant-hostsupdater.gem'))
+      system('vagrant plugin install ' + File.join(vagrant_dir, 'vagrant-hostsupdater.gem'))
+      File.delete(File.join(vagrant_dir, 'vagrant-hostsupdater.gem'))
+      puts "#{yellow}VVV has completed installing the vagrant-hostsupdater plugins. Please run the requested command again.#{creset}"
       exit
     else
-      config.vagrant.plugins = ['vagrant-hostmanager']
+      config.vagrant.plugins = ['vagrant-hostsupdater']
     end
   end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -264,12 +264,9 @@ if show_logo
     platform << 'systemd ' if Vagrant::Util::Platform.systemd?
   end
 
-  if Vagrant.has_plugin?('vagrant-hostsupdater')
-    platform << 'vagrant-hostsupdater '
-  end
-
+  platform << 'vagrant-hostmanager' if Vagrant.has_plugin?('vagrant-hostmanager')
+  platform << 'vagrant-hostsupdater' if Vagrant.has_plugin?('vagrant-hostsupdater')
   platform << 'vagrant-vbguest' if Vagrant.has_plugin?('vagrant-vbguest')
-
   platform << 'vagrant-disksize' if Vagrant.has_plugin?('vagrant-disksize')
 
   platform << 'CaseSensitiveFS' if Vagrant::Util::Platform.fs_case_sensitive?
@@ -376,14 +373,14 @@ Vagrant.configure('2') do |config|
   end
 
   # Auto Download Vagrant plugins, supported from Vagrant 2.2.0
-  unless Vagrant.has_plugin?('vagrant-hostsupdater')
-    if File.file?(File.join(vagrant_dir, 'vagrant-hostsupdater.gem'))
-      system('vagrant plugin install ' + File.join(vagrant_dir, 'vagrant-hostsupdater.gem'))
-      File.delete(File.join(vagrant_dir, 'vagrant-hostsupdater.gem'))
-      puts "#{yellow}VVV has completed installing local plugins. Please run the requested command again.#{creset}"
+  unless Vagrant.has_plugin?('vagrant-hostmanager')
+    if File.file?(File.join(vagrant_dir, 'vagrant-hostmanager.gem'))
+      system('vagrant plugin install ' + File.join(vagrant_dir, 'vagrant-hostmanager.gem'))
+      File.delete(File.join(vagrant_dir, 'vagrant-hostmanager.gem'))
+      puts "#{yellow}VVV has completed installing the vagrant-hostmanager plugins. Please run the requested command again.#{creset}"
       exit
     else
-      config.vagrant.plugins = ['vagrant-hostsupdater']
+      config.vagrant.plugins = ['vagrant-hostmanager']
     end
   end
 
@@ -774,8 +771,16 @@ Vagrant.configure('2') do |config|
   #
   # By default, we'll include the domains set up by VVV through the vvv-hosts file
   # located in the www/ directory and in config/config.yml.
-  if defined?(VagrantPlugins::HostsUpdater)
+  #
 
+  if defined?(VagrantPlugins::HostManager)
+    config.hostmanager.aliases = vvv_config['hosts']
+    config.hostmanager.enabled = true
+    config.hostmanager.manage_host = true
+    config.hostmanager.manage_guest = true
+    config.hostmanager.ignore_private_ip = false
+    config.hostmanager.include_offline = true
+  elsif defined?(VagrantPlugins::HostsUpdater)
     # Pass the found host names to the hostsupdater plugin so it can perform magic.
     config.hostsupdater.aliases = vvv_config['hosts']
     config.hostsupdater.remove_on_suspend = true

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -784,6 +784,9 @@ Vagrant.configure('2') do |config|
     # Pass the found host names to the hostsupdater plugin so it can perform magic.
     config.hostsupdater.aliases = vvv_config['hosts']
     config.hostsupdater.remove_on_suspend = true
+  else
+    puts "! Neither the HostManager or HostsUpdater plugins are installed!!! Domains won't work without one of these plugins!"
+    puts "Run vagrant plugin install vagrant-hostmanager then try again."
   end
 
   # Vagrant Triggers


### PR DESCRIPTION
## Summary:

hostsupdater sets our host files on the host OS, but the status of that project is unknown. It looks like the owner might have gone AWOL, and there are Windows issues sitting unfixed, PR's unreviewed, etc.

Given we have Windows users with issues ( see #2026 ), we should look into an alternative, this PR tries to swap hostsupdater for hostmanager, with a fallback to the original.

If you have both installed, hostsupdater will still try to add the `vvv` domain to the hosts file, I could find no way to eliminate this.

PR is currently working locally on an existing VM in MacOS with Virtualbox:

<img width="1113" alt="Screenshot 2020-04-10 at 10 50 21" src="https://user-images.githubusercontent.com/58855/78982917-08313f00-7b1b-11ea-9bd5-b2e7ed9bf1c3.png">

I'd like to see the results of testing this PR on Windows and Linux, in particular from those users with issues

<!-- what does it add/fix/change/remove? -->

## Checks

<!--  Have you: -->

* [xv] I've tested this PR with Vagrant **v2.2.7** and VirtualBox **v6.0.14** on **MacOS**
* [x] This PR is for the `develop` branch not the `master` branch.
* [x] I've updated the changelog.
* [x] This PR is complete and ready for review.
 
 <!-- don't forget to fill out the bolded parts -->
