### PR TITLE
GH Action - Run Provisioners

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -25,12 +25,27 @@ jobs:
       # Make Symlinks
       - name: Create Vagrant Like Environment
         run: |
+          # uninstall pre installed packages (to test if utilities work)
+          sudo apt-get -q --autoremove --purge remove php*
+          sudo apt-get -q autoclean
+
           # create vagrant user
           sudo groupadd -g 2000 vagrant
           sudo useradd -u 2000 -g vagrant -m vagrant
 
+          # Install bindfs, which would allow us to "mount" folders with specific permissions
+          # similar to vagrant shares
+          sudo apt-get update
+          sudo apt-get install bindfs -y
+
+          # vbox_mount function to sumulate synced folders
+          function vbox_mount() {
+            sudo mkdir -p "$2"
+            sudo bindfs --chown-ignore --chgrp-ignore --chmod-ignore -u "$3" -g "$4" "$1" "$2"
+          }
+
           # create srv folder
-          sudo mkdir -p "/srv"
+          sudo -u "vagrant" mkdir -p "/srv"
 
           # copy files provided by vagrant
           sudo cp -f "$GITHUB_WORKSPACE/config/default-config.yml" "$GITHUB_WORKSPACE/config/config.yml"
@@ -38,34 +53,19 @@ jobs:
 
           # simulate vagrant synced folders
           sudo mkdir -p "$GITHUB_WORKSPACE/certificates"
-          sudo chown -R vagrant:vagrant "$GITHUB_WORKSPACE"
-          sudo ln -s "$GITHUB_WORKSPACE/database/sql" "/srv/database"
-          sudo ln -s "$GITHUB_WORKSPACE/config" "/srv/config"
-          sudo ln -s "$GITHUB_WORKSPACE/provision" "/srv/provision"
-          sudo ln -s "$GITHUB_WORKSPACE/certificates" "/srv/certificates"
-          sudo ln -s "$GITHUB_WORKSPACE/www" "/srv/www"
           sudo mkdir -p "$GITHUB_WORKSPACE/log/memcached"
           sudo mkdir -p "$GITHUB_WORKSPACE/log/nginx"
           sudo mkdir -p "$GITHUB_WORKSPACE/log/php"
           sudo mkdir -p "$GITHUB_WORKSPACE/log/provisioners"
-          sudo chown -R root:syslog "$GITHUB_WORKSPACE/log"
-          sudo ln -s "$GITHUB_WORKSPACE/log/memcached" "/var/log/memcached"
-          sudo ln -s "$GITHUB_WORKSPACE/log/nginx" "/var/log/nginx"
-          sudo ln -s "$GITHUB_WORKSPACE/log/php" "/var/log/php"
-          sudo ln -s "$GITHUB_WORKSPACE/log/provisioners" "/var/log/provisioners"
-
-          # Ensure permissions are correct (may not be needed)
-          sudo chown -R vagrant:vagrant "/srv"
-          sudo chown -R root:syslog "/var/log/memcached"
-          sudo chown -R root:syslog "/var/log/nginx"
-          sudo chown -R root:syslog "/var/log/php"
-          sudo chown -R root:syslog "/var/log/provisioners"
-
-          # uninstall pre installed packages (to test if utilities work)
-          sudo apt-get remove php*
-          sudo apt-get purge php*
-          sudo apt-get autoremove
-          sudo apt-get autoclean
+          vbox_mount "$GITHUB_WORKSPACE/database/sql" "/srv/database" "vagrant" "vagrant"
+          vbox_mount "$GITHUB_WORKSPACE/config" "/srv/config" "vagrant" "vagrant"
+          vbox_mount "$GITHUB_WORKSPACE/provision" "/srv/provision" "vagrant" "vagrant"
+          vbox_mount "$GITHUB_WORKSPACE/certificates" "/srv/certificates" "vagrant" "vagrant"
+          vbox_mount "$GITHUB_WORKSPACE/www" "/srv/www" "vagrant" "www-data"
+          vbox_mount "$GITHUB_WORKSPACE/log/memcached" "/var/log/memcached" "root" "syslog"
+          vbox_mount "$GITHUB_WORKSPACE/log/nginx" "/var/log/nginx" "root" "syslog"
+          vbox_mount "$GITHUB_WORKSPACE/log/php" "/var/log/php" "root" "syslog"
+          vbox_mount "$GITHUB_WORKSPACE/log/provisioners" "/var/log/provisioners" "root" "syslog"
 
       # Runs the main provisioner as sudo
       - name: Run all provisioners

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -25,16 +25,48 @@ jobs:
       # Make Symlinks
       - name: Create Vagrant Like Environment
         run: |
