### PR TITLE
Test provisioning on vagrant, instead of a linux VM with docker.

### DIFF
--- a/.github/workflows/vvv-provisioning.yml
+++ b/.github/workflows/vvv-provisioning.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           ref: stable
 
+      - name: install goodhosts
+        run: vagrant plugin install --local
+
       - name: vagrant up (stable)
         run: vagrant up
 
@@ -59,6 +62,9 @@ jobs:
         with:
           ref: develop
 
+      - name: install goodhosts
+        run: vagrant plugin install --local
+
       - name: vagrant up (develop)
         run: vagrant up
 
@@ -90,6 +96,9 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+
+      - name: install goodhosts
+        run: vagrant plugin install --local
 
       - name: vagrant up (current branch)
         run: vagrant up

--- a/.github/workflows/vvv-provisioning.yml
+++ b/.github/workflows/vvv-provisioning.yml
@@ -45,7 +45,7 @@ jobs:
         if: ${{ always() }}
         with:
           name: logs
-          path: "$GITHUB_WORKSPACE/log"
+          path: "${{ github.workspace }}/log"
 
   on-develop:
     name: Develop Reprovision
@@ -79,7 +79,7 @@ jobs:
         if: ${{ always() }}
         with:
           name: logs
-          path: "$GITHUB_WORKSPACE/log"
+          path: "${{ github.workspace }}/log"
 
   on-clean:
     name: Clean Provision
@@ -104,4 +104,4 @@ jobs:
         if: ${{ always() }}
         with:
           name: logs
-          path: "$GITHUB_WORKSPACE/log"
+          path: "${{ github.workspace }}/log"

--- a/.github/workflows/vvv-provisioning.yml
+++ b/.github/workflows/vvv-provisioning.yml
@@ -32,6 +32,8 @@ jobs:
         run: vagrant up
 
       - uses: actions/checkout@v2
+        with:
+          clean: false
 
       - name: vagrant up (current branch)
         run: vagrant up --provision
@@ -69,6 +71,8 @@ jobs:
         run: vagrant up
 
       - uses: actions/checkout@v2
+        with:
+          clean: false
 
       - name: vagrant up (current branch)
         run: vagrant up --provision

--- a/.github/workflows/vvv-provisioning.yml
+++ b/.github/workflows/vvv-provisioning.yml
@@ -38,19 +38,11 @@ jobs:
       - name: vagrant up (current branch)
         run: vagrant up --provision
 
-      - name: Prepare Output
-        if: ${{ always() }}
-        run: |
-          sudo cp -rf "$GITHUB_WORKSPACE/log" "/vvv-logs"
-          MYUID=$(id -u -n)
-          MYGID=$(id -g -n)
-          sudo chown -R $MYUID:$MYGID "/vvv-logs"
-
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:
           name: logs
-          path: "/vvv-logs"
+          path: "$GITHUB_WORKSPACE/log"
 
   on-develop:
     name: Develop Reprovision
@@ -77,19 +69,11 @@ jobs:
       - name: vagrant up (current branch)
         run: vagrant up --provision
 
-      - name: Prepare Output
-        if: ${{ always() }}
-        run: |
-          sudo cp -rf "$GITHUB_WORKSPACE/log" "/vvv-logs"
-          MYUID=$(id -u -n)
-          MYGID=$(id -g -n)
-          sudo chown -R $MYUID:$MYGID "/vvv-logs"
-
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:
           name: logs
-          path: "/vvv-logs"
+          path: "$GITHUB_WORKSPACE/log"
 
   on-clean:
     name: Clean Provision
@@ -107,16 +91,8 @@ jobs:
       - name: vagrant up (current branch)
         run: vagrant up
 
-      - name: Prepare Output
-        if: ${{ always() }}
-        run: |
-          sudo cp -rf "$GITHUB_WORKSPACE/log" "/vvv-logs"
-          MYUID=$(id -u -n)
-          MYGID=$(id -g -n)
-          sudo chown -R $MYUID:$MYGID "/vvv-logs"
-
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:
           name: logs
-          path: "/vvv-logs"
+          path: "$GITHUB_WORKSPACE/log"

--- a/.github/workflows/vvv-provisioning.yml
+++ b/.github/workflows/vvv-provisioning.yml
@@ -96,6 +96,13 @@ jobs:
       # - CURL mailhog API to see if it's working or not
       # - Check VM hostfile
 
