### PR TITLE
Time to make the long provisioning warning be a bear. (and also provide more accurate information)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ permalink: /docs/en-US/changelog/
 
 ## 3.7.2 ( 2021 )
 
+* Updated message on full provision to be more clear
+* Added mascot to full provision message
 
 ## 3.7.1 ( 2021 July 20th )
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ permalink: /docs/en-US/changelog/
 
 ## 3.7.2 ( 2021 )
 
-* Updated message on full provision to be more clear
-* Added mascot to full provision message
+* Added a new bear to full provision message, and updated message to be more clear
 
 ## 3.7.1 ( 2021 July 20th )
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -694,7 +694,19 @@ Vagrant.configure('2') do |config|
     end
   end
 
-  config.vm.provision "pre-provision-script", type: 'shell', keep_color: true, inline: "echo \"\n༼ つ ◕_◕ ༽つ A full provision can take a little while!\n             Go make a cup of tea and sit back.\n             If you only wanted to turn VVV on, use vagrant up\n\""
+  # \033[38;5;4m
+  # \033[38;5;4m                                      \033[01;32mA full provision will take a bit.
+  # \033[38;5;4m    ▄▀▀▀▄▄▄▄▄▄▄▀▀▀▄          ▄   ▄    \033[01;32mSit back, relax, and have some tea.
+  # \033[38;5;4m    █▒▒░░░░░░░░░▒▒█         █   █
+  # \033[38;5;4m     █░░█░░░░░█░░█         ▀   ▀      \033[01;32mIf you keep seeing this message,
+  # \033[38;5;4m  ▄▄  █░░░▀█▀░░░█  ▄▄  ▄▀▀█▀▀▀▀▀▀█    \033[01;32mmake sure you're running 'vagrant up'
+  # \033[38;5;4m █░░█ ▀▄░░░░░░░▄▀ █░░█ █  █      █
+  # \033[38;5;4m─────────────────────── ▀▀█      █ ───────────────
+  # \033[38;5;4m                           ▀▄▄▄▄▀
+  # \033[0m
+
+  # Changed the message here because it's going to show the first time you do vagrant up, which might be confusing
+  config.vm.provision "pre-provision-script", type: 'shell', keep_color: true, inline: "echo \"\033[38;5;4m\n\033[38;5;4m                                      \033[01;32mA full provision will take a bit.\n\033[38;5;4m    ▄▀▀▀▄▄▄▄▄▄▄▀▀▀▄          ▄   ▄    \033[01;32mSit back, relax, and have some tea.\n\033[38;5;4m    █▒▒░░░░░░░░░▒▒█         █   █\n\033[38;5;4m     █░░█░░░░░█░░█         ▀   ▀      \033[01;32mIf you keep seeing this message,\n\033[38;5;4m  ▄▄  █░░░▀█▀░░░█  ▄▄  ▄▀▀█▀▀▀▀▀▀█    \033[01;32mmake sure you're running \'vagrant up\'\n\033[38;5;4m █░░█ ▀▄░░░░░░░▄▀ █░░█ █  █      █\n\033[38;5;4m─────────────────────── ▀▀█      █ ───────────────\n\033[38;5;4m                           ▀▄▄▄▄▀\n\033[0m\""
 
   # provison-pre.sh acts as a pre-hook to our default provisioning script. Anything that
   # should run before the shell commands laid out in provision.sh (or your provision-custom.sh

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -693,17 +693,19 @@ Vagrant.configure('2') do |config|
       config.vm.provision "flag-root-vagrant-command", type: 'shell', keep_color: true, inline: "mkdir -p /vagrant && touch /vagrant/provisioned_as_root"
     end
   end
