### PR TITLE
Remove WP CLI Doctor and force permissions/ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ permalink: /docs/en-US/changelog/
 * Sync clocks before provisioning if ntpdate is available to avoid Apt mirror time issues
 * Fixed cloning the dashboard git repository with unknown remote branches
 * Skip mounting custom folders for skipped sites
+* Improved WP CLI ownership and permission settings
+* Removed WP CLI doctor subcommand package that was causing issues for some users
 
 ## 3.6.2 ( 2021 March 17th )
 

--- a/provision/core/wp-cli/provision.sh
+++ b/provision/core/wp-cli/provision.sh
@@ -16,8 +16,9 @@ function wp_cli_setup() {
   if [[ ! -f "/usr/local/bin/wp" ]]; then
     vvv_info " * Downloading wp-cli nightly, see <url>http://wp-cli.org</url>"
     curl -sO https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar
-    chmod +x wp-cli-nightly.phar
     mv wp-cli-nightly.phar /usr/local/bin/wp
+    chown vagrant /usr/local/bin/wp
+    chmod +x /usr/local/bin/wp
 
     vvv_success " * WP CLI Nightly Installed"
 
@@ -28,17 +29,20 @@ function wp_cli_setup() {
     curl -s https://raw.githubusercontent.com/wp-cli/wp-cli/master/utils/wp-completion.bash -o /srv/config/wp-cli/wp-completion.bash
     chown vagrant /srv/config/wp-cli/wp-completion.bash
   else
+    chown vagrant /usr/local/bin/wp
+    chmod +x /usr/local/bin/wp
     vvv_info " * Updating wp-cli..."
-    wp cli update --nightly --yes
+    noroot wp cli update --nightly --yes
     vvv_success " * WP CLI Nightly updated"
   fi
+
+  # ensure WP CLI is owned by the right user and executable
+  chown vagrant /usr/local/bin/wp
+  chmod +x /usr/local/bin/wp
 
   if [ "${VVV_DOCKER}" != 1 ]; then
     vvv_info " * Disabling debug mods if present before running wp package installs"
     xdebug_off
-    vvv_info " * Installing WP CLI doctor sub-command"
-    noroot wp package install git@github.com:wp-cli/doctor-command.git
-    vvv_info " * Installed WP CLI doctor sub-command"
 
     vvv_info " * Updating WP packages"
     noroot wp package update


### PR DESCRIPTION
change WP CLI provisioning to remove the doctor subcommand and enforce the owner and permissions of the wp command

<!-- what does it add/fix/change/remove? Bonus points for screenshots if it's pretty! -->

## Checks

<!--  Have you: -->
* [x] I've updated the changelog.
* [x] I've tested this PR
* [x] This PR is for the `develop` branch not the `stable` branch.
* [x] This PR is complete and ready for review.
