### PR TITLE
Enable the VM hostname to be set via config.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ permalink: /docs/en-US/changelog/
 * Cleaned up leftover `nvm` removal code from main provisioner ( #2185 )
 * Added support for `vagrant-goodhosts`, we recommend using this in the future instead of `vagrant-hostsupdater`
 * Added `box-cleanup.sh` and `box-minimize.sh` scripts. Run these before creating a vagrant box to reduce disk size. These are only intended for box file creation.
+* Enabled the VM hostname to be set via `vm_config.hostname` in `config.yml`.
 
 ### Bug Fixes
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -437,7 +437,14 @@ Vagrant.configure('2') do |config|
     end
   end
 
-  config.vm.hostname = 'vvv'
+  # Enable hostnames to be set via vm_config.hostname, but default to "vvv".
+  if defined? vvv_config['vm_config']['hostname'] then
+    config.vm.hostname = vvv_config['vm_config']['hostname']
+    config.vm.define vvv_config['vm_config']['hostname']
+  else
+    config.vm.hostname = 'vvv'
+    config.vm.define 'vvv'
+  end
 
   # Specify disk size
   #

--- a/config/default-config.yml
+++ b/config/default-config.yml
@@ -116,6 +116,8 @@ vm_config:
   memory: 2048
   # CPU cores:
   cores: 2
+  # VM hostname:
+  hostname: vvv
 
   # this tells VVV to use the prebuilt box copied from the USB drive at contributor days
   # once set to false, do not change back to true, and reprovision


### PR DESCRIPTION
## Summary:

Enable the VM's hostname to be set via the `config.yml` file, useful when a developer might have multiple instances of VVV on a single host machine.

This change technically affects two settings within the VM:

1. The hostname (`/etc/hostname`) within the virtual machine
2. The name assigned to the VM within Vagrant (currently, VVV has been defaulting to "default")

      ```sh
      $ vagrant global-status
      id       name             provider   state    directory
      -------------------------------------------------------------------------
      f0fb7bf  my-vvv-hostname  virtualbox running  /Users/steve/Vagrant/VVV
      ```

## Checks

* [x] I've tested this PR with Vagrant **v2.2.9** and VirtualBox **v6.1** on **macOS 10.15**
* [x] This PR is for the `develop` branch not the `master` branch.
* [x] I've updated the changelog.
* [x] This PR is complete and ready for review.