### PR TITLE
Added NVM utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ permalink: /docs/en-US/changelog/
 ### Enhancements
 
 * -
+* - Added `nvm` as an optional core utility ( #2185 )
+* - Cleaned up leftover `nvm` removal code from main provisioner ( #2185 )
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@ permalink: /docs/en-US/changelog/
 
 ### Enhancements
 
-* -
-* Added `nvm` as an optional core utility ( #2185 )
 * Cleaned up leftover `nvm` removal code from main provisioner ( #2185 )
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ permalink: /docs/en-US/changelog/
 ### Enhancements
 
 * -
-* - Added `nvm` as an optional core utility ( #2185 )
-* - Cleaned up leftover `nvm` removal code from main provisioner ( #2185 )
+* Added `nvm` as an optional core utility ( #2185 )
+* Cleaned up leftover `nvm` removal code from main provisioner ( #2185 )
 
 ### Bug Fixes
 

--- a/config/default-config.yml
+++ b/config/default-config.yml
@@ -98,6 +98,7 @@ utilities:
     #- webgrind # PHP Debugging
     #- mongodb # needed for Tideways/XHGui
     #- tideways # PHP profiling tool, also installs xhgui check https://varyingvagrantvagrants.org/docs/en-US/references/tideways-xhgui/
+    #- nvm # Node Version Manager
     #- php56
     #- php70
     #- php71

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -452,14 +452,6 @@ tools_install() {
   # Disable xdebug before any composer provisioning.
   sh /srv/config/homebin/xdebug_off
 
-  echo " * Checking for NVM"
-  if [[ -f ~/.nvm ]]; then
-    echo " * .nvm folder found, switching to system node, and removing NVM folders"
-    nvm use system
-    rm -rf ~/.nvm ~/.npm ~/.bower /srv/config/nvm
-    echo " * NVM folders removed"
-  fi
-
   if [[ $(nodejs -v | sed -ne 's/[^0-9]*\(\([0-9]\.\)\{0,4\}[0-9][^.]\).*/\1/p') != '10' ]]; then
     echo " * Downgrading to Node v10."
     apt remove nodejs -y


### PR DESCRIPTION
This adds `nvm` as a core utility in default config. Its disabled by default and has to be enabled in config prior to provisioning VVV.

This PR also removes the code from `provision/provision.sh` which looks for and deletes `nvm` folder.

Ref: #2177 
Ref: https://github.com/Varying-Vagrant-Vagrants/vvv-utilities/pull/67
