### PR TITLE
Only install the PCov version we need, and other PHP install tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ permalink: /docs/en-US/changelog/
 * Enhanced database backup terminal output ( #2256 )
 * Sites with no `hosts` defined will now default to `{sitename}.test` ( #2267 )
 * The default version of PHP was upgraded to v7.3 ( #2307 )
+* Only install the specific version of PHP Pcov we need, rather than all versions ( #2310 )
 
 ### Deprecations
 

--- a/provision/core/php/provision.sh
+++ b/provision/core/php/provision.sh
@@ -27,7 +27,7 @@ function php_register_packages() {
 
     # Extra PHP modules that we find useful
     php-pear
-    php-pcov
+    "php${VVV_BASE_PHPVERSION}-pcov"
     "php${VVV_BASE_PHPVERSION}-ssh2"
     "php${VVV_BASE_PHPVERSION}-yaml"
     "php${VVV_BASE_PHPVERSION}-bcmath"
@@ -57,14 +57,16 @@ function php_register_packages() {
 vvv_add_hook before_packages php_register_packages
 
 function phpfpm_setup() {
-  # Copy php-fpm configuration from local
-  echo " * Copying PHP configs"
-  cp -f "/srv/config/php-config/php-fpm.conf" "/etc/php/${VVV_BASE_PHPVERSION}/fpm/php-fpm.conf"
-  cp -f "/srv/config/php-config/php-www.conf" "/etc/php/${VVV_BASE_PHPVERSION}/fpm/pool.d/www.conf"
-  cp -f "/srv/config/php-config/php-custom.ini" "/etc/php/${VVV_BASE_PHPVERSION}/fpm/conf.d/php-custom.ini"
-  cp -f "/srv/config/php-config/opcache.ini" "/etc/php/${VVV_BASE_PHPVERSION}/fpm/conf.d/opcache.ini"
-  cp -f "/srv/config/php-config/xdebug.ini" "/etc/php/${VVV_BASE_PHPVERSION}/mods-available/xdebug.ini"
-  cp -f "/srv/config/php-config/mailhog.ini" "/etc/php/${VVV_BASE_PHPVERSION}/mods-available/mailhog.ini"
+  # Copy php-fpm configs from local
+  if [ -d "/etc/php/${VVV_BASE_PHPVERSION}/" ]; then
+    echo " * Copying PHP configs"
+    cp -f "/srv/config/php-config/php-fpm.conf" "/etc/php/${VVV_BASE_PHPVERSION}/fpm/php-fpm.conf"
+    cp -f "/srv/config/php-config/php-www.conf" "/etc/php/${VVV_BASE_PHPVERSION}/fpm/pool.d/www.conf"
+    cp -f "/srv/config/php-config/php-custom.ini" "/etc/php/${VVV_BASE_PHPVERSION}/fpm/conf.d/php-custom.ini"
+    cp -f "/srv/config/php-config/opcache.ini" "/etc/php/${VVV_BASE_PHPVERSION}/fpm/conf.d/opcache.ini"
+    cp -f "/srv/config/php-config/xdebug.ini" "/etc/php/${VVV_BASE_PHPVERSION}/mods-available/xdebug.ini"
+    cp -f "/srv/config/php-config/mailhog.ini" "/etc/php/${VVV_BASE_PHPVERSION}/mods-available/mailhog.ini"
+  fi
 
   if [[ -f "/etc/php/${VVV_BASE_PHPVERSION}/mods-available/mailcatcher.ini" ]]; then
     echo " * Cleaning up mailcatcher.ini from a previous install"


### PR DESCRIPTION
Use the PHP specific version of pcov instead of installing all of them, and only copy configs if the folder exists

This needs testing, once it's confirmed to work for an existing and a new VVV instance, we can port this to the utilities.

## Checks

<!--  Have you: -->
* [ ] I've updated the changelog.
* [ ] I've tested this PR
* [x] This PR is for the `develop` branch not the `stable` branch.
* [ ] This PR is complete and ready for review.
