### PR TITLE
Allow hosts yml property to default to the site name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ permalink: /docs/en-US/changelog/
 * Support for cloning git repositories into sites via `config.yml` ( #2247 )
 * Install WP-CLI doctor package ( #2051 )
 * Enhanced database backup terminal output ( #2256 ) 
-* Allow to skip `hosts` in site configuration, and default to `sitename.test` ( #2267 ) 
+* Sites with no `hosts` defined will now default to `{sitename}.test` ( #2267 ) 
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ permalink: /docs/en-US/changelog/
 * Support for cloning git repositories into sites via `config.yml` ( #2247 )
 * Install WP-CLI doctor package ( #2051 )
 * Enhanced database backup terminal output ( #2256 ) 
+* Allow to skip `hosts` in site configuration, and default to `sitename.test` ( #2267 ) 
 
 ### Deprecations
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -206,8 +206,11 @@ vvv_config['sites'].each do |site, args|
       lines = File.readlines(path).map(&:chomp)
       lines.grep(/\A[^#]/)
     end.flatten
-
-    vvv_config['hosts'] += vvv_config['sites'][site]['hosts']
+    if vvv_config['sites'][site]['hosts'].is_a? Hash
+      vvv_config['hosts'] += vvv_config['sites'][site]['hosts']
+    else
+      vvv_config['hosts'] += ["#{site}.test"]
+    end
   end
   vvv_config['sites'][site].delete('hosts')
 end

--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -124,7 +124,7 @@ function vvv_process_site_hosts() {
     fi
   else
     echo " * Adding hosts from the VVV config entry"
-    for line in $(get_hosts_list); do
+    for line in $hosts; do
       if [[ -z "$(grep -q "^127.0.0.1 $line$" /etc/hosts)" ]]; then
         echo "127.0.0.1 ${line} # vvv-auto" >> "/etc/hosts"
         echo "   - Added ${line} from ${VVV_CONFIG}"

--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -24,8 +24,7 @@ VVV_CONFIG=/vagrant/config.yml
 # Takes 2 values, a key to fetch a value for, and an optional default value
 # e.g. echo $(get_config_value 'key' 'defaultvalue')
 function get_config_value() {
-  local value=$(shyaml -q get-value "sites.${SITE_ESCAPED}.custom.${1}" "${2}" < ${VVV_CONFIG})
-  echo "${value}"
+  vvv_get_site_config_value "custom.${1}" "${2}"
 }
 
 function get_hosts() {

--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -24,22 +24,22 @@ VVV_CONFIG=/vagrant/config.yml
 # Takes 2 values, a key to fetch a value for, and an optional default value
 # e.g. echo $(get_config_value 'key' 'defaultvalue')
 function get_config_value() {
-  local value=$(shyaml get-value "sites.${SITE_ESCAPED}.custom.${1}" "${2}" 2> /dev/null < ${VVV_CONFIG})
+  local value=$(shyaml -q get-value "sites.${SITE_ESCAPED}.custom.${1}" "${2}" < ${VVV_CONFIG})
   echo "${value}"
 }
 
 function get_hosts() {
-  local value=$(shyaml get-values-0 "sites.${SITE_ESCAPED}.hosts" 2> /dev/null < ${VVV_CONFIG} | tr '\0' ' ' | sed 's/ *$//')
+  local value=$(shyaml -q get-values-0 "sites.${SITE_ESCAPED}.hosts" < ${VVV_CONFIG} | tr '\0' ' ' | sed 's/ *$//')
   echo "${value:-"${VVV_SITE_NAME}.test"}"
 }
 
 function get_hosts_list() {
-  local value=$(shyaml get-values "sites.${SITE_ESCAPED}.hosts" 2> /dev/null < ${VVV_CONFIG})
+  local value=$(shyaml -q get-values "sites.${SITE_ESCAPED}.hosts" < ${VVV_CONFIG})
   echo "${value:-"${VVV_SITE_NAME}.test"}"
 }
 
 function get_primary_host() {
-  local value=$(shyaml get-value "sites.${SITE_ESCAPED}.hosts.0" "${1}" 2> /dev/null < ${VVV_CONFIG})
+  local value=$(shyaml -q get-value "sites.${SITE_ESCAPED}.hosts.0" "${1}" < ${VVV_CONFIG})
   echo "${value:-"${VVV_SITE_NAME}.test"}"
 }
 
@@ -224,7 +224,7 @@ function vvv_provision_site_nginx() {
 }
 
 function vvv_get_site_config_value() {
-  local value=$(shyaml get-value "sites.${SITE_ESCAPED}.${1}" "${2}" 2> /dev/null < ${VVV_CONFIG})
+  local value=$(shyaml -q get-value "sites.${SITE_ESCAPED}.${1}" "${2}" < ${VVV_CONFIG})
   echo "${value}"
 }
 


### PR DESCRIPTION
Allow hosts to default to the sitename, reducing the require config

This would basically allow something like this

```yml
sites:
  wordpress-one:
    repo: https://github.com/Varying-Vagrant-Vagrants/custom-site-template.git
```

And this site will provision as `wordpress-one.test`