### PR TITLE
Add Xdebug info button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Finally, check that your custom modifications haven't been added in the official
 * Adds a `vagrant` command inside the virtual machine to tell users they are still inside the VM and need to exit
 * `switch_php_debugmod` now checks if a module is installed and enabled, with improved output to make it clearer which versions of PHP support the module
 * Print provision log if there are errors
+* Adds an Xdebug Info button to the dashboard when Xdebug is enabled
 
 ### Bug Fixes
 

--- a/www/default/phpinfo/index.php
+++ b/www/default/phpinfo/index.php
@@ -4,10 +4,10 @@
  */
 ?>
 <nav class="center">
-	<a href="/phpinfo/">PHP Info</a>
+	<a href="//vvv.test/phpinfo/">PHP Info</a>
 	<?php
 	if ( function_exists( 'xdebug_info' ) ) {
-		?>, <a href="/xdebuginfo/">Xdebug Info</a><?php
+		?>, <a href="//vvv.test/xdebuginfo/">Xdebug Info</a><?php
 	}
 	?>
 </nav>

--- a/www/default/phpinfo/index.php
+++ b/www/default/phpinfo/index.php
@@ -7,7 +7,7 @@
 	<a href="//vvv.test/phpinfo/">PHP Info</a>
 	<?php
 	if ( function_exists( 'xdebug_info' ) ) {
-		?>, <a href="//vvv.test/xdebuginfo/">Xdebug Info</a><?php
+		?>&middot; <a href="//vvv.test/xdebuginfo/">Xdebug Info</a><?php
 	}
 	?>
 </nav>

--- a/www/default/xdebuginfo/index.php
+++ b/www/default/xdebuginfo/index.php
@@ -13,6 +13,8 @@
 </nav>
 <hr/>
 <?php
-echo '<div id="phpinfo">';
-phpinfo();
-echo '</div>';
+if ( function_exists( 'xdebug_info' ) ) {
+	echo '<div id="xdebuginfo">';
+	xdebug_info();
+	echo '</div>';
+}

--- a/www/default/xdebuginfo/index.php
+++ b/www/default/xdebuginfo/index.php
@@ -4,10 +4,10 @@
  */
 ?>
 <nav class="center">
-	<a href="/phpinfo/">PHP Info</a>
+	<a href="//vvv.test/phpinfo/">PHP Info</a>
 	<?php
 	if ( function_exists( 'xdebug_info' ) ) {
-		?>, <a href="/xdebuginfo/">Xdebug Info</a><?php
+		?>, <a href="//vvv.test/xdebuginfo/">Xdebug Info</a><?php
 	}
 	?>
 </nav>

--- a/www/default/xdebuginfo/index.php
+++ b/www/default/xdebuginfo/index.php
@@ -3,18 +3,43 @@
  * Output the phpinfo for our setup
  */
 ?>
+<style type="text/css">
+body {
+    color: #222;
+    font-family: sans-serif;
+}
+
+hr {
+    width: 934px;
+    background-color: #ccc;
+    border: 0;
+    height: 1px;
+}
+
+.center {
+	text-align: center;
+}
+
+.warning {
+	text-align: center;
+}
+</style>
 <nav class="center">
 	<a href="//vvv.test/phpinfo/">PHP Info</a>
 	<?php
 	if ( function_exists( 'xdebug_info' ) ) {
-		?>, <a href="//vvv.test/xdebuginfo/">Xdebug Info</a><?php
+		?>&middot; <a href="//vvv.test/xdebuginfo/">Xdebug Info</a><?php
 	}
 	?>
 </nav>
 <hr/>
-<?php
-if ( function_exists( 'xdebug_info' ) ) {
-	echo '<div id="xdebuginfo">';
-	xdebug_info();
-	echo '</div>';
-}
+
+<div id="xdebuginfo">
+	<?php
+	if ( ! function_exists( 'xdebug_info' ) ) {
+		xdebug_info();
+	} else {
+		echo '<div class="warning"><strong>Warning:</strong> Xdebug not enabled.</div>';
+	}
+	?>
+</div>


### PR DESCRIPTION
Moves `xdebug_info()` to its own file, per #2382 

## Checks

<!--  Have you: -->
* [x] I've updated the changelog.
* [x] I've tested this PR
* [x] This PR is for the `develop` branch not the `stable` branch.
* [x] This PR is complete and ready for review.