+      - name: Prepare Output
+        if: ${{ always() }}
+        run: |
+          MYUID=$(id -u -n)
+          MYGID=$(id -g -n)
+          sudo chown -R $MYUID:$MYGID "$GITHUB_WORKSPACE/log"
+
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:

--- a/.github/workflows/vvv-provisioning.yml
+++ b/.github/workflows/vvv-provisioning.yml
@@ -38,6 +38,9 @@ jobs:
       - name: vagrant up (current branch)
         run: vagrant up --provision
 
+      - name: tests
+        run: provision/tests/macos-tests.sh
+
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:
@@ -69,6 +72,9 @@ jobs:
       - name: vagrant up (current branch)
         run: vagrant up --provision
 
+      - name: tests
+        run: provision/tests/macos-tests.sh
+
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:
@@ -90,6 +96,9 @@ jobs:
 
       - name: vagrant up (current branch)
         run: vagrant up
+
+      - name: tests
+        run: provision/tests/macos-tests.sh
 
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}

--- a/.github/workflows/vvv-provisioning.yml
+++ b/.github/workflows/vvv-provisioning.yml
@@ -106,7 +106,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:
-          name: logs
+          name: logs-on-docker
           path: "${{ github.workspace }}/log"
 
   # This workflow contains a single job called "build"
@@ -141,7 +141,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:
-          name: logs
+          name: logs-on-stable
           path: "${{ github.workspace }}/log"
 
   on-develop:
@@ -175,7 +175,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:
-          name: logs
+          name: logs-on-develop
           path: "${{ github.workspace }}/log"
 
   on-clean:
@@ -200,5 +200,5 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:
-          name: logs
+          name: logs-on-clean
           path: "${{ github.workspace }}/log"

--- a/.github/workflows/vvv-provisioning.yml
+++ b/.github/workflows/vvv-provisioning.yml
@@ -13,89 +13,86 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
-  build:
-    name: Run Provisioner
+  on-stable:
+    name: Stable Reprovision
     # The type of runner that the job will run on