-
-# \033[38;5;4m
-# \033[38;5;4m    ▄▀▀▀▄▄▄▄▄▄▄▀▀▀▄     ▄   ▄    \033[0mA full provision will take a bit.
-# \033[38;5;4m    █▒▒░░░░░░░░░▒▒█    █   █     \033[0mSit back, relax, and have some tea.
-# \033[38;5;4m     █░░█░░░░░█░░█    ▀   ▀
-# \033[38;5;4m  ▄▄  █░░░▀█▀░░░█ ▄▀▀█▀▀▀▀▀▀█    \033[0mIf you keep seeing this message,
-# \033[38;5;4m █░░█ ▀▄░░░░░░░▄▀ █  █      █    \033[0mmake sure you're running 'vagrant up'.
-# \033[38;5;4m───────────────────────────────\033[0m
+  
+  long_provision_bear = <<~HTM
+  #{blue}#{creset}
+  #{blue}    ▄▀▀▀▄▄▄▄▄▄▄▀▀▀▄     ▄   ▄    #{green}A full provision will take a bit.#{creset}
+  #{blue}    █▒▒░░░░░░░░░▒▒█    █   █     #{green}Sit back, relax, and have some tea.#{creset}
+  #{blue}     █░░█░░░░░█░░█    ▀   ▀      #{creset}
+  #{blue}  ▄▄  █░░░▀█▀░░░█ ▄▀▀█▀▀▀▀▀▀█    #{green}If you keep seeing this message,#{creset}
+  #{blue} █░░█ ▀▄░░░░░░░▄▀ █  █      █    #{green}make sure you're running 'vagrant up'.#{creset}
+  #{blue}───────────────────────────────────────────────────────────────────────#{creset}
+  HTML
 
   # Changed the message here because it's going to show the first time you do vagrant up, which might be confusing
-  config.vm.provision "pre-provision-script", type: 'shell', keep_color: true, inline: "echo \"\n\033[38;5;4m    ▄▀▀▀▄▄▄▄▄▄▄▀▀▀▄     ▄   ▄    \033[0mA full provision will take a bit.\n\033[38;5;4m    █▒▒░░░░░░░░░▒▒█    █   █     \033[0mSit back, relax, and have some tea.\n\033[38;5;4m     █░░█░░░░░█░░█    ▀   ▀\n\033[38;5;4m  ▄▄  █░░░▀█▀░░░█ ▄▀▀█▀▀▀▀▀▀█    \033[0mIf you keep seeing this message,\n\033[38;5;4m █░░█ ▀▄░░░░░░░▄▀ █  █      █    \033[0mmake sure you're running 'vagrant up'.\n\033[38;5;4m───────────────────────────────\033[0m\n\""
+  config.vm.provision "pre-provision-script", type: 'shell', keep_color: true, inline: "echo \"#{long_provision_bear}\""
 
   # provison-pre.sh acts as a pre-hook to our default provisioning script. Anything that
   # should run before the shell commands laid out in provision.sh (or your provision-custom.sh

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -694,19 +694,16 @@ Vagrant.configure('2') do |config|
     end
   end
 
-  # \033[38;5;4m
-  # \033[38;5;4m                                      \033[01;32mA full provision will take a bit.
-  # \033[38;5;4m    ▄▀▀▀▄▄▄▄▄▄▄▀▀▀▄          ▄   ▄    \033[01;32mSit back, relax, and have some tea.
-  # \033[38;5;4m    █▒▒░░░░░░░░░▒▒█         █   █
-  # \033[38;5;4m     █░░█░░░░░█░░█         ▀   ▀      \033[01;32mIf you keep seeing this message,
-  # \033[38;5;4m  ▄▄  █░░░▀█▀░░░█  ▄▄  ▄▀▀█▀▀▀▀▀▀█    \033[01;32mmake sure you're running 'vagrant up'
-  # \033[38;5;4m █░░█ ▀▄░░░░░░░▄▀ █░░█ █  █      █
-  # \033[38;5;4m─────────────────────── ▀▀█      █ ───────────────
-  # \033[38;5;4m                           ▀▄▄▄▄▀
-  # \033[0m
+# \033[38;5;4m
+# \033[38;5;4m    ▄▀▀▀▄▄▄▄▄▄▄▀▀▀▄     ▄   ▄    \033[0mA full provision will take a bit.
+# \033[38;5;4m    █▒▒░░░░░░░░░▒▒█    █   █     \033[0mSit back, relax, and have some tea.
+# \033[38;5;4m     █░░█░░░░░█░░█    ▀   ▀
+# \033[38;5;4m  ▄▄  █░░░▀█▀░░░█ ▄▀▀█▀▀▀▀▀▀█    \033[0mIf you keep seeing this message,
+# \033[38;5;4m █░░█ ▀▄░░░░░░░▄▀ █  █      █    \033[0mmake sure you're running 'vagrant up'.
+# \033[38;5;4m───────────────────────────────\033[0m
 
   # Changed the message here because it's going to show the first time you do vagrant up, which might be confusing
