### PR TITLE
Fix host plugin checks on vagrant plugin list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ permalink: /docs/en-US/changelog/
 * Increased the priority of Nodesource and Ondrej packages to avoid issues
 * Fixed Parallels mount permissions
 * Fixes for site names containing spaces causing Nginx and TLS issues
+* Warnings that you're missing vagrant plugins no longer show when running vagrant plugin commands
 
 ## 3.6.2 ( 2021 March 17th )
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -804,8 +804,14 @@ Vagrant.configure('2') do |config|
     config.hostsupdater.aliases = vvv_config['hosts']
     config.hostsupdater.remove_on_suspend = true
   else
-    puts "! Neither the HostManager, GoodHosts or HostsUpdater plugins are installed!!! Domains won't work without one of these plugins!"
-    puts "Run 'vagrant plugin install vagrant-goodhosts' then try again."
+    show_check = true if %w[up halt resume suspend status provision reload].include? ARGV[0]
+    if show_check
+      puts ""
+      puts " X ! There is no hosts file vagrant plugin installed!"
+      puts " X You need the vagrant-goodhosts plugin (or HostManager/ HostsUpdater ) for domains to work in the browser"
+      puts " X Run 'vagrant plugin install --local' to fix this."
+      puts ""
+    end
   end
 
   # Vagrant Triggers


### PR DESCRIPTION
Updates the warning when no hosts plugin is present and make it not sh…ow on the plugin command

<!-- what does it add/fix/change/remove? Bonus points for screenshots if it's pretty! -->

## Checks

<!--  Have you: -->
* [x] I've updated the changelog.
* [x] I've tested this PR
* [x] This PR is for the `develop` branch not the `stable` branch.
* [x] This PR is complete and ready for review.