-          ln -s "$GITHUB_WORKSPACE/database/sql" "/srv/database"
-          ln -s "$GITHUB_WORKSPACE/config" "/srv/config"
-          ln -s "$GITHUB_WORKSPACE/provision" "/srv/provision"
-          ln -s "$GITHUB_WORKSPACE/certificates" "/srv/certificates"
-          ln -s "$GITHUB_WORKSPACE/www" "/srv/www"
-          ln -s "$GITHUB_WORKSPACE/log/memcached" "/var/log/memcached"
-          ln -s "$GITHUB_WORKSPACE/log/nginx" "/var/log/nginx"
-          ln -s "$GITHUB_WORKSPACE/log/php" "/var/log/php"
-          ln -s "$GITHUB_WORKSPACE/log/provisioners" "/var/log/provisioners"
+          # create vagrant user
+          sudo groupadd -g 2000 vagrant
+          sudo useradd -u 2000 -g vagrant -m vagrant
 
-      # Runs a single command using the runners shell
-      - name: Run a one-line script
-        run: cat "/srv/config/bash_aliases"
+          # create srv folder
+          sudo mkdir -p "/srv"
+
+          # copy files provided by vagrant
+          sudo cp -f "$GITHUB_WORKSPACE/config/default-config.yml" "$GITHUB_WORKSPACE/config/config.yml"
+          sudo cp -f "$GITHUB_WORKSPACE/version" "/home/vagrant/version"
+
+          # simulate vagrant synced folders
+          sudo mkdir -p "$GITHUB_WORKSPACE/certificates"
+          sudo chown -R vagrant:vagrant "$GITHUB_WORKSPACE"
+          sudo ln -s "$GITHUB_WORKSPACE/database/sql" "/srv/database"
+          sudo ln -s "$GITHUB_WORKSPACE/config" "/srv/config"
+          sudo ln -s "$GITHUB_WORKSPACE/provision" "/srv/provision"
+          sudo ln -s "$GITHUB_WORKSPACE/certificates" "/srv/certificates"
+          sudo ln -s "$GITHUB_WORKSPACE/www" "/srv/www"
+          sudo mkdir -p "$GITHUB_WORKSPACE/log/memcached"
+          sudo mkdir -p "$GITHUB_WORKSPACE/log/nginx"
+          sudo mkdir -p "$GITHUB_WORKSPACE/log/php"
+          sudo mkdir -p "$GITHUB_WORKSPACE/log/provisioners"
+          sudo chown -R root:syslog "$GITHUB_WORKSPACE/log"
+          sudo ln -s "$GITHUB_WORKSPACE/log/memcached" "/var/log/memcached"
+          sudo ln -s "$GITHUB_WORKSPACE/log/nginx" "/var/log/nginx"
+          sudo ln -s "$GITHUB_WORKSPACE/log/php" "/var/log/php"
+          sudo ln -s "$GITHUB_WORKSPACE/log/provisioners" "/var/log/provisioners"
+
+          # Ensure permissions are correct (may not be needed)
+          sudo chown -R vagrant:vagrant "/srv"
+          sudo chown -R root:syslog "/var/log/memcached"
+          sudo chown -R root:syslog "/var/log/nginx"
+          sudo chown -R root:syslog "/var/log/php"
+          sudo chown -R root:syslog "/var/log/provisioners"
+
+          # uninstall pre installed packages (to test if utilities work)
+          sudo apt-get remove php*
+          sudo apt-get purge php*
+          sudo apt-get autoremove
+          sudo apt-get autoclean
+
+      # Runs the main provisioner as sudo
+      - name: Run all provisioners
+        run: sudo bash /srv/provision/tests/run-provisioners.sh

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -70,3 +70,15 @@ jobs:
       # Runs the main provisioner as sudo
       - name: Run all provisioners
         run: sudo bash /srv/provision/tests/run-provisioners.sh
