### PR TITLE
Remove APT list files and switch compress default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ permalink: /docs/en-US/changelog/
 
 * Fix mysql root password reset ( #2182 )
 * Fix empty string yml value reading on site provisioner ( #2201 )
+* Remove APT list files and switch compress type default for repositories to avoid hash mismatch ( #2208 )
 
 ## 3.4.1 ( 2020 June 4th )
 

--- a/config/apt-conf-d/99hashmismatch
+++ b/config/apt-conf-d/99hashmismatch
@@ -1,0 +1,4 @@
+Acquire::http::Pipeline-Depth 0;
+Acquire::http::No-Cache true;
+Acquire::BrokenProxy    true;
+Acquire::CompressionTypes::Order::=gz;

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -423,14 +423,15 @@ package_install() {
   # fix https://github.com/Varying-Vagrant-Vagrants/VVV/issues/2150
   echo " * Cleaning up dpkg lock file"
   rm /var/lib/dpkg/lock*
-  
+
   echo " * Updating apt keys"
   apt-key update -y
 
   # Update all of the package references before installing anything
+  echo " * Copying /srv/config/apt-conf-d/99hashmismatch to /etc/apt/apt.conf.d/99hashmismatch"
+  cp -f "/srv/config/apt-conf-d/99hashmismatch" "/etc/apt/apt.conf.d/99hashmismatch"
   echo " * Running apt-get update..."
   rm -rf /var/lib/apt/lists/*
-  apt-get update -o Acquire::CompressionTypes::Order::=gz
   apt-get update -y --fix-missing
 
   # Install required packages
@@ -703,8 +704,8 @@ check_mysql_root_password() {
   # Get if root has correct password and mysql_native_password as plugin
   sql=$( cat <<-SQL
       SELECT count(*) from mysql.user WHERE
-      User='root' AND 
-      authentication_string=PASSWORD('root') AND 
+      User='root' AND
+      authentication_string=PASSWORD('root') AND
       plugin='mysql_native_password';
 SQL
 )

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -429,6 +429,8 @@ package_install() {
 
   # Update all of the package references before installing anything
   echo " * Running apt-get update..."
+  rm -rf /var/lib/apt/lists/*
+  apt-get update -o Acquire::CompressionTypes::Order::=gz
   apt-get update -y --fix-missing
 
   # Install required packages


### PR DESCRIPTION
Usually repository have the file in various version and gz is the default one that usually doesn't have troubles.
The majority of guides suggest doing a cleanup and to avoid other issue to define this default

Require some testing by the users with the issues and the others, just to test if everything works.

Fix: ##2208
