### PR TITLE
switch back to composer v1

### DIFF
--- a/provision/core/composer/provision.sh
+++ b/provision/core/composer/provision.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 function composer_setup() {
   # Disable xdebug before any composer provisioning.
+  echo " * Turning off XDebug to avoid Composer performance issues"
   sh /srv/config/homebin/xdebug_off
 
   echo " * Making sure the composer cache is not owned by root"
@@ -14,13 +15,16 @@ function composer_setup() {
   export COMPOSER_ALLOW_SUPERUSER=1
   export COMPOSER_NO_INTERACTION=1
 
-  echo " * Checking for Composer"
+  echo " * Checking Composer is installed"
   exists_composer="$(which composer)"
   if [[ "/usr/local/bin/composer" != "${exists_composer}" ]]; then
     echo " * Installing Composer..."
     curl -sS "https://getcomposer.org/installer" | php
     chmod +x "composer.phar"
     mv "composer.phar" "/usr/local/bin/composer"
+    echo " * Forcing composer to v1.x"
+    composer selfupdate --1
+    echo " * Composer installer steps completed"
   fi
 
   github_token=$(shyaml get-value general.github_token 2> /dev/null < "${VVV_CONFIG}")
@@ -38,9 +42,12 @@ function composer_setup() {
   if [[ -n "$(noroot composer --version --no-ansi | grep 'Composer version')" ]]; then
     echo " * Updating Composer..."
     COMPOSER_HOME=/usr/local/src/composer noroot composer --no-ansi global config bin-dir /usr/local/bin
-    COMPOSER_HOME=/usr/local/src/composer noroot composer --no-ansi self-update --stable --no-progress --no-interaction
+    COMPOSER_HOME=/usr/local/src/composer noroot composer --no-ansi self-update --1 --stable --no-progress --no-interaction
+    echo " * Making sure the PHPUnit 7.5 package is available..."
     COMPOSER_HOME=/usr/local/src/composer noroot composer --no-ansi global require --prefer-dist --no-update --no-progress --no-interaction phpunit/phpunit:^7.5
+    echo " * Updating global composer packages..."
     COMPOSER_HOME=/usr/local/src/composer noroot composer --no-ansi global update --no-progress --no-interaction
+    echo " * Global composer package update completed"
   fi
 
   vvv_hook after_composer


### PR DESCRIPTION
<!-- what does it add/fix/change/remove? Bonus points for screenshots if it's pretty! -->

Related to #2291, though we should switch to v2 once PHPCodesniffer and core work fine with it

## Checks

<!--  Have you: -->
* [ ] I've updated the changelog.
* [ ] I've tested this PR
* [x] This PR is for the `develop` branch not the `stable` branch.
* [ ] This PR is complete and ready for review.
