### PR TITLE
Modify/better php debug switcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ permalink: /docs/en-US/changelog/
 * SHDocs added to core provisioners
 * Improved PHP configuration file installation
 * Adds a `vagrant` command inside the virtual machine to tell users they are still inside the VM and need to exit
+* `switch_php_debugmod` now checks if a module is installed and enabled, with improved output to make it clearer which versions of PHP support the module
 
 ### Bug Fixes
 

--- a/config/homebin/switch_php_debugmod
+++ b/config/homebin/switch_php_debugmod
@@ -24,18 +24,16 @@ disable_phpmods() {
 	# declare that our first param is an array
 	declare -a mods=("${!1}")
 
-	# Take the mods array and turn it into a commar separated list
-	local mods_joined=$(printf ", %s" "${mods[@]}")
-	mods_joined=${mods_joined:1}
-	mods_joined="${mods_joined#"${mods_joined%%[![:space:]]*}"}"
-	#vvv_info " * Disabling if present: <b>'${mods_joined}'</b>"
-
 	for i in "${mods[@]}"
 	do
-		if [[ ${enabled_mods,,} == *"${i}"* ]]; then
-			vvv_info " * Disabling active PHP debug mod: <b>'${i}'</b>"
-			sudo phpdismod "${i}"
-		fi
+		for v in $(sudo update-alternatives --list php)
+		do
+			phpv=${v: -3}
+			if is_module_active_fpm "${phpv}" "${i}"; then
+				vvv_info " * Disabling active PHP <b>v${phpv}</b><info> debug mod: </info><b>'${i}'</b>"
+				sudo phpdismod -v "${phpv}" -m "${i}"
+			fi
+		done
 	done
 }
 
