### PR TITLE
Fix PHP running under the wrong user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ permalink: /docs/en-US/changelog/
 * 
 ### Bug Fixes
 
-* 
+* Fix PHP running as the wrong user
+
 ## 3.6.2 ( 2021 March 17th )
 ### Bug Fixes
 

--- a/config/php-config/php-www.conf
+++ b/config/php-config/php-www.conf
@@ -19,7 +19,7 @@
 ; Unix user/group of processes
 ; Note: The user is mandatory. If the group is not set, the default user's group
 ;       will be used.
-user = www-data
+user = vagrant
 group = www-data
 
 ; The address on which to accept FastCGI requests.


### PR DESCRIPTION
@tomjn This was the fix for my issue with WordPress requiring SFTP to upload things. I can make this only apply when installing on an M1, but this feels like a core bug.

Fixes #2398 

## Checks

<!--  Have you: -->
* [x] I've updated the changelog.
* [x] I've tested this PR
* [x] This PR is for the `develop` branch not the `stable` branch.
* [x] This PR is complete and ready for review.