-  config.vm.provision "pre-provision-script", type: 'shell', keep_color: true, inline: "echo \"\033[38;5;4m\n\033[38;5;4m                                      \033[01;32mA full provision will take a bit.\n\033[38;5;4m    ▄▀▀▀▄▄▄▄▄▄▄▀▀▀▄          ▄   ▄    \033[01;32mSit back, relax, and have some tea.\n\033[38;5;4m    █▒▒░░░░░░░░░▒▒█         █   █\n\033[38;5;4m     █░░█░░░░░█░░█         ▀   ▀      \033[01;32mIf you keep seeing this message,\n\033[38;5;4m  ▄▄  █░░░▀█▀░░░█  ▄▄  ▄▀▀█▀▀▀▀▀▀█    \033[01;32mmake sure you're running \'vagrant up\'\n\033[38;5;4m █░░█ ▀▄░░░░░░░▄▀ █░░█ █  █      █\n\033[38;5;4m─────────────────────── ▀▀█      █ ───────────────\n\033[38;5;4m                           ▀▄▄▄▄▀\n\033[0m\""
+  config.vm.provision "pre-provision-script", type: 'shell', keep_color: true, inline: "echo \"\n\033[38;5;4m    ▄▀▀▀▄▄▄▄▄▄▄▀▀▀▄     ▄   ▄    \033[0mA full provision will take a bit.\n\033[38;5;4m    █▒▒░░░░░░░░░▒▒█    █   █     \033[0mSit back, relax, and have some tea.\n\033[38;5;4m     █░░█░░░░░█░░█    ▀   ▀\n\033[38;5;4m  ▄▄  █░░░▀█▀░░░█ ▄▀▀█▀▀▀▀▀▀█    \033[0mIf you keep seeing this message,\n\033[38;5;4m █░░█ ▀▄░░░░░░░▄▀ █  █      █    \033[0mmake sure you're running 'vagrant up'.\n\033[38;5;4m───────────────────────────────\033[0m\n\""
 
   # provison-pre.sh acts as a pre-hook to our default provisioning script. Anything that
   # should run before the shell commands laid out in provision.sh (or your provision-custom.sh

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -696,11 +696,11 @@ Vagrant.configure('2') do |config|
   
   long_provision_bear = <<~HTM
   #{blue}#{creset}
