### PR TITLE
shyaml has a "default" parameter on the command, use it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ permalink: /docs/en-US/changelog/
 ### Bug Fixes
 
 * Fix mysql root password reset ( #2182 )
+* Fix empty string yml value reading on site provisioner ( #2201 )
 
 ## 3.4.1 ( 2020 June 4th )
 

--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -24,8 +24,8 @@ VVV_CONFIG=/vagrant/config.yml
 # Takes 2 values, a key to fetch a value for, and an optional default value
 # e.g. echo $(get_config_value 'key' 'defaultvalue')
 function get_config_value() {
-  local value=$(shyaml get-value "sites.${SITE_ESCAPED}.custom.${1}" 2> /dev/null < ${VVV_CONFIG})
-  echo "${value:-$2}"
+  local value=$(shyaml get-value "sites.${SITE_ESCAPED}.custom.${1}" "${2}" 2> /dev/null < ${VVV_CONFIG})
+  echo "${value}"
 }
 
 function get_hosts() {
@@ -34,8 +34,8 @@ function get_hosts() {
 }
 
 function get_primary_host() {
-  local value=$(shyaml get-value "sites.${SITE_ESCAPED}.hosts.0" 2> /dev/null < ${VVV_CONFIG})
-  echo "${value:-$1}"
+  local value=$(shyaml get-value "sites.${SITE_ESCAPED}.hosts.0" "${1}" 2> /dev/null < ${VVV_CONFIG})
+  echo "${value}"
 }
 
 function vvv_provision_site_nginx_config() {


### PR DESCRIPTION
The idea of handling defaults is to handle empty strings, but if it's specifically set to empty, our old way of reading specific values fail

[Here's](https://github.com/0k/shyaml#handling-missing-paths) docs related to what I used