+
+      - name: Prepare Output
+        run: |
+          sudo cp -rf "$GITHUB_WORKSPACE/log" "/vvv-logs"
+          MYUID=$(id -u -n)
+          MYGID=$(id -g -n)
+          sudo chown -R $MYUID:$MYGID "/vvv-logs"
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: logs
+          path: "/vvv-logs"

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,0 +1,40 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the develop branch
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-18.04
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Make Symlinks
+      - name: Create Vagrant Like Environment
+        run: |
+          ln -s "$GITHUB_WORKSPACE/database/sql" "/srv/database"
+          ln -s "$GITHUB_WORKSPACE/config" "/srv/config"
+          ln -s "$GITHUB_WORKSPACE/provision" "/srv/provision"
+          ln -s "$GITHUB_WORKSPACE/certificates" "/srv/certificates"
+          ln -s "$GITHUB_WORKSPACE/www" "/srv/www"
+          ln -s "$GITHUB_WORKSPACE/log/memcached" "/var/log/memcached"
+          ln -s "$GITHUB_WORKSPACE/log/nginx" "/var/log/nginx"
+          ln -s "$GITHUB_WORKSPACE/log/php" "/var/log/php"
+          ln -s "$GITHUB_WORKSPACE/log/provisioners" "/var/log/provisioners"
+
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: cat "/srv/config/bash_aliases"

--- a/.github/workflows/vvv-provisioning.yml
+++ b/.github/workflows/vvv-provisioning.yml
@@ -89,6 +89,7 @@ jobs:
       # - Check VM hostfile
 
       - name: Prepare Output
+        if: ${{ always() }}
         run: |
           sudo cp -rf "$GITHUB_WORKSPACE/log" "/vvv-logs"
           MYUID=$(id -u -n)
@@ -96,6 +97,7 @@ jobs:
           sudo chown -R $MYUID:$MYGID "/vvv-logs"
 
       - uses: actions/upload-artifact@v2
+        if: ${{ always() }}
         with:
           name: logs
           path: "/vvv-logs"

--- a/.github/workflows/vvv-provisioning.yml
+++ b/.github/workflows/vvv-provisioning.yml
@@ -72,9 +72,27 @@ jobs:
           vbox_mount "$GITHUB_WORKSPACE/log/php" "/var/log/php" "root" "syslog" "666"
           vbox_mount "$GITHUB_WORKSPACE/log/provisioners" "/var/log/provisioners" "root" "syslog" "666"
 
-      # Runs the main provisioner as sudo
-      - name: Run all provisioners
-        run: sudo bash /srv/provision/tests/run-provisioners.sh
+      # Runs the provisioners in the expected order
+      - name: Run provison-pre.sh
+        run: sudo bash -c '. "/srv/provision/tests/provisioners.sh" && pre_hook'
+
+      - name: Run provison.sh
+        run: sudo bash -c '. "/srv/provision/tests/provisioners.sh" && provision_main'
+
+      - name: Run provison-dashboard.sh
+        run: sudo bash -c '. "/srv/provision/tests/provisioners.sh" && provision_dashboard'
+
+      - name: Run provison-utility-source.sh
+        run: sudo bash -c '. "/srv/provision/tests/provisioners.sh" && provision_utility_sources'
+
+      - name: Run provison-utility.sh
+        run: sudo bash -c '. "/srv/provision/tests/provisioners.sh" && provision_utilities'
+
+      - name: Run provison-site.sh
+        run: sudo bash -c '. "/srv/provision/tests/provisioners.sh" && provision_sites'
+
+      - name: Run provison-post.sh
+        run: sudo bash -c '. "/srv/provision/tests/provisioners.sh" && post_hook'
 
       # At this point, we would run some extra tests
       # TODO: Ideas