-    runs-on: ubuntu-18.04
+    runs-on: macos-10.15
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+        with:
+          ref: stable
+
+      - name: vagrant up (stable)
+        run: vagrant up
+
+      - uses: actions/checkout@v2
+
+      - name: vagrant up (current branch)
+        run: vagrant up --provision
+
+      - name: Prepare Output
+        if: ${{ always() }}
+        run: |
+          sudo cp -rf "$GITHUB_WORKSPACE/log" "/vvv-logs"
+          MYUID=$(id -u -n)
+          MYGID=$(id -g -n)
+          sudo chown -R $MYUID:$MYGID "/vvv-logs"
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: logs
+          path: "/vvv-logs"
+
+  on-develop:
+    name: Develop Reprovision
+    # The type of runner that the job will run on
+    runs-on: macos-10.15
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+        with:
+          ref: develop
+
+      - name: vagrant up (develop)
+        run: vagrant up
+
+      - uses: actions/checkout@v2
+
+      - name: vagrant up (current branch)
+        run: vagrant up --provision
+
+      - name: Prepare Output
+        if: ${{ always() }}
+        run: |
+          sudo cp -rf "$GITHUB_WORKSPACE/log" "/vvv-logs"
+          MYUID=$(id -u -n)
+          MYGID=$(id -g -n)
+          sudo chown -R $MYUID:$MYGID "/vvv-logs"
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: logs
+          path: "/vvv-logs"
+
+  on-clean:
+    name: Clean Provision
+    # The type of runner that the job will run on
+    runs-on: macos-10.15
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      # Make Symlinks
-      - name: Create Vagrant Like Environment
-        run: |
-          # uninstall pre installed packages (to test if extensions work)
-          sudo apt-get -q --autoremove --purge remove php*
-          sudo apt-get -q autoclean
-
-          # remove pre-installed composer
-          if [ -f /usr/bin/composer ]; then
-            sudo rm -f /usr/bin/composer
-          fi
-
-          # create vagrant user
-          sudo groupadd -g 2000 vagrant
-          sudo useradd -u 2000 -g vagrant -m vagrant
-
-          # vvv_symlink function to sumulate synced folders
-          function vvv_symlink() {
-            if [ ! -d "${1}" ]; then
-              sudo mkdir -p "${1}"
-            fi
-            sudo chown -R vagrant:vagrant "${1}"
-            sudo ln -sf "${1}" "${2}"
-          }
-
-          # create srv folder
-          sudo -u "vagrant" mkdir -p "/srv"
-
-          # copy files provided by vagrant
-          sudo cp -f "$GITHUB_WORKSPACE/config/default-config.yml" "$GITHUB_WORKSPACE/config/config.yml"
-          sudo cp -f "$GITHUB_WORKSPACE/version" "/home/vagrant/version"
-
-          # make folders available
-          vvv_symlink "$GITHUB_WORKSPACE/database/sql" "/srv/database"
-          vvv_symlink "$GITHUB_WORKSPACE/config" "/srv/config"
-          vvv_symlink "$GITHUB_WORKSPACE/provision" "/srv/provision"
-          vvv_symlink "$GITHUB_WORKSPACE/certificates" "/srv/certificates"
-          vvv_symlink "$GITHUB_WORKSPACE/www" "/srv/www"
-          vvv_symlink "$GITHUB_WORKSPACE/log/memcached" "/var/log/memcached"
-          vvv_symlink "$GITHUB_WORKSPACE/log/nginx" "/var/log/nginx"
-          vvv_symlink "$GITHUB_WORKSPACE/log/php" "/var/log/php"
-          vvv_symlink "$GITHUB_WORKSPACE/log/provisioners" "/var/log/provisioners"
-
-      # Runs the provisioners in the expected order
-      - name: Run provison-pre.sh
-        run: sudo bash -c '. "/srv/provision/tests/provisioners.sh" && pre_hook'
-
-      - name: Run provision.sh
-        run: sudo bash -c '. "/srv/provision/tests/provisioners.sh" && provision_main'
-
-      - name: Run provision-tools.sh
-        run: sudo bash -c '. "/srv/provision/tests/provisioners.sh" && provision_tools'
-
-      - name: Run provison-dashboard.sh
-        run: sudo bash -c '. "/srv/provision/tests/provisioners.sh" && provision_dashboard'
-
-      - name: Run provision-extension-source.sh
-        run: sudo bash -c '. "/srv/provision/tests/provisioners.sh" && provision_extension_sources'
-
-      - name: Run provision-extension.sh
-        run: sudo bash -c '. "/srv/provision/tests/provisioners.sh" && provision_extensions'
-
-      - name: Run provision-site.sh
-        run: sudo bash -c '. "/srv/provision/tests/provisioners.sh" && provision_sites'
-
-      - name: Run provision-post.sh
-        run: sudo bash -c '. "/srv/provision/tests/provisioners.sh" && post_hook'
-
-      # At this point, we would run some extra tests
-      # TODO: Ideas
-      # - Add screenshots of provisioned sites
-      # - CURL mailhog API to see if it's working or not
-      # - Check VM hostfile
+      - name: vagrant up (current branch)
+        run: vagrant up
 
       - name: Prepare Output
         if: ${{ always() }}