@@ -45,8 +43,9 @@ enable_phpmod() {
 }
 
 is_module_active_fpm() {
-	phpquery -q -v "${1}" -s fpm -m "${2}" || errorcode=$?
-	if [ $errorcode -eq 0 ]; then
+	phpv=${1: -3}
+	phpquery -q -v "${phpv}" -s fpm -m "${2}" || errorcode=$?
+	if [[ "${errorcode}" -eq "0" ]]; then
 		return 0
 	fi
 	return 1

--- a/config/homebin/switch_php_debugmod
+++ b/config/homebin/switch_php_debugmod
@@ -44,6 +44,22 @@ enable_phpmod() {
 	sudo phpenmod "${1}"
 }
 
+is_module_active_fpm() {
+	phpquery -q -v "${1}" -s fpm -m "${2}" || errorcode=$?
+	if [ $errorcode -eq 0 ]; then
+		return 0
+	fi
+	return 1
+}
+
+is_module_installed_fpm() {
+	phpquery -q -v "${1}" -s fpm -m "${2}" || errorcode=$?
+	if [ $errorcode -eq 1 ]; then
+		return 1
+	fi
+	return 0
+}
+
 restart_phpfpm() {
 	vvv_info " * Restarting PHP FPM services so that the change takes effect"
 	find /etc/init.d/ -name "php*-fpm" -exec bash -c 'sudo service "$(basename "$0")" restart' {} \;
@@ -54,7 +70,7 @@ disable_phpmods phpmods[@]
 
 if [[ "${mod}" == "none" ]]; then
 	restart_phpfpm
-  vvv_success " * All PHP Debug mods are now turned off."
+	vvv_success " * All PHP Debug mods are now turned off."
 	exit 0
 fi
 
@@ -64,7 +80,7 @@ if [[ "${mod}" == "tideways" ]]; then
 	enable_phpmod "xhgui"
 	enable_phpmod "tideways_xhprof"
 	restart_phpfpm
-  vvv_success " * PHP Debug mod switch to <b>${mod}</b><success> complete.</success>"
+	vvv_success " * PHP Debug mod switch to <b>${mod}</b><success> complete.</success>"
 	exit 0
 fi
 

--- a/config/homebin/switch_php_debugmod
+++ b/config/homebin/switch_php_debugmod
@@ -26,37 +26,41 @@ disable_phpmods() {
 
 	for i in "${mods[@]}"
 	do
-		for v in $(sudo update-alternatives --list php)
+		for phpv in $(phpquery -V)
 		do
-			phpv=${v: -3}
-			if is_module_active_fpm "${phpv}" "${i}"; then
-				vvv_info " * Disabling active PHP <b>v${phpv}</b><info> debug mod: </info><b>'${i}'</b>"
-				sudo phpdismod -v "${phpv}" -m "${i}"
+			if is_module_enabled_fpm "${phpv}" "${i}"; then
+				vvv_info " ✘ Disabling active PHP <b>v${phpv}</b><info> debug mod: </info><b>'${i}'</b>"
+				sudo phpdismod -v "${phpv}" "${i}"
 			fi
 		done
 	done
 }
 
 enable_phpmod() {
-	vvv_info " * Enabling PHP debug mod: <b>'${1}'</b>"
-	sudo phpenmod "${1}"
+	for phpv in $(phpquery -V)
+	do
+		if is_module_installed_fpm "${phpv}" "${1}"; then
+			vvv_info " * Enabling <b>'${1}'</b><info> for PHP <b>v${phpv}</b>"
+			sudo phpenmod -q -v "${phpv}" -s fpm "${1}"
+			sudo phpenmod -q -v "${phpv}" -s cli "${1}"
+		else
+			vvv_info " * Skipped enabling ${1} in PHP <b>v${phpv}</b><info>, module isn't installed for this version"
+		fi
+	done
 }
 
-is_module_active_fpm() {
-	phpv=${1: -3}
-	phpquery -q -v "${phpv}" -s fpm -m "${2}" || errorcode=$?
-	if [[ "${errorcode}" -eq "0" ]]; then
+is_module_enabled_fpm() {
+	if [ -f "/var/lib/php/modules/${1}/fpm/enabled_by_admin/${2}" ]; then
 		return 0
 	fi
 	return 1
 }
 
 is_module_installed_fpm() {
-	phpquery -q -v "${1}" -s fpm -m "${2}" || errorcode=$?
-	if [ $errorcode -eq 1 ]; then
-		return 1
+	if [ -f "/etc/php/${1}/mods-available/${2}.ini" ]; then
+		return 0
 	fi
-	return 0
+	return 1
 }
 
 restart_phpfpm() {
@@ -64,22 +68,24 @@ restart_phpfpm() {
 	find /etc/init.d/ -name "php*-fpm" -exec bash -c 'sudo service "$(basename "$0")" restart' {} \;
 }
 
-#vvv_info " * Disabling active debug PHP mods"
 disable_phpmods phpmods[@]
 
 if [[ "${mod}" == "none" ]]; then
 	restart_phpfpm
-	vvv_success " * All PHP Debug mods are now turned off."
+	vvv_success " ✔ All PHP Debug mods are now turned off."
 	exit 0
 fi
 
+if [[ "${mod}" == "pcov" ]]; then
+	vvv_info " * pcov supports PHP 7.1 and above, it is not available for 5.6 and 7.0"
+fi
 
 # Tideways needs 2 mods enabling
 if [[ "${mod}" == "tideways" ]]; then
 	enable_phpmod "xhgui"
 	enable_phpmod "tideways_xhprof"
 	restart_phpfpm
-	vvv_success " * PHP Debug mod switch to <b>${mod}</b><success> complete.</success>"
+	vvv_success " ✔ PHP Debug mod switch to <b>${mod}</b><success> complete.</success>"
 	exit 0
 fi
 
@@ -92,4 +98,4 @@ fi
 
 enable_phpmod "${mod}"
 restart_phpfpm
-vvv_success " * PHP Debug mod switch to <b>${mod}</b><success> complete.</success>"
+vvv_success " ✔ PHP Debug mod switch to <b>${mod}</b><success> on all available PHP versions complete.</success>"


### PR DESCRIPTION
This greatly improves the `switch_php_debugmod` script so that:

 - it no longer tries to disable modules that are already disabled
 - it no longer tries to enabel modules that are not installed
 - it enables/disables modules on a per PHP basis to avoid warnings when a module does not support all installed versions ( e.g. pcov did not support 7.0 and below, and would generating warnings if those were installed )
 - improves output so it's clearer to users what's happening and which versions of PHP a debug module is active on

## Checks

<!--  Have you: -->
* [ ] I've updated the changelog.
* [ ] I've tested this PR
* [ ] This PR is for the `develop` branch not the `stable` branch.
* [ ] This PR is complete and ready for review.
