### PR TITLE
Fix git warnings when specifying a dashboard branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ permalink: /docs/en-US/changelog/
 * Warnings that you're missing vagrant plugins no longer show when running vagrant plugin commands
 * Force the Virtual Machine to 64bit on VirtualBox to avoid infinite loops on 32bit architectures
 * Force the installation and update of grunt and grunt-cli so that old grunt is always overwritten when updated
+* Fixed cloning the dashboard git repository with unknown remote branches
 
 ## 3.6.2 ( 2021 March 17th )
 

--- a/provision/provision-dashboard.sh
+++ b/provision/provision-dashboard.sh
@@ -10,16 +10,23 @@ if [[ false != "dashboard" && false != "${REPO}" ]]; then
   noroot mkdir -p "${DIR}"
   # Clone or pull the resources repository
   if [[ ! -d "${DIR}/.git" ]]; then
-    vvv_info " *  Cloning dashboard from '${REPO}' into '${DIR}' using the '${BRANCH}' branch."
-    noroot git clone "${REPO}" --branch "${BRANCH}" "${DIR}" -q
-    cd "${DIR}"
-    noroot git checkout "${BRANCH}" -q
+    vvv_info " * Cloning dashboard from '${REPO}' into '${DIR}' using the '${BRANCH}' branch."
+
+    # Clone or pull the site repository
+    if noroot git clone --recursive --branch "${BRANCH}" "${REPO}" "${DIR}"; then
+      vvv_success " ✔ Dashboard cloned successfully"
+    else
+      vvv_error " ! Git failed to clone the dashboard. It tried to clone the ${BRANCH} of ${REPO} into ${DIR}${CRESET}"
+      exit 1
+    fi
   else
     vvv_info " * Updating dashboard on the '${BRANCH}' branch."
-    cd "${DIR}"
-    noroot git reset "origin/${BRANCH}" --hard -q
-    noroot git pull origin "${BRANCH}" -q
-    noroot git checkout "${BRANCH}" -q
+    popd "${DIR}"
+    vvv_info " * Fetching origin ${BRANCH}"
+    noroot git fetch origin "${BRANCH}"
+    vvv_info " * performing a hard reset on origin/${BRANCH}"
+    noroot git reset "origin/${BRANCH}" --hard
+    pushd
   fi
   vvv_warn " * Note that custom dashboards will be going away in a future update, use a site provisioner and a custom host instead such as dashboard.test."
 else


### PR DESCRIPTION
When specifying a custom branch for the dashboard repository, git can sometimes cause warnings because it hasn't fetched the remote data yet

## Checks

<!--  Have you: -->
* [x] I've updated the changelog.
* [x] I've tested this PR
* [x] This PR is for the `develop` branch not the `stable` branch.
* [x] This PR is complete and ready for review.
