### PR TITLE
Upgrade default PHP to v7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ permalink: /docs/en-US/changelog/
 ### Enhancements
 
 * Improve the way that PHPCS gets provisioned to avoid conflicts with composer v2 (#2357)
+* PHP v7.4 is now the default PHP ( other versions are available on CLI if installed via `php73`, `php72`, etc )
 * Beautify the PHP debug switcher script
 * Support for basic formatting tags in `vvv_warn` `vvv_error` `vvv_info` and `vvv_success`
 * A new `vvv_output` and `vvv_format_output` bash functions

--- a/config/homebin/vvv_restore_php_default
+++ b/config/homebin/vvv_restore_php_default
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+DEFAULTPHP="7.4"
+echo " * Restoring the default PHP CLI version ( ${DEFAULTPHP} )"
+update-alternatives --set php "/usr/bin/php${DEFAULTPHP}"
+update-alternatives --set phar "/usr/bin/phar${DEFAULTPHP}"
+update-alternatives --set phar.phar "/usr/bin/phar.phar${DEFAULTPHP}"
+update-alternatives --set phpize "/usr/bin/phpize${DEFAULTPHP}"
+update-alternatives --set php-config "/usr/bin/php-config${DEFAULTPHP}"
+echo " * Restoration complete"

--- a/config/nginx-config/nginx.conf
+++ b/config/nginx-config/nginx.conf
@@ -88,7 +88,7 @@ http {
 
     # Upstream to abstract backend connection(s) for PHP.
     upstream php {
-        server unix:/var/run/php7.3-fpm.sock;
+        server unix:/var/run/php7.4-fpm.sock;
     }
 
     include /etc/nginx/upstreams/*.conf;

--- a/config/nginx-config/sites/default.conf
+++ b/config/nginx-config/sites/default.conf
@@ -48,7 +48,7 @@ server {
         # be sure that it exists.
         fastcgi_param   SCRIPT_FILENAME         $document_root$fastcgi_script_name;
 
-        # Use the upstream for fastcgi / php5-fpm that we defined in nginx.conf
+        # Use the upstream for fastcgi / php-fpm that we defined in nginx.conf
         fastcgi_pass   php;
 
         # And get to serving the file!

--- a/config/php-config/php-custom.ini
+++ b/config/php-config/php-custom.ini
@@ -38,7 +38,7 @@ track_errors = Off
 html_errors = 1
 
 ; Log errors to specified file.
-error_log = /var/log/php/php7.3_errors.log
+error_log = /var/log/php/php7.4_errors.log
 
 ; Maximum size of POST data that PHP will accept.
 post_max_size = 1024M

--- a/config/php-config/php-fpm.conf
+++ b/config/php-config/php-fpm.conf
@@ -12,7 +12,7 @@
 ; Relative path can also be used. They will be prefixed by:
 ;  - the global prefix if it's been set (-p argument)
 ;  - /usr otherwise
-;include=/etc/php/7.3/fpm/*.conf
+;include=/etc/php/7.4/fpm/*.conf
 
 ;;;;;;;;;;;;;;;;;;
 ; Global Options ;
@@ -22,14 +22,14 @@
 ; Pid file
 ; Note: the default prefix is /var
 ; Default Value: none
-pid = /run/php/php7.3-fpm.pid
+pid = /run/php/php7.4-fpm.pid
 
 ; Error log file
 ; If it's set to "syslog", log is sent to syslogd instead of being written
 ; in a local file.
 ; Note: the default prefix is /var
 ; Default Value: log/php-fpm.log
-error_log = /var/log/php/php7.3-fpm.log
+error_log = /var/log/php/php7.4-fpm.log
 
 ; syslog_facility is used to specify what type of program is logging the
 ; message. This lets syslogd specify that messages from different facilities
@@ -126,4 +126,4 @@ error_log = /var/log/php/php7.3-fpm.log
 
 ; To configure the pools it is recommended to have one .conf file per
 ; pool in the following directory:
-include=/etc/php/7.3/fpm/pool.d/*.conf
+include=/etc/php/7.4/fpm/pool.d/*.conf

--- a/config/php-config/php-www.conf
+++ b/config/php-config/php-www.conf
@@ -30,7 +30,7 @@ group = www-data
 ;                            specific port;
 ;   '/path/to/unix/socket' - to listen on a unix socket.
 ; Note: This value is mandatory.
-listen = /var/run/php7.3-fpm.sock
+listen = /var/run/php7.4-fpm.sock
 
 ; Set listen(2) backlog. A value of '-1' means unlimited.
 ; Default Value: 128 (-1 on FreeBSD and OpenBSD)

--- a/config/php-config/upstream.conf
+++ b/config/php-config/upstream.conf
@@ -1,4 +1,4 @@
 # Upstream to abstract backend connection(s) for PHP.
-upstream php73 {
-	server unix:/var/run/php7.3-fpm.sock;
+upstream php74 {
+	server unix:/var/run/php7.4-fpm.sock;
 }

--- a/provision/core/php/provision.sh
+++ b/provision/core/php/provision.sh
@@ -2,7 +2,7 @@
 # @description Installs the default version of PHP
 set -eo pipefail
 
-VVV_BASE_PHPVERSION=${VVV_BASE_PHPVERSION:-"7.3"}
+VVV_BASE_PHPVERSION=${VVV_BASE_PHPVERSION:-"7.4"}
 function php_register_packages() {
   if ! vvv_src_list_has "ondrej/php"; then
     cp -f "/srv/provision/core/php/sources.list" "/etc/apt/sources.list.d/vvv-php-sources.list"
@@ -71,7 +71,7 @@ function phpfpm_setup() {
       cp -f "/srv/config/php-config/php-custom.ini" "/etc/php/${VVV_BASE_PHPVERSION}/fpm/conf.d/php-custom.ini"
     fi
   fi
-  
+
   vvv_info " * Checking supplementary PHP configs"
 
   for V in /etc/php/*; do


### PR DESCRIPTION
Changes the default PHP from 7.3 to 7.4

## Checks

<!--  Have you: -->
* [x] I've updated the changelog.
* [x] I've tested this PR
* [x] This PR is for the `develop` branch not the `stable` branch.
* [x] This PR is complete and ready for review.
