### PR TITLE
Vagrant goodhosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ permalink: /docs/en-US/changelog/
 ### Enhancements
 
 * Cleaned up leftover `nvm` removal code from main provisioner ( #2185 )
+* Support for new plugin `vagrant-goodhosts` to replace in the future `vagrant-hostsupdater`
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ permalink: /docs/en-US/changelog/
 ### Enhancements
 
 * Cleaned up leftover `nvm` removal code from main provisioner ( #2185 )
-* Support for new plugin `vagrant-goodhosts` to replace in the future `vagrant-hostsupdater`
+* Added support for `vagrant-goodhosts`, we recommend using this in the future instead of `vagrant-hostsupdater`
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ VVV is a local developer environment, mainly aimed at [WordPress](https://wordpr
 To use it, download and install [Vagrant](https://www.vagrantup.com) and [VirtualBox](https://www.virtualbox.org/). Then, clone this repository and run:
 
 ```shell
-vagrant plugin install vagrant-hostsupdater --local
+vagrant plugin install vagrant-goodhosts --local
 vagrant up --provision
 ```
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -788,7 +788,10 @@ Vagrant.configure('2') do |config|
     config.hostmanager.manage_guest = true
     config.hostmanager.ignore_private_ip = false
     config.hostmanager.include_offline = true
-  elsif defined?(VagrantPlugins::HostsUpdater) || defined?(VagrantPlugins::GoodHosts)
+  elsif defined?(VagrantPlugins::GoodHosts)
+    config.goodhosts.aliases = vvv_config['hosts']
+    config.goodhosts.remove_on_suspend = true
+  elsif defined?(VagrantPlugins::HostsUpdater)
     # Pass the found host names to the hostsupdater plugin so it can perform magic.
     config.hostsupdater.aliases = vvv_config['hosts']
     config.hostsupdater.remove_on_suspend = true

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -266,6 +266,7 @@ if show_logo
 
   platform << 'vagrant-hostmanager' if Vagrant.has_plugin?('vagrant-hostmanager')
   platform << 'vagrant-hostsupdater' if Vagrant.has_plugin?('vagrant-hostsupdater')
+  platform << 'vagrant-goodhosts' if Vagrant.has_plugin?('vagrant-goodhosts')
   platform << 'vagrant-vbguest' if Vagrant.has_plugin?('vagrant-vbguest')
   platform << 'vagrant-disksize' if Vagrant.has_plugin?('vagrant-disksize')
 
@@ -708,7 +709,7 @@ Vagrant.configure('2') do |config|
                       args: [
                         vvv_config['dashboard']['repo'],
                         vvv_config['dashboard']['branch']
-                      ], 
+                      ],
                       env: { "VVV_LOG" => "dashboard" }
 
   vvv_config['utility-sources'].each do |name, args|
@@ -720,7 +721,7 @@ Vagrant.configure('2') do |config|
                           name,
                           args['repo'].to_s,
                           args['branch']
-                        ], 
+                        ],
                         env: { "VVV_LOG" => "utility-source-#{name}" }
   end
 
@@ -787,12 +788,12 @@ Vagrant.configure('2') do |config|
     config.hostmanager.manage_guest = true
     config.hostmanager.ignore_private_ip = false
     config.hostmanager.include_offline = true
-  elsif defined?(VagrantPlugins::HostsUpdater)
+  elsif defined?(VagrantPlugins::HostsUpdater) || defined?(VagrantPlugins::GoodHosts)
     # Pass the found host names to the hostsupdater plugin so it can perform magic.
     config.hostsupdater.aliases = vvv_config['hosts']
     config.hostsupdater.remove_on_suspend = true
   else
-    puts "! Neither the HostManager or HostsUpdater plugins are installed!!! Domains won't work without one of these plugins!"
+    puts "! Neither the HostManager, GoodHosts or HostsUpdater plugins are installed!!! Domains won't work without one of these plugins!"
     puts "Run vagrant plugin install vagrant-hostmanager then try again."
   end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -374,7 +374,7 @@ Vagrant.configure('2') do |config|
   end
 
   # Auto Download Vagrant plugins, supported from Vagrant 2.2.0
-  unless Vagrant.has_plugin?('vagrant-hostsupdater')
+  unless Vagrant.has_plugin?('vagrant-hostsupdater') && (Vagrant.has_plugin?('vagrant-goodhosts') || Vagrant.has_plugin?('vagrant-hostsmanager'))
     if File.file?(File.join(vagrant_dir, 'vagrant-hostsupdater.gem'))
       system('vagrant plugin install ' + File.join(vagrant_dir, 'vagrant-hostsupdater.gem'))
       File.delete(File.join(vagrant_dir, 'vagrant-hostsupdater.gem'))

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -375,13 +375,13 @@ Vagrant.configure('2') do |config|
 
   # Auto Download Vagrant plugins, supported from Vagrant 2.2.0
   unless Vagrant.has_plugin?('vagrant-hostsupdater') && Vagrant.has_plugin?('vagrant-goodhosts') && Vagrant.has_plugin?('vagrant-hostsmanager')
-    if File.file?(File.join(vagrant_dir, 'vagrant-hostsupdater.gem'))
-      system('vagrant plugin install ' + File.join(vagrant_dir, 'vagrant-hostsupdater.gem'))
-      File.delete(File.join(vagrant_dir, 'vagrant-hostsupdater.gem'))
-      puts "#{yellow}VVV has completed installing the vagrant-hostsupdater plugins. Please run the requested command again.#{creset}"
+    if File.file?(File.join(vagrant_dir, 'vagrant-goodhosts.gem'))
+      system('vagrant plugin install ' + File.join(vagrant_dir, 'vagrant-goodhosts.gem'))
+      File.delete(File.join(vagrant_dir, 'vagrant-goodhosts.gem'))
+      puts "#{yellow}VVV has completed installing the vagrant-goodhosts plugins. Please run the requested command again.#{creset}"
       exit
     else
-      config.vagrant.plugins = ['vagrant-hostsupdater']
+      config.vagrant.plugins = ['vagrant-goodhosts']
     end
   end
 
@@ -772,7 +772,7 @@ Vagrant.configure('2') do |config|
 
   # Local Machine Hosts
   #
-  # If the Vagrant plugin hostsupdater (https://github.com/cogitatio/vagrant-hostsupdater) is
+  # If the Vagrant plugin goodhosts (https://github.com/Mte90/vagrant-goodhosts/) is
   # installed, the following will automatically configure your local machine's hosts file to
   # be aware of the domains specified below. Watch the provisioning script as you may need to
   # enter a password for Vagrant to access your hosts file.
@@ -781,17 +781,17 @@ Vagrant.configure('2') do |config|
   # located in the www/ directory and in config/config.yml.
   #
 
-  if defined?(VagrantPlugins::HostManager)
+  if Vagrant.has_plugin?('vagrant-goodhosts')
+    config.goodhosts.aliases = vvv_config['hosts']
+    config.goodhosts.remove_on_suspend = true
+  elsif Vagrant.has_plugin?('vagrant-hostsmanager')
     config.hostmanager.aliases = vvv_config['hosts']
     config.hostmanager.enabled = true
     config.hostmanager.manage_host = true
     config.hostmanager.manage_guest = true
     config.hostmanager.ignore_private_ip = false
     config.hostmanager.include_offline = true
-  elsif defined?(VagrantPlugins::GoodHosts)
-    config.goodhosts.aliases = vvv_config['hosts']
-    config.goodhosts.remove_on_suspend = true
-  elsif defined?(VagrantPlugins::HostsUpdater)
+  elsif Vagrant.has_plugin?('vagrant-hostsupdater')
     # Pass the found host names to the hostsupdater plugin so it can perform magic.
     config.hostsupdater.aliases = vvv_config['hosts']
     config.hostsupdater.remove_on_suspend = true

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -374,7 +374,7 @@ Vagrant.configure('2') do |config|
   end
 
   # Auto Download Vagrant plugins, supported from Vagrant 2.2.0
-  unless Vagrant.has_plugin?('vagrant-hostsupdater') && (Vagrant.has_plugin?('vagrant-goodhosts') || Vagrant.has_plugin?('vagrant-hostsmanager'))
+  unless Vagrant.has_plugin?('vagrant-hostsupdater') && Vagrant.has_plugin?('vagrant-goodhosts') && Vagrant.has_plugin?('vagrant-hostsmanager')
     if File.file?(File.join(vagrant_dir, 'vagrant-hostsupdater.gem'))
       system('vagrant plugin install ' + File.join(vagrant_dir, 'vagrant-hostsupdater.gem'))
       File.delete(File.join(vagrant_dir, 'vagrant-hostsupdater.gem'))

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -378,7 +378,7 @@ Vagrant.configure('2') do |config|
     if File.file?(File.join(vagrant_dir, 'vagrant-goodhosts.gem'))
       system('vagrant plugin install ' + File.join(vagrant_dir, 'vagrant-goodhosts.gem'))
       File.delete(File.join(vagrant_dir, 'vagrant-goodhosts.gem'))
-      puts "#{yellow}VVV has completed installing the vagrant-goodhosts plugins. Please run the requested command again.#{creset}"
+      puts "#{yellow}VVV needed to install the vagrant-goodhosts plugin which is now installed. Please run the requested command again.#{creset}"
       exit
     else
       config.vagrant.plugins = ['vagrant-goodhosts']
@@ -797,7 +797,7 @@ Vagrant.configure('2') do |config|
     config.hostsupdater.remove_on_suspend = true
   else
     puts "! Neither the HostManager, GoodHosts or HostsUpdater plugins are installed!!! Domains won't work without one of these plugins!"
-    puts "Run vagrant plugin install vagrant-hostmanager then try again."
+    puts "Run 'vagrant plugin install vagrant-goodhosts' then try again."
   end
 
   # Vagrant Triggers


### PR DESCRIPTION
This branch add support for this new plugin.

# How to test

* Use this branch for VVV (just change the plugin priorities on settings the hosts doesn't do anything dangerous for your instance)
* Download the gem from https://github.com/goodhosts/vagrant/releases/tag/1.0.0-beta4
* Install it on your pc with this cli command `vagrant plugin install vagrant-goodhosts-*.gem`
* Now do `vagrant up` of your VVV instance with this branch
* Check if the website works in your browser and if the hosts file in your system is changed
* Execute a `vagrant halt` and check if the hosts file in your system doesn't ave anymroe the new definition generated on up

Fix https://github.com/Varying-Vagrant-Vagrants/VVV/issues/2136