### PR TITLE
Fix logs for utility provisioners.

### DIFF
--- a/provision/provision-helpers.sh
+++ b/provision/provision-helpers.sh
@@ -17,6 +17,7 @@ if [[ -f /vagrant/config.yml ]]; then
 fi
 
 export VVV_CONFIG
+export VVV_CURRENT_LOG_FILE=""
 
 function containsElement () {
   declare -a array=(${2})
@@ -138,6 +139,7 @@ function log_to_file() {
 	# pipe to file
 	exec > >(tee -a "${logfile}" )
 	exec 2> >(tee -a "${logfile}" >&2 )
+	VVV_CURRENT_LOG_FILE="${logfile}"
 }
 export -f log_to_file
 

--- a/provision/provision-utility.sh
+++ b/provision/provision-utility.sh
@@ -5,7 +5,7 @@
 PROVISIONER="/srv/provision/utilities/${1}/${2}/provision.sh"
 
 if [[ -f $PROVISIONER ]]; then
-    ( source "${PROVISIONER}" )
+    ( bash "${PROVISIONER}" >> "${VVV_CURRENT_LOG_FILE}" )
     SUCCESS=$?
 	if [ "${SUCCESS}" -eq 0 ]; then
 		provisioner_success; exit;


### PR DESCRIPTION
This fixes an issue brought up by @tomjn , in which the utility provisioner printed more output than before #2116 .

After researching, I've realized that none of the site provisioners print any output (at all) before #2116 because they were executed as separate commands (in a child process) as opposed to being sourced into the current shell.

For now i'm opening this PR as a draft, but we should consider instead of doing this, to mod the utility provisioners to output things to stdout when needed, so that we still get messages like:

```
 * Copying phpMyAdmin into place
 * Cleaning up after phpMyAdmin
 * phpMyAdmin setup complete
```

Which were not printed (but logged) before #2116 .

I'll do some research and maybe do this PR to vvv-utilities.