### PR TITLE
Use PHP 7.3 by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,11 @@ permalink: /docs/en-US/changelog/
 * Added `box-cleanup.sh` and `box-minimize.sh` scripts. Run these before creating a vagrant box to reduce disk size. These are only intended for box file creation.
 * Prevent use of sudo vagrant up ( #2215 )
 * Major refactor of the main provisioner, and introduction of a hook system to be used while provisioning ( #2230, #2238 )
-* Support for cloning git repositories into sites via `config.yml` ( #2247 )
+* Support for cloning git repositories into site folders via `config/config.yml` ( #2247 )
 * Install WP-CLI doctor package ( #2051 )
-* Enhanced database backup terminal output ( #2256 ) 
-* Sites with no `hosts` defined will now default to `{sitename}.test` ( #2267 ) 
+* Enhanced database backup terminal output ( #2256 )
+* Sites with no `hosts` defined will now default to `{sitename}.test` ( #2267 )
+* The default version of PHP was upgraded to v7.3
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ permalink: /docs/en-US/changelog/
 * Install WP-CLI doctor package ( #2051 )
 * Enhanced database backup terminal output ( #2256 )
 * Sites with no `hosts` defined will now default to `{sitename}.test` ( #2267 )
-* The default version of PHP was upgraded to v7.3
+* The default version of PHP was upgraded to v7.3 ( #2307 )
 
 ### Deprecations
 

--- a/provision/core/php/provision.sh
+++ b/provision/core/php/provision.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VVV_BASE_PHPVERSION=${VVV_BASE_PHPVERSION:-"7.2"}
+VVV_BASE_PHPVERSION=${VVV_BASE_PHPVERSION:-"7.3"}
 function php_register_packages() {
   if ! vvv_src_list_has "ondrej/php"; then
     cp -f "/srv/provision/core/php/sources.list" "/etc/apt/sources.list.d/vvv-php-sources.list"


### PR DESCRIPTION
This changes the default PHP version to 7.3

## Checks

<!--  Have you: -->
* [x] I've updated the changelog.
* [ ] I've tested this PR
* [x] This PR is for the `develop` branch not the `stable` branch.
* [ ] This PR is complete and ready for review.
