### PR TITLE
Emergency fix - broken default config

### DIFF
--- a/config/default-config.yml
+++ b/config/default-config.yml
@@ -136,10 +136,11 @@ general:
   # You can always backup/restore manually using vagrant ssh -c "db_backup" or vagrant ssh -c "db_restore"
 
   # Backup the databases to the database/backups subfolder on halt/suspend/destroy, set to false to disable
-  db_backup: false
-     gzip: true
-     #exclude:
-     #  - wordpress-trunk
+  db_backup:
+      enable: false
+      gzip: true
+      #exclude:
+      #  - wordpress-trunk
 
   # Import the databases if they're missing from backups
   db_restore: false

--- a/config/homebin/vagrant_destroy
+++ b/config/homebin/vagrant_destroy
@@ -18,7 +18,7 @@ else
     fi
 
     # Check if backups are turned on or off
-    run_backups=`cat ${VVV_CONFIG} | shyaml get-value general.db_backup 2> /dev/null`
+    run_backups=`cat ${VVV_CONFIG} | shyaml get-value general.db_backup.enable 2> /dev/null`
 
     if [[ $run_backups != "False" ]]
     then

--- a/config/homebin/vagrant_halt
+++ b/config/homebin/vagrant_halt
@@ -18,7 +18,7 @@ else
     fi
 
     # Check if backups are turned on or off
-    run_backups=`cat ${VVV_CONFIG} | shyaml get-value general.db_backup 2> /dev/null`
+    run_backups=`cat ${VVV_CONFIG} | shyaml get-value general.db_backup.enable 2> /dev/null`
 
     if [[ $run_backups != "False" ]]; then
 	    /srv/config/homebin/db_backup

--- a/config/homebin/vagrant_suspend
+++ b/config/homebin/vagrant_suspend
@@ -18,7 +18,7 @@ else
     fi
 
     # Check if backups are turned on or off
-    run_backups=`cat ${VVV_CONFIG} | shyaml get-value general.db_backup 2> /dev/null`
+    run_backups=`cat ${VVV_CONFIG} | shyaml get-value general.db_backup.enable 2> /dev/null`
 
     if [[ $run_backups != "False" ]]
     then


### PR DESCRIPTION
Somehow, we managed to merge a broken default config and nobody noticed. This is an emergency patch to fix it. A YAML node can't also be a tag.
