### PR TITLE
adjust global composer dependencies

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -506,8 +506,9 @@ tools_install() {
   if [[ -n "$(noroot composer --version --no-ansi | grep 'Composer version')" ]]; then
     echo " * Updating Composer..."
     COMPOSER_HOME=/usr/local/src/composer noroot composer --no-ansi global config bin-dir /usr/local/bin
-    COMPOSER_HOME=/usr/local/src/composer noroot composer --no-ansi self-update --no-progress --no-interaction
-    COMPOSER_HOME=/usr/local/src/composer noroot composer --no-ansi global require --no-update --no-progress --no-interaction phpunit/phpunit:6.* phpunit/php-invoker:1.1.* mockery/mockery:0.9.* d11wtq/boris:v1.0.8
+    COMPOSER_HOME=/usr/local/src/composer noroot composer --no-ansi self-update --stable --no-progress --no-interaction
+    COMPOSER_HOME=/usr/local/src/composer noroot composer --no-ansi global require --prefer-dist --no-update --no-progress --no-interaction phpunit/phpunit:^7.5
+    COMPOSER_HOME=/usr/local/src/composer noroot composer --no-ansi global require --prefer-dist --no-update --no-progress --no-interaction phpunit/phpunit:^7.5
     COMPOSER_HOME=/usr/local/src/composer noroot composer --no-ansi global update --no-progress --no-interaction
   fi
 


### PR DESCRIPTION
 - Explicitly require stable version of composer on self update
 - Explicitly prefer dist packages
 - Remove mockery phpinvoker and the PHP reply boris package
 - Update the required version of PHPUnit to `^7.5` to match cores `composer.json`

## Checks

<!--  Have you: -->

* [ ] I've tested this PR with Vagrant **vXX** and VirtualBox **vXX** on **Operating System**
* [x] This PR is for the `develop` branch not the `master` branch.
* [ ] I've updated the changelog.
* [ ] This PR is complete and ready for review.
 
 <!-- don't forget to fill out the bolded parts -->
