### PR TITLE
fix(provision-site): fixing copy paste mistake, updating to search fo…

### DIFF
--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -247,8 +247,8 @@ function vvv_provision_site_script() {
     vvv_run_site_template_script "vvv-init.sh" "${VM_DIR}"
     SUCCESS=$?
   else
-    vvv_warn " * Warning: A site provisioner was not found at .vvv/vvv-init.conf provision/vvv-init.conf or vvv-init.conf, searching 3 folders down, please be patient..."
-    local SITE_INIT_SCRIPTS=$(find "${VM_DIR}" -maxdepth 3 -name 'vvv-init.conf');
+    vvv_warn " * Warning: A site provisioner was not found at .vvv/vvv-init.sh provision/vvv-init.sh or vvv-init.sh, searching 3 folders down, please be patient..."
+    local SITE_INIT_SCRIPTS=$(find "${VM_DIR}" -maxdepth 3 -name 'vvv-init.sh');
     if [[ -z $SITE_INIT_SCRIPTS ]] ; then
       vvv_warn " * Warning: No site provisioner was found, VVV could not perform any scripted setup that might install software for this site"
     else


### PR DESCRIPTION
…r vvv-init.sh instead of vvv-init.conf

vvv_proviion_site_script was likely created from duplicating
vvv_provision_site_nginx and vvv-nginx.conf was not fully replaced with
vvv-init.sh some places still referenced vvv-info.conf which is
incorrect.

BREAKING CHANGE: Previously was not searching for the right file, so now
will start provisioning if the consumer has a vvv-init.sh within their
projects that was not in /.vvv/, /provision/, / of their project.

Closes #2368 

* [x] I've tested this PR
* [ ] This PR is for the `develop` branch not the `stable` branch.
* [ ] This PR is complete and ready for review.
