### PR TITLE
add gem binaries to Path if the folder exists

### DIFF
--- a/config/bash_aliases
+++ b/config/bash_aliases
@@ -31,6 +31,14 @@ if [[ $PATH != *"/srv/www/phpcs/scripts"* ]]; then
 	export PATH="$PATH:/srv/www/phpcs/scripts"
 fi
 
+
+# Ruby Gems
+if [ -d "$HOME/.gem/bin" ] ; then
+  if [[ $PATH != *"${HOME}/.gem/bin"* ]]; then
+	  export PATH="$PATH:${HOME}/.gem/bin"
+  fi
+fi
+
 # Vagrant scripts
 if [[ $PATH != *"/srv/config/homebin"* ]]; then
 	export PATH="$PATH:/srv/config/homebin"


### PR DESCRIPTION
Without this, binaries for installed gems aren't available in path

## Checks

<!--  Have you: -->

* [ ] I've tested this PR with Vagrant **vXX** and VirtualBox **vXX** on **Operating System**
* [ ] This PR is for the `develop` branch not the `master` branch.
* [ ] I've updated the changelog.
* [ ] This PR is complete and ready for review.
 
 <!-- don't forget to fill out the bolded parts -->
