### PR TITLE
Add/better provisioner messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,19 @@ permalink: /docs/en-US/changelog/
 
 # Changelog
 
-## 3.5.x ( 2020 TBA )
+## 3.6.x ( 2021 )
+
+### Enhancements
+
+* Beautify the PHP debug switcher script
+* Support for basic formatting tags in `vvv_warn` `vvv_error` `vvv_info` and `vvv_success`
+* A new `vvv_output` and `vvv_format_output` bash functions
+
+### Bug Fixes
+
+* Fixed the user of `vvv_warn` `vvv_success` `vvv_error` and `vvv_info` outside of provisioners
+
+## 3.5.1 ( 2020 December 11th )
 
 ### Enhancements
 

--- a/config/homebin/switch_php_debugmod
+++ b/config/homebin/switch_php_debugmod
@@ -1,6 +1,8 @@
 #!/bin/bash
-
 set -eo pipefail
+
+
+source /srv/provision/provision-helpers.sh
 
 # Grab the currently active PHP mods, and lowercase it for comparison
 enabled_mods=$(php -m)
@@ -26,28 +28,28 @@ disable_phpmods() {
 	local mods_joined=$(printf ", %s" "${mods[@]}")
 	mods_joined=${mods_joined:1}
 	mods_joined="${mods_joined#"${mods_joined%%[![:space:]]*}"}"
-	echo " * Disabling if present: '${mods_joined}'"
+	vvv_info " * Disabling if present: <b>'${mods_joined}'</b>"
 
 	for i in "${mods[@]}"
 	do
 		if [[ ${enabled_mods,,} == *"${i}"* ]]; then
-			echo " * Disabling active module: '${i}'"
+			vvv_info " * Disabling active module: <b>'${i}'</b>"
 			sudo phpdismod "${i}"
 		fi
 	done
 }
 
 enable_phpmod() {
-	echo " * Enabling '${1}'"
+	vvv_info " * Enabling <b>'${1}'</b>"
 	sudo phpenmod "${1}"
 }
 
 restart_phpfpm() {
-	echo " * Restarting PHP FPM's so the change takes effect"
+	vvv_info " * Restarting PHP FPM's so the change takes effect"
 	find /etc/init.d/ -name "php*-fpm" -exec bash -c 'sudo service "$(basename "$0")" restart' {} \;
 }
 
-echo " * Disabling active debug PHP mods"
+vvv_info " * Disabling active debug PHP mods"
 disable_phpmods phpmods[@]
 
 if [[ "${mod}" == "none" ]]; then
@@ -62,6 +64,13 @@ if [[ "${mod}" == "tideways" ]]; then
 	enable_phpmod "tideways_xhprof"
 	restart_phpfpm
 	exit 0
+fi
+
+if [[ "${mod}" == "xdebug" ]]; then
+	# Ensure the log file for xdebug is group writeable.
+	vvv_info " * Making sure log/php/xdebug-remote.log is readable and present"
+	sudo touch /var/log/php/xdebug-remote.log
+	sudo chmod 664 /var/log/php/xdebug-remote.log
 fi
 
 enable_phpmod "${mod}"

--- a/config/homebin/xdebug_on
+++ b/config/homebin/xdebug_on
@@ -1,10 +1,3 @@
 #!/bin/bash
 
 switch_php_debugmod xdebug
-
-# Ensure the log file for xdebug is group writeable.
-echo "Making sure log/php/xdebug-remote.log is readable and present"
-sudo touch /var/log/php/xdebug-remote.log
-sudo chmod 664 /var/log/php/xdebug-remote.log
-
-echo "XDebug is enabled! Note that XDebug doesn't always support the newest version of PHP on release, check the XDebug site for more details"

--- a/provision/provision-helpers.sh
+++ b/provision/provision-helpers.sh
@@ -201,17 +201,6 @@ function vvv_format_output() {
 }
 export -f vvv_format_output
 
