### PR TITLE
Avoid stdout on all provisioners (except main)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ permalink: /docs/en-US/changelog/
 * Swap the MariaDB apt mirror used for a more reliable source ( partially #2140 and in a217369 )
 * Fixed an issue with the dpkg lock file not being cleaned up sometimes ( #2151 )
 * Fix issues with the sad bear showing at the end of provisioning despite provisioners being succesful ( #2161 )
+* Fix provisioners printing all output to console (not just errors) ( #2174 )
 
 ## 3.3.0 ( 2020 Feb 26th )
 

--- a/provision/provision-helpers.sh
+++ b/provision/provision-helpers.sh
@@ -137,7 +137,11 @@ function log_to_file() {
 	exec 1>&6
 	exec 2>&7
 	# pipe to file
-	exec > >( tee -a "${logfile}" >/dev/null ) # stdout should not go to the console
+	if [[ "${1}" == "provisioner-main" ]]; then
+		exec > >( tee -a "${logfile}" ) # main provisioner outputs everything
+	else
+		exec > >( tee -a "${logfile}" >/dev/null ) # others, only stderr
+	fi
 	exec 2> >( tee -a "${logfile}" >&2 )
 	VVV_CURRENT_LOG_FILE="${logfile}"
 }

--- a/provision/provision-helpers.sh
+++ b/provision/provision-helpers.sh
@@ -137,8 +137,8 @@ function log_to_file() {
 	exec 1>&6
 	exec 2>&7
 	# pipe to file
-	exec > >(tee -a "${logfile}" )
-	exec 2> >(tee -a "${logfile}" >&2 )
+	exec > >( tee -a "${logfile}" >/dev/null ) # stdout should not go to the console
+	exec 2> >( tee -a "${logfile}" >&2 )
 	VVV_CURRENT_LOG_FILE="${logfile}"
 }
 export -f log_to_file

--- a/provision/provision-helpers.sh
+++ b/provision/provision-helpers.sh
@@ -133,7 +133,7 @@ function log_to_file() {
 	local logfile="${logfolder}/${1}.log"
 	mkdir -p "${logfolder}"
 	touch "${logfile}"
-	# reset output otherwise it will log to previous files
+	# reset output otherwise it will log to previous files. from backup made in provisioners.sh
 	exec 1>&6
 	exec 2>&7
 	# pipe to file

--- a/provision/provisioners.sh
+++ b/provision/provisioners.sh
@@ -32,9 +32,9 @@ function provisioner_end() {
     echo -e "------------------------------------------------------------------------------------"
     rm -f "/vagrant/failed_provisioners/provisioner-${VVV_PROVISIONER_RUNNING}"
   else
-    echo -e "------------------------------------------------------------------------------------"
-    vvv_error " ! The '${VVV_PROVISIONER_RUNNING}' provisioner ran into problems, check the full log for more details! It completed in ${elapsed} seconds."
-    echo -e "------------------------------------------------------------------------------------"
+    >&2 echo -e "------------------------------------------------------------------------------------"
+    >&2 vvv_error " ! The '${VVV_PROVISIONER_RUNNING}' provisioner ran into problems, check the full log for more details! It completed in ${elapsed} seconds."
+    >&2 echo -e "------------------------------------------------------------------------------------"
   fi
   echo ""
   trap - EXIT

--- a/provision/provisioners.sh
+++ b/provision/provisioners.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
+# don't allow inclusion of this file more than once
 if ( type provisioner_begin &>/dev/null ); then
 	return
 fi
 
+# backup original file descriptors
 exec 6>&1
 exec 7>&2
 


### PR DESCRIPTION
This is an attempt to fix #2173 and also clarify a bit of the process to pipe data to a file.

While researching this, i noticed there's a bug in the current implementation which is kind of a pain in the ass to fix, but was not introduced by my refactor.

This basically is a concurrency issue with tee. The way it currently works is that each output (stdout and stderr) are piped to FIFO queues, which is later fed to tee. The script only waits for the queue to be written, but not until tee finishes writing (appending actually) to the file. This is the reason that in some cases the log lines might be out of order, or in a weird situation. Link to an explanation of this [here](https://stackoverflow.com/questions/58035279/why-does-exectee-output-display-out-of-order/58036027#58036027).

I've tried addressing this, but didn't have time to fully fix this, and I think this may be a bit out of the scope of the issue i'm trying to fix (yet it's an issue with the tee piping technique implemented)

After research, the code before my refactor behaved the same as it did before this PR. This PR effectively behaves like @tomjn suggested it should.

