### PR TITLE
install php7.2-intl extension

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -169,6 +169,7 @@ apt_package_install_list=(
   php7.2-bcmath
   php7.2-curl
   php7.2-gd
+  php7.2-intl
   php7.2-mbstring
   php7.2-mysql
   php7.2-imap


### PR DESCRIPTION
## Summary:

Install PHP 7.2 intl extension

## Checks

Partial fix for #2178.