### PR TITLE
Add a vagrant command to the guest VM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ permalink: /docs/en-US/changelog/
 * Improved output of backup and import scripts
 * SHDocs added to core provisioners
 * Improved PHP configuration file installation
+* Adds a `vagrant` command inside the virtual machine to tell users they are still inside the VM and need to exit
 
 ### Bug Fixes
 

--- a/config/homebin/vagrant
+++ b/config/homebin/vagrant
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+source /srv/provision/provision-helpers.sh
+
+echo -e "${CRESET}"
+echo -e "${YELLOW}  ? ▄▀▀▀▄▄▄▄▄▄▄▀▀▀▄ ? ${CRESET}"
+echo -e "${YELLOW}   ✧█▒▒░░░░░░░░░▒▒█   ${CRESET}"
+echo -e "${YELLOW} ?   █░░█░░░░░█░░█ ?  ${CRESET}"
+echo -e "${YELLOW}      █▄░▀█▀░░░░█ ?   ${CRESET}"
+echo -e "${YELLOW}     █░░█░░░░░░▄▀     ${CRESET}"
+echo -e "${YELLOW}──────────────────────${CRESET}"
+echo ""
+echo -e "${PURPLE} ! You're still SSH'd into the VVV virtual machine!${CRESET}"
+echo -e "${PURPLE}   Run exit and try again${CRESET}"


### PR DESCRIPTION
If a user runs `vagrant ssh` then forgets and runs a `vagrant` command without exit it will say the command can't be found

Well no longer!

<img width="432" alt="Screenshot 2021-01-20 at 17 15 18" src="https://user-images.githubusercontent.com/58855/105213643-da1b6980-5b46-11eb-8600-dd5c66f2e5bf.png">


## Checks

<!--  Have you: -->
* [x] I've updated the changelog.
* [x] I've tested this PR
* [x] This PR is for the `develop` branch not the `stable` branch.
* [x] This PR is complete and ready for review.