-  #{blue}    ▄▀▀▀▄▄▄▄▄▄▄▀▀▀▄     ▄   ▄    #{green}A full provision will take a bit.#{creset}
-  #{blue}    █▒▒░░░░░░░░░▒▒█    █   █     #{green}Sit back, relax, and have some tea.#{creset}
-  #{blue}     █░░█░░░░░█░░█    ▀   ▀      #{creset}
-  #{blue}  ▄▄  █░░░▀█▀░░░█ ▄▀▀█▀▀▀▀▀▀█    #{green}If you keep seeing this message,#{creset}
-  #{blue} █░░█ ▀▄░░░░░░░▄▀ █  █      █    #{green}make sure you're running 'vagrant up'.#{creset}
+  #{blue}    ▄▀▀▀▄▄▄▄▄▄▄▀▀▀▄    ▄   ▄    #{green}A full provision will take a bit.#{creset}
+  #{blue}    █▒▒░░░░░░░░░▒▒█   █   █     #{green}Sit back, relax, and have some tea.#{creset}
+  #{blue}     █░░█░░░░░█░░█   ▀   ▀      #{creset}
+  #{blue}  ▄▄  █░░░▀█▀░░░█   █▀▀▀▀▀▀█    #{green}If you keep seeing this message,#{creset}
+  #{blue} █░░█ ▀▄░░░░░░░▄▀▄▀▀█      █    #{green}make sure you're running 'vagrant up'.#{creset}
   #{blue}───────────────────────────────────────────────────────────────────────#{creset}
   HTML
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -699,8 +699,8 @@ Vagrant.configure('2') do |config|
   #{blue}    ▄▀▀▀▄▄▄▄▄▄▄▀▀▀▄    ▄   ▄    #{green}A full provision will take a bit.#{creset}
   #{blue}    █▒▒░░░░░░░░░▒▒█   █   █     #{green}Sit back, relax, and have some tea.#{creset}
   #{blue}     █░░█░░░░░█░░█   ▀   ▀      #{creset}
-  #{blue}  ▄▄  █░░░▀█▀░░░█   █▀▀▀▀▀▀█    #{green}If you keep seeing this message,#{creset}
-  #{blue} █░░█ ▀▄░░░░░░░▄▀▄▀▀█      █    #{green}make sure you're running 'vagrant up'.#{creset}
+  #{blue}  ▄▄  █░░░▀█▀░░░█   █▀▀▀▀▀▀█    #{green}If you didn't want to provision you can#{creset}
+  #{blue} █░░█ ▀▄░░░░░░░▄▀▄▀▀█      █    #{green}turn VVV on with 'vagrant up'.#{creset}
   #{blue}───────────────────────────────────────────────────────────────────────#{creset}
   HTML
 


### PR DESCRIPTION
Updates the character that warns you the first provision is long to be a bear. 

![tea-time](https://user-images.githubusercontent.com/66798/127407114-dd836ae6-7d91-4ebf-a574-a5dfd21eaeff.png) 


Also updated the text, because previously, it suggests running  `vagrant up` if you only wanted to turn on VVV, but the first time you do a `vagrant up`, if you haven't provisioned, you'd see this message. So now it's a bit more clear hopefully.

I kept the output as inline in the Vagrantfile, but happy to split into a separate file if we want.


Also look how cute they are with their lil tea mug, even sitting on a little table


```shell
    default: Running: inline script
    default:     
    default:                                       A full provision will take a bit.
    default:     ▄▀▀▀▄▄▄▄▄▄▄▀▀▀▄          ▄   ▄    Sit back, relax, and have some tea.
    default:     █▒▒░░░░░░░░░▒▒█         █   █
    default:      █░░█░░░░░█░░█         ▀   ▀      If you keep seeing this message,
    default:   ▄▄  █░░░▀█▀░░░█  ▄▄  ▄▀▀█▀▀▀▀▀▀█    make sure you're running 'vagrant up'
    default:  █░░█ ▀▄░░░░░░░▄▀ █░░█ █  █      █
    default: ─────────────────────── ▀▀█      █ ───────────────
    default:                            ▀▄▄▄▄▀
    default:
==> default: Running provisioner: default (shell)...
    default: Running: /var/folders/86/w0vt5r5x4n369p808m9py51c0000gn/T/vagrant-shell20210728-66392-crly12.sh
    default:  - skipping ntpdate clock sync, not installed yet
    default:  ✔  ▷ Running the 'main' provisioner
```

## Checks

<!--  Have you: -->
* [ ] I've updated the changelog.
* [x] I've tested this PR
* [x] This PR is for the `develop` branch not the `stable` branch.
* [x] This PR is complete and ready for review.