--- a/.github/workflows/vvv-provisioning.yml
+++ b/.github/workflows/vvv-provisioning.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: CI
+name: VVV Provisioning
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the develop branch
@@ -8,12 +8,13 @@ on:
   push:
     branches: [ develop ]
   pull_request:
-    branches: [ develop ]
+    branches: [ develop, stable ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
   build:
+    name: Run Provisioner
     # The type of runner that the job will run on
     runs-on: ubuntu-18.04
 
@@ -70,6 +71,12 @@ jobs:
       # Runs the main provisioner as sudo
       - name: Run all provisioners
         run: sudo bash /srv/provision/tests/run-provisioners.sh
+
+      # At this point, we would run some extra tests
+      # TODO: Ideas
+      # - Add screenshots of provisioned sites
+      # - CURL mailhog API to see if it's working or not
+      # - Check VM hostfile
 
       - name: Prepare Output
         run: |

--- a/.github/workflows/vvv-provisioning.yml
+++ b/.github/workflows/vvv-provisioning.yml
@@ -41,8 +41,12 @@ jobs:
 
           # vbox_mount function to sumulate synced folders
           function vbox_mount() {
+            local perms="-p ug=rwx,o=r";
+            if [ ! -z "${5}" ]; then 
+              perms="-p ${5}"
+            fi
             sudo mkdir -p "$2"
-            sudo bindfs --chown-ignore --chgrp-ignore --chmod-ignore -u "$3" -g "$4" "$1" "$2"
+            sudo bindfs --chown-ignore --chgrp-ignore --chmod-ignore -u "$3" -g "$4" "$1" "$2" $perms
           }
 
           # create srv folder
@@ -62,11 +66,11 @@ jobs:
           vbox_mount "$GITHUB_WORKSPACE/config" "/srv/config" "vagrant" "vagrant"
           vbox_mount "$GITHUB_WORKSPACE/provision" "/srv/provision" "vagrant" "vagrant"
           vbox_mount "$GITHUB_WORKSPACE/certificates" "/srv/certificates" "vagrant" "vagrant"
-          vbox_mount "$GITHUB_WORKSPACE/www" "/srv/www" "vagrant" "www-data"
-          vbox_mount "$GITHUB_WORKSPACE/log/memcached" "/var/log/memcached" "root" "syslog"
-          vbox_mount "$GITHUB_WORKSPACE/log/nginx" "/var/log/nginx" "root" "syslog"
-          vbox_mount "$GITHUB_WORKSPACE/log/php" "/var/log/php" "root" "syslog"
-          vbox_mount "$GITHUB_WORKSPACE/log/provisioners" "/var/log/provisioners" "root" "syslog"
+          vbox_mount "$GITHUB_WORKSPACE/www" "/srv/www" "vagrant" "www-data" "ug=rwx,o=r,o+D"
+          vbox_mount "$GITHUB_WORKSPACE/log/memcached" "/var/log/memcached" "root" "syslog" "666"
+          vbox_mount "$GITHUB_WORKSPACE/log/nginx" "/var/log/nginx" "root" "syslog" "666"
+          vbox_mount "$GITHUB_WORKSPACE/log/php" "/var/log/php" "root" "syslog" "666"
+          vbox_mount "$GITHUB_WORKSPACE/log/provisioners" "/var/log/provisioners" "root" "syslog" "666"
 
       # Runs the main provisioner as sudo
       - name: Run all provisioners

--- a/.github/workflows/vvv-provisioning.yml
+++ b/.github/workflows/vvv-provisioning.yml
@@ -34,19 +34,12 @@ jobs:
           sudo groupadd -g 2000 vagrant
           sudo useradd -u 2000 -g vagrant -m vagrant
 
-          # Install bindfs, which would allow us to "mount" folders with specific permissions
-          # similar to vagrant shares
-          sudo apt-get update
-          sudo apt-get install bindfs -y
-
-          # vbox_mount function to sumulate synced folders
-          function vbox_mount() {
-            local perms="-p ug=rwx,o=r";
-            if [ ! -z "${5}" ]; then 
-              perms="-p ${5}"
+          # vvv_symlink function to sumulate synced folders
+          function vvv_symlink() {
+            if [ ! -d "${1}" ]; then 
+              sudo mkdir -p "${1}"
             fi
-            sudo mkdir -p "$2"
-            sudo bindfs --chown-ignore --chgrp-ignore --chmod-ignore -u "$3" -g "$4" "$1" "$2" $perms
+            sudo ln -sf "${1}" "${2}"
           }
 
           # create srv folder
@@ -56,21 +49,16 @@ jobs:
           sudo cp -f "$GITHUB_WORKSPACE/config/default-config.yml" "$GITHUB_WORKSPACE/config/config.yml"
           sudo cp -f "$GITHUB_WORKSPACE/version" "/home/vagrant/version"
 
-          # simulate vagrant synced folders
-          sudo mkdir -p "$GITHUB_WORKSPACE/certificates"
-          sudo mkdir -p "$GITHUB_WORKSPACE/log/memcached"
-          sudo mkdir -p "$GITHUB_WORKSPACE/log/nginx"
-          sudo mkdir -p "$GITHUB_WORKSPACE/log/php"
-          sudo mkdir -p "$GITHUB_WORKSPACE/log/provisioners"
-          vbox_mount "$GITHUB_WORKSPACE/database/sql" "/srv/database" "vagrant" "vagrant"
-          vbox_mount "$GITHUB_WORKSPACE/config" "/srv/config" "vagrant" "vagrant"
-          vbox_mount "$GITHUB_WORKSPACE/provision" "/srv/provision" "vagrant" "vagrant"
-          vbox_mount "$GITHUB_WORKSPACE/certificates" "/srv/certificates" "vagrant" "vagrant"
-          vbox_mount "$GITHUB_WORKSPACE/www" "/srv/www" "vagrant" "www-data" "ug=rwx,o=r,o+D"
-          vbox_mount "$GITHUB_WORKSPACE/log/memcached" "/var/log/memcached" "root" "syslog" "666"
-          vbox_mount "$GITHUB_WORKSPACE/log/nginx" "/var/log/nginx" "root" "syslog" "666"
-          vbox_mount "$GITHUB_WORKSPACE/log/php" "/var/log/php" "root" "syslog" "666"
-          vbox_mount "$GITHUB_WORKSPACE/log/provisioners" "/var/log/provisioners" "root" "syslog" "666"
+          # make folders available
+          vvv_symlink "$GITHUB_WORKSPACE/database/sql" "/srv/database"
+          vvv_symlink "$GITHUB_WORKSPACE/config" "/srv/config"
+          vvv_symlink "$GITHUB_WORKSPACE/provision" "/srv/provision"
+          vvv_symlink "$GITHUB_WORKSPACE/certificates" "/srv/certificates"
+          vvv_symlink "$GITHUB_WORKSPACE/www" "/srv/www"
+          vvv_symlink "$GITHUB_WORKSPACE/log/memcached" "/var/log/memcached"
+          vvv_symlink "$GITHUB_WORKSPACE/log/nginx" "/var/log/nginx"
+          vvv_symlink "$GITHUB_WORKSPACE/log/php" "/var/log/php"
+          vvv_symlink "$GITHUB_WORKSPACE/log/provisioners" "/var/log/provisioners"
 
       # Runs the provisioners in the expected order
       - name: Run provison-pre.sh

--- a/.github/workflows/vvv-provisioning.yml
+++ b/.github/workflows/vvv-provisioning.yml
@@ -39,6 +39,7 @@ jobs:
             if [ ! -d "${1}" ]; then 
               sudo mkdir -p "${1}"
             fi
+            sudo chown -R vagrant:vagrant "${1}"
             sudo ln -sf "${1}" "${2}"
           }
 

--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -135,16 +135,16 @@ function vvv_provision_site_repo() {
       if [[ -d "${VM_DIR}/.git" ]]; then
         echo " * Updating ${SITE} in ${VM_DIR}..."
         cd "${VM_DIR}"
-        git reset "origin/${BRANCH}" --hard -q
-        git pull origin "${BRANCH}" -q
-        git checkout "${BRANCH}" -q
+        noroot git reset "origin/${BRANCH}" --hard -q
+        noroot git pull origin "${BRANCH}" -q
+        noroot git checkout "${BRANCH}" -q
       else
         echo "${RED}Problem! A site folder for ${SITE} was found at ${VM_DIR} that doesn't use a site template, but a site template is defined in the config file. Either the config file is mistaken, or a previous attempt to provision has failed, VVV will not try to git clone the site template to avoid data destruction, either remove the folder, or fix the config/config.yml entry${CRESET}"
       fi
     else
       # Clone or pull the site repository
       echo -e " * Downloading ${SITE}, git cloning from ${REPO} into ${VM_DIR}"
-      git clone --recursive --branch "${BRANCH}" "${REPO}" "${VM_DIR}" -q
+      noroot git clone --recursive --branch "${BRANCH}" "${REPO}" "${VM_DIR}" -q
       if [ $? -eq 0 ]; then
         echo " * ${SITE} Site Template clone successful"
       else

--- a/provision/tests/provisioners.sh
+++ b/provision/tests/provisioners.sh
@@ -114,7 +114,7 @@ function provision_site() {
   local site=$1
   local skip_provisioning=$(get_config_value "sites.${site}.skip_provisioning" "False")
   if [[ $skip_provisioning == "True" ]]; then
-    continue
+    return
   fi
   local repo=$(get_config_type "sites.${site}")
   if [[ "${repo}" == "str" ]]; then

--- a/provision/tests/provisioners.sh
+++ b/provision/tests/provisioners.sh
@@ -144,4 +144,11 @@ function provision_main() {
     VVV_LOG="main"
     bash /srv/provision/provision.sh
   fi
+
+  # refresh VVV_CONFIG, as the main provisioner actually creates the /vagrant/config.yml
+  VVV_CONFIG=/vagrant/vvv-custom.yml
+  if [[ -f /vagrant/config.yml ]]; then
+    VVV_CONFIG=/vagrant/config.yml
+  fi
+  export VVV_CONFIG
 }

--- a/provision/tests/provisioners.sh
+++ b/provision/tests/provisioners.sh
@@ -7,7 +7,7 @@ function vvv_run_provisioner() {
   local STATUS
   bash $@
   STATUS=$?
-  if [ -z $STATUS ]; then
+  if [ "${STATUS}" -eq 0 ]; then
     return $STATUS
   fi
   exit $STATUS


### PR DESCRIPTION
This is something i've been working over the weekend.

It will attempt to simulate the same environment the provisioners get inside the VM, so that it runs all the provisioners.

So far, this only runs the provisioners (using part of the refactor we've made a couple months ago) and make the full logs available for download as artifacts.

Ideally, we could add extra steps here with some sort of test suite as a separate PR.

------

Couple of things I tried and didn't work:

- Running this on an official ubuntu:18.04 docker image fails due to several reasons, the main ones being: no systemd available, and no access to /etc/hosts (as that's managed by docker)
- Running the provisioner from vagrant (full test), doesn't work because GH Actions doesn't allow a VM to run in a VM (due to lack of VT-x support).
- Running on CircleCI get similar results as above, same limitations.
- Using symlinks to "simulate" mounts has a bunch of permission issues. bindfs basically forces user and group on the mounted location, therefore there's no ownership/permission issues (similar to how synced folders work in VBox). 