--- a/.github/workflows/vvv-provisioning.yml
+++ b/.github/workflows/vvv-provisioning.yml
@@ -12,6 +12,96 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
+  on-docker:
+    name: Docker Provisioner
+    # The type of runner that the job will run on
+    runs-on: ubuntu-18.04
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Make Symlinks
+      - name: Create Vagrant Like Environment
+        run: |
+          # uninstall pre installed packages (to test if extensions work)
+          sudo apt-get -q --autoremove --purge remove php*
+          sudo apt-get -q autoclean
+
+          # remove pre-installed composer
+          if [ -f /usr/bin/composer ]; then
+            sudo rm -f /usr/bin/composer
+          fi
+
+          # create vagrant user
+          sudo groupadd -g 2000 vagrant
+          sudo useradd -u 2000 -g vagrant -m vagrant
+
+          # vvv_symlink function to sumulate synced folders
+          function vvv_symlink() {
+            if [ ! -d "${1}" ]; then
+              sudo mkdir -p "${1}"
+            fi
+            sudo chown -R vagrant:vagrant "${1}"
+            sudo ln -sf "${1}" "${2}"
+          }
+
+          # create srv folder
+          sudo -u "vagrant" mkdir -p "/srv"
+
+          # copy files provided by vagrant
+          sudo cp -f "$GITHUB_WORKSPACE/config/default-config.yml" "$GITHUB_WORKSPACE/config/config.yml"
+          sudo cp -f "$GITHUB_WORKSPACE/version" "/home/vagrant/version"
+
+          # make folders available
+          vvv_symlink "$GITHUB_WORKSPACE/database/sql" "/srv/database"
+          vvv_symlink "$GITHUB_WORKSPACE/config" "/srv/config"
+          vvv_symlink "$GITHUB_WORKSPACE/provision" "/srv/provision"
+          vvv_symlink "$GITHUB_WORKSPACE/certificates" "/srv/certificates"
+          vvv_symlink "$GITHUB_WORKSPACE/www" "/srv/www"
+          vvv_symlink "$GITHUB_WORKSPACE/log/memcached" "/var/log/memcached"
+          vvv_symlink "$GITHUB_WORKSPACE/log/nginx" "/var/log/nginx"
+          vvv_symlink "$GITHUB_WORKSPACE/log/php" "/var/log/php"
+          vvv_symlink "$GITHUB_WORKSPACE/log/provisioners" "/var/log/provisioners"
+
+      # Runs the provisioners in the expected order
+      - name: Run provison-pre.sh
+        run: sudo bash -c '. "/srv/provision/tests/provisioners.sh" && pre_hook'
+
+      - name: Run provision.sh
+        run: sudo bash -c '. "/srv/provision/tests/provisioners.sh" && provision_main'
+
+      - name: Run provision-tools.sh
+        run: sudo bash -c '. "/srv/provision/tests/provisioners.sh" && provision_tools'
+
+      - name: Run provison-dashboard.sh
+        run: sudo bash -c '. "/srv/provision/tests/provisioners.sh" && provision_dashboard'
+
+      - name: Run provision-extension-source.sh
+        run: sudo bash -c '. "/srv/provision/tests/provisioners.sh" && provision_extension_sources'
+
+      - name: Run provision-extension.sh
+        run: sudo bash -c '. "/srv/provision/tests/provisioners.sh" && provision_extensions'
+
+      - name: Run provision-site.sh
+        run: sudo bash -c '. "/srv/provision/tests/provisioners.sh" && provision_sites'
+
+      - name: Run provision-post.sh
+        run: sudo bash -c '. "/srv/provision/tests/provisioners.sh" && post_hook'
+
+      # At this point, we would run some extra tests
+      # TODO: Ideas
+      # - Add screenshots of provisioned sites
+      # - CURL mailhog API to see if it's working or not
+      # - Check VM hostfile
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: logs
+          path: "${{ github.workspace }}/log"
+
   # This workflow contains a single job called "build"
   on-stable:
     name: Stable Reprovision

--- a/provision/tests/macos-tests.sh
+++ b/provision/tests/macos-tests.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# TODO: Attempt vvv_info and vvv_error replacements for macOS
+source provision/provision-helpers.sh
+
+function testDomain() {
+	DOMAIN=$1
+	STATUS=$(curl -o /dev/null -s -w "%{http_code}\n" "http://${1}")
+	if [[ "200" != "${STATUS}" ]]; then
+		echo -e "${RED} ! ${DOMAIN} is unavailable${CRESET}"
+		exit 1;
+	else
+		echo -e "${GREEN} ✔ ${DOMAIN} is accessible${CRESET}"
+	fi
+}
+
+testDomain "vvv.test"
+testDomain "one.wordpress.test"
+testDomain "two.wordpress.test"


### PR DESCRIPTION
This tests provisioning in different scenarios with vagrant and virtualbox.

One issue i've noticed:

There seems to be some times where we get failures on the provisioners (likely product of a bad setup of the MacOS VM or something of the sort). Rerunning the actions typically get a valid result.

The error is something like follows:

>   Vagrant can't use the requested machine because it is locked! This
>   means that another Vagrant process is currently reading or modifying
>   the machine. Please wait for that Vagrant process to end and try
>   again. Details about the machine are shown below:
> 
>   Name: default
>   Provider: virtualbox

Again, just re running the action (which will run the 3 jobs again, since they're all part of the same workflow).

Didn't change the changelog, since this doesn't change any features.

## Checks

<!--  Have you: -->
* [ ] I've updated the changelog.
* [x] I've tested this PR
* [x] This PR is for the `develop` branch not the `stable` branch.
* [x] This PR is complete and ready for review.
