### PR TITLE
Site git folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ permalink: /docs/en-US/changelog/
 * Added `box-cleanup.sh` and `box-minimize.sh` scripts. Run these before creating a vagrant box to reduce disk size. These are only intended for box file creation.
 * Prevent use of sudo vagrant up ( #2215 )
 * Major refactor of the main provisioner, and introduction of a hook system to be used while provisioning ( #2230, #2238 )
+* Support for cloning git repositories into sites via `config.yml`
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ permalink: /docs/en-US/changelog/
 * Added `box-cleanup.sh` and `box-minimize.sh` scripts. Run these before creating a vagrant box to reduce disk size. These are only intended for box file creation.
 * Prevent use of sudo vagrant up ( #2215 )
 * Major refactor of the main provisioner, and introduction of a hook system to be used while provisioning ( #2230, #2238 )
-* Support for cloning git repositories into sites via `config.yml`
+* Support for cloning git repositories into sites via `config.yml` ( #2247 )
 
 ### Deprecations
 

--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -218,13 +218,6 @@ function vvv_provision_site_nginx() {
   fi
 }
 
-
-
-#function vvv_get_site_config_keys {
-#  local value=$(shyaml keys "sites.${SITE_ESCAPED}.${1}" 2> /dev/null < ${VVV_CONFIG})
-#  echo "${value:-$@}"
-#}
-
 function vvv_get_site_config_value() {
   local value=$(shyaml get-value "sites.${SITE_ESCAPED}.${1}" "${2}" 2> /dev/null < ${VVV_CONFIG})
   echo "${value}"

--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -234,16 +234,17 @@ function vvv_clone_site_git_folder() {
 function vvv_custom_folder_git() {
   local folder="${1}"
   local repo=$(vvv_get_site_config_value "folders.${folder}.git.repo" "?")
-  local overwrite=$(vvv_get_site_config_value "folders.${folder}.git.overwrite" "False")
-  local forcepull=$(vvv_get_site_config_value "folders.${folder}.git.forcepull" "False")
+  local overwrite_on_clone=$(vvv_get_site_config_value "folders.${folder}.git.overwrite_on_clone" "False")
+  local hard_reset=$(vvv_get_site_config_value "folders.${folder}.git.hard_reset" "False")
+  local pull=$(vvv_get_site_config_value "folders.${folder}.git.pull" "False")
 
   if [ ! -d "${VVV_PATH_TO_SITE}/${folder}" ]; then
     vvv_clone_site_git_folder "${repo}" "${folder}"
   else
-    if [[ $overwrite = "True" ]]; then
+    if [[ $overwrite_on_clone = "True" ]]; then
       if [ ! -d "${VVV_PATH_TO_SITE}/${folder}/.git" ]; then
         vvv_info " - VVV was asked to clone into a folder that already exists (${folder}), but does not contain a git repo"
-        vvv_info " - Overwrite is turned on so VVV will purge with extreme predjudice and clone over the folders grave"
+        vvv_info " - overwrite_on_clone is turned on so VVV will purge with extreme predjudice and clone over the folders grave"
         rm -rf "${VVV_PATH_TO_SITE}/${folder}"
         vvv_clone_site_git_folder "${repo}" "${folder}"
       fi
@@ -252,12 +253,17 @@ function vvv_custom_folder_git() {
     fi
   fi
 
-  if [[ $forcepull = "True" ]]; then
-    vvv_info " - resetting git checkout and pulling down latest for ${folder}"
+  if [[ $hard_reset = "True" ]]; then
+    vvv_info " - resetting git checkout and discarding changes in ${folder}"
     cd "${VVV_PATH_TO_SITE}/${folder}"
     noroot git reset --hard -q
-    noroot git pull -q
     noroot git checkout -q
+    cd -
+  fi
+  if [[ $pull = "True" ]]; then
+    vvv_info " - runnning git pull for ${folder}"
+    cd "${VVV_PATH_TO_SITE}/${folder}"
+    noroot git pull -q
     cd -
   fi
 }

--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -234,21 +234,21 @@ function vvv_clone_site_git_folder() {
 function vvv_custom_folder_git() {
   local folder="${1}"
   local repo=$(vvv_get_site_config_value "folders.${folder}.git.repo" "?")
-  local overwrite=$(vvv_get_site_config_value "git.${folder}.git.overwrite" "False")
-  local forcepull=$(vvv_get_site_config_value "git.${folder}.git.forcepull" "False")
+  local overwrite=$(vvv_get_site_config_value "folders.${folder}.git.overwrite" "False")
+  local forcepull=$(vvv_get_site_config_value "folders.${folder}.git.forcepull" "False")
 
   if [ ! -d "${VVV_PATH_TO_SITE}/${folder}" ]; then
     vvv_clone_site_git_folder "${repo}" "${folder}"
   else
     if [[ $overwrite = "True" ]]; then
       if [ ! -d "${VVV_PATH_TO_SITE}/${folder}/.git" ]; then
-        vvv_info " - VVV was asked to clone into a folder that already exists, but does not contain a git repo"
+        vvv_info " - VVV was asked to clone into a folder that already exists (${folder}), but does not contain a git repo"
         vvv_info " - Overwrite is turned on so VVV will purge with extreme predjudice and clone over the folders grave"
         rm -rf "${VVV_PATH_TO_SITE}/${folder}"
         vvv_clone_site_git_folder "${repo}" "${folder}"
       fi
     else
-      echo " - Cannot clone, a folder that is not a git repo already exists. Set overwrite: true to force the folders deletion and a clone will take place"
+      echo " - Cannot clone into '${folder}', a folder that is not a git repo already exists. Set overwrite: true to force the folders deletion and a clone will take place"
     fi
   fi
 

--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -268,7 +268,7 @@ function vvv_custom_folders() {
     do
       if [[ $folder != '...' ]]; then
         local gitvcs=$(vvv_get_site_config_value "folders.${folder}.git" "False")
-        if [ $gitvcs != "False"]; then
+        if [[ $gitvcs != "False" ]]; then
           vvv_custom_folder_git "${folder}"
         fi
       fi

--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -244,12 +244,13 @@ function vvv_clone_custom_git_repos() {
     do
       if [[ $folder != '...' ]]; then
         local repo=$(vvv_get_site_config_value "git.${folder}.repo" "?")
-        local overwrite=$(vvv_get_site_config_value "git.${folder}.overwrite" "false")
-        local forcepull=$(vvv_get_site_config_value "git.${folder}.forcepull" "false")
+        local overwrite=$(vvv_get_site_config_value "git.${folder}.overwrite" "False")
+        local forcepull=$(vvv_get_site_config_value "git.${folder}.forcepull" "False")
+
         if [ ! -d "${VVV_PATH_TO_SITE}/${folder}" ]; then
           vvv_clone_site_git_folder "${repo}" "${folder}"
         else
-          if [ $overwrite = "True" ]; then
+          if [[ $overwrite = "True" ]]; then
             if [ ! -d "${VVV_PATH_TO_SITE}/${folder}/.git" ]; then
               vvv_info " - VVV was asked to clone into a folder that already exists, but does not contain a git repo"
               vvv_info " - Overwrite is turned on so VVV will purge with extreme predjudice and clone over the folders grave"
@@ -258,14 +259,17 @@ function vvv_clone_custom_git_repos() {
             fi
           else
             echo " - Cannot clone, a folder that is not a git repo already exists. Set overwrite: true to force the folders deletion and a clone will take place"
+          fi
         fi
-        if [ $forcepull = "True" ]; then
+
+        if [[ $forcepull = "True" ]]; then
           vvv_info " - resetting git checkout and pulling down latest for ${folder}"
           cd "${VVV_PATH_TO_SITE}/${folder}"
           noroot git reset --hard -q
           noroot git pull -q
           noroot git checkout -q
           cd -
+        fi
       fi
     done
   else


### PR DESCRIPTION
This PR lets sites specify git repos and folders to clone them to.

For example, in theory this creates a VIP Go site with the VIP Go skeleton:

```yaml
  vipone:
    repo: https://github.com/Varying-Vagrant-Vagrants/custom-site-template.git
    hosts:
      - vipone.test
    git:
      public_html/wp-content/:
        repo: https://github.com/Automattic/vip-go-skeleton.git
        overwrite: true # delete wp-content if it is not a git repo
      public_html/wp-content/mu-plugins:
        repo: https://github.com/Automattic/vip-go-mu-plugins.git
        overwrite: true # delete wp-content/mu-plugins if it is not a git repo
        forcepull: true # on provision hard reset, discard local changes, and pull down the latest version
```

## Checks

<!--  Have you: -->
* [x] I've updated the changelog.
* [x] I've tested this PR
* [x] This PR is for the `develop` branch not the `stable` branch.
* [x] This PR is complete and ready for review.
