### PR TITLE
Remove explicit need for text/html gzip

### DIFF
--- a/provision/core/nginx/config/nginx.conf
+++ b/provision/core/nginx/config/nginx.conf
@@ -80,7 +80,6 @@ http {
         image/x-icon
         text/css
         text/plain
-        text/html
         text/x-component;
 
     # Disable gzip for bad browsers


### PR DESCRIPTION
It seems it's already disabled

Taken from #2537:

```
        # text/html Responses with the “text/html” type are always compressed. https://nginx.org/en/docs/http/ngx_http_gzip_module.html#gzip_types
```

https://nginx.org/en/docs/http/ngx_http_gzip_module.html#gzip_types

<!-- what does it add/fix/change/remove? Bonus points for screenshots if it's pretty! -->

## Checks

<!--  Have you: -->
* [ ] I've updated the changelog.
* [ ] I've tested this PR
* [x] This PR is for the `develop` branch not the `stable` branch.
* [ ] This PR is complete and ready for review.
