### PR TITLE
WP alias with `--no-ssh`

### DIFF
--- a/config/bash_aliases
+++ b/config/bash_aliases
@@ -51,3 +51,5 @@ if [ -n "$BASH" ]; then
 	# add autocomplete for wp-cli
 	[ -s "/srv/config/wp-cli/wp-completion.bash" ] && . /srv/config/wp-cli/wp-completion.bash
 fi
+
+alias wp='wp --no-ssh'


### PR DESCRIPTION
In this way we can use wp-cli inside the VM without any issue.
