### PR TITLE
Fix an error in dashboard updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@ permalink: /docs/en-US/changelog/
 
 # Changelog
 
+## 3.7.2 ( 2021 )
+
+
 ## 3.7.1 ( 2021 July 20th )
+
+### Bug Fixes
+
+* Fixed dashboard updating
 
 ### Enhancements
 

--- a/provision/provision-dashboard.sh
+++ b/provision/provision-dashboard.sh
@@ -21,12 +21,12 @@ if [[ false != "dashboard" && false != "${REPO}" ]]; then
     fi
   else
     vvv_info " * Updating dashboard on the '${BRANCH}' branch."
-    popd "${DIR}"
+    pushd "${DIR}"
     vvv_info " * Fetching origin ${BRANCH}"
     noroot git fetch origin "${BRANCH}"
     vvv_info " * performing a hard reset on origin/${BRANCH}"
     noroot git reset "origin/${BRANCH}" --hard
-    pushd
+    popd
   fi
   vvv_warn " * Note that custom dashboards will be going away in a future update, use a site provisioner and a custom host instead such as dashboard.test."
 else


### PR DESCRIPTION
Dashboard provisioning fails to update due to a popd and pushd that are the wrong way around

## Checks

<!--  Have you: -->
* [x] I've updated the changelog.
* [ ] I've tested this PR
* [x] This PR is for the `develop` branch not the `stable` branch.
* [x] This PR is complete and ready for review.