-function vvv_info() {
-  MSG=$(vvv_format_output "<info>${1}</info>")
-  echo -e "${MSG}"
-  if [[ ! -z "${VVV_LOG}" ]]; then
-    if [ "${VVV_LOG}" != "main" ]; then
-  	  >&6 echo -e "${MSG}"
-    fi
-  fi
-}
-export -f vvv_info
-
 function vvv_output() {
   MSG=$(vvv_format_output "${1}")
 	echo -e "${MSG}"
@@ -222,6 +211,11 @@ function vvv_output() {
   fi
 }
 export -f vvv_output
+
+function vvv_info() {
+  vvv_output "<info>${1}</info>"
+}
+export -f vvv_info
 
 function vvv_error() {
   MSG=$(vvv_format_output "<error>${1}</error>")

--- a/provision/provision-helpers.sh
+++ b/provision/provision-helpers.sh
@@ -6,10 +6,14 @@
 # other provisioners
 
 export YELLOW="\033[38;5;3m"
+export YELLOW_UNDERLINE="\033[4;38;5;3m"
 export GREEN="\033[38;5;2m"
 export RED="\033[38;5;9m"
+export BLUE="\033[38;5;4m" # 33m"
+export PURPLE="\033[38;5;5m" # 129m"
 export CRESET="\033[0m"
 export BOLD="\033[1m"
+
 
 VVV_CONFIG=/vagrant/vvv-custom.yml
 if [[ -f /vagrant/config.yml ]]; then
@@ -171,32 +175,67 @@ function vvv_src_list_has() {
 }
 export -f vvv_src_list_has
 
+
+function vvv_format_output() {
+  declare -A tags=(
+    ["</>"]="${CRESET}"
+    ["<info>"]="${BOLD}"
+    ["</info>"]="${CRESET}"
+    ["<success>"]="${GREEN}"
+    ["</success>"]="${CRESET}"
+    ["<warn>"]="${YELLOW}"
+    ["</warn>"]="${CRESET}"
+    ["<error>"]="${RED}"
+    ["</error>"]="${CRESET}"
+    ["<url>"]="${YELLOW_UNDERLINE}"
+    ["</url>"]="${CRESET}"
+    ["<b>"]="${BOLD}${PURPLE}"
+    ["</b>"]="${CRESET}"
+  )
+
+  MSG="${1}"
+  for tag in "${!tags[@]}"; do
+    MSG=$(echo "${MSG//"${tag}"/"${tags[$tag]}"}" )
+  done
+  echo -e "${MSG}"
+}
+export -f vvv_format_output
+
 function vvv_info() {
-  echo -e "${CRESET}${1}${CRESET}"
-  if [ "${VVV_LOG}" != "main" ]; then
-    >&6 echo -e "${CRESET}${1}${CRESET}"
+  MSG=$(vvv_format_output "<info>${1}</info>")
+  echo -e "${MSG}"
+  if [[ ! -z "${VVV_LOG}" ]]; then
+    if [ "${VVV_LOG}" != "main" ]; then
+  	  >&6 echo -e "${MSG}"
+    fi
   fi
 }
 export -f vvv_info
 
+function vvv_output() {
+  MSG=$(vvv_format_output "${1}")
+	echo -e "${MSG}"
+  if [[ ! -z "${VVV_LOG}" ]]; then
+    if [ "${VVV_LOG}" != "main" ]; then
+  	  >&6 echo -e "${MSG}"
+    fi
+  fi
+}
+export -f vvv_output
+
 function vvv_error() {
-	echo -e "${RED}${1}${CRESET}"
+  MSG=$(vvv_format_output "<error>${1}</error>")
+	echo -e "${MSG}"
 }
 export -f vvv_error
 
 function vvv_warn() {
-	echo -e "${YELLOW}${1}${CRESET}"
-  if [ "${VVV_LOG}" != "main" ]; then
-  	>&6 echo -e "${YELLOW}${1}${CRESET}"
-  fi
+  vvv_output "<warn>${1}</warn>"
 }
 export -f vvv_warn
 
 function vvv_success() {
-	echo -e "${GREEN}${1}${CRESET}"
-  if [ "${VVV_LOG}" != "main" ]; then
-  	>&6 echo -e "${GREEN}${1}${CRESET}"
-  fi
+  vvv_output "<success>${1}</success>"
 }
 export -f vvv_success
 
@@ -274,34 +313,34 @@ vvv_package_install() {
   declare -a packages=($@)
 
   # fix https://github.com/Varying-Vagrant-Vagrants/VVV/issues/2150
-  echo " * Cleaning up dpkg lock file"
+  vvv_info " * Cleaning up dpkg lock file"
   rm /var/lib/dpkg/lock*
 
-  echo " * Updating apt keys"
+  vvv_info " * Updating apt keys"
   apt-key update -y
 
   # Update all of the package references before installing anything
-  echo " * Running apt-get update..."
+  vvv_info " * Running apt-get update..."
   rm -rf /var/lib/apt/lists/*
   apt-get update -y --fix-missing
 
   # Install required packages
-  echo " * Installing apt-get packages..."
+  vvv_info " * Installing apt-get packages..."
 
   # To avoid issues on provisioning and failed apt installation
   dpkg --configure -a
   if ! apt-get -y --allow-downgrades --allow-remove-essential --allow-change-held-packages -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confnew install --fix-missing --no-install-recommends --fix-broken ${packages[@]}; then
-    echo " * Installing apt-get packages returned a failure code, cleaning up apt caches then exiting"
+    vvv_info " * Installing apt-get packages returned a failure code, cleaning up apt caches then exiting"
     apt-get clean -y
     return 1
   fi
 
   # Remove unnecessary packages
-  echo " * Removing unnecessary apt packages..."
+  vvv_info " * Removing unnecessary apt packages..."
   apt-get autoremove -y
 
   # Clean up apt caches
-  echo " * Cleaning apt caches..."
+  vvv_info " * Cleaning apt caches..."
   apt-get clean -y
 
   return 0


### PR DESCRIPTION
This improves the PHP debug mod switcher and provisioner helpers with formatting.

It also:

 - fixes a redirection bug when `vvv_warn` etc are used outside of a provisioner
 - adds primitive formatting Symfony console style
 - moves some xdebug log checking into the switch debug mod script so that `xdebug_on` isn't required

<img width="607" alt="Screenshot 2020-12-15 at 15 27 04" src="https://user-images.githubusercontent.com/58855/102240537-e2510b00-3eef-11eb-941b-b03486686b35.png">


## Checks

<!--  Have you: -->
* [x] I've updated the changelog.
* [x] I've tested this PR
* [x] This PR is for the `develop` branch not the `stable` branch.
* [x] This PR is complete and ready for review.
