### PR TITLE
Prevent use of sudo vagrant up, #2215

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ permalink: /docs/en-US/changelog/
 * Added support for `vagrant-goodhosts`, we recommend using this in the future instead of `vagrant-hostsupdater`
 * Added `box-cleanup.sh` and `box-minimize.sh` scripts. Run these before creating a vagrant box to reduce disk size. These are only intended for box file creation.
 * Fixed an issue preventing backups of databases whose names contained reserved words ( #2213 )
+* Prevent use of sudo vagrant up ( #2215 )
 
 ### Bug Fixes
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -123,6 +123,12 @@ if show_logo
   puts splashfirst
 end
 
+case (Process.uid)
+when 0
+  puts "#{red}VVV (and Vagrant) cannot be executed as root user or with sudo permissions!#{creset}\n\n"
+  exit
+end
+  
 # Load the config file before the second section of the splash screen
 
 # Perform file migrations from older versions

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -125,8 +125,16 @@ end
 
 case (Process.uid)
 when 0
-  puts "#{red}VVV (and Vagrant) cannot be executed as root user or with sudo permissions!#{creset}\n\n"
-  exit
+	puts "#{red}     ! DANGER  !"
+	puts "#{red} ! ▄▀▀▀▄▄▄▄▄▄▄▀▀▀▄ !  You should never use sudo or root with vagrant.#{creset}"
+	puts "#{red}  !█▒▒░░░░░░░░░▒▒█    It causes lots of problems :(#{creset}"
+	puts "#{red}!   █░░█░▄▄░░█░░█ !   #{creset}"
+	puts "#{red}     █░░█░░█░▄▄█    ! We're really sorry but you may need to do painful#{creset}"
+	puts "#{red}  !  ▀▄░█░░██░░█      cleanup commands to fix this.#{creset}"
+	puts " "
+	puts "#{red}If vagrant does not work for you without sudo, open a GitHub issue instead#{creset}"
+	puts "#{red}In the future, this warning will halt provisioning to prevent new users making this mistake.#{creset}"
+  # exit
 end
   
 # Load the config file before the second section of the splash screen


### PR DESCRIPTION
## Summary:

fix #2215, basically stop the execution of vagrant with an alert if the user is root or is running with root permission.

Require a bit of testing.
