### PR TITLE
#2559 use parallels as the default provider if it is an arm machine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ permalink: /docs/en-US/changelog/
 
 # Changelog
 
+## 3.9
+
+### Enhancements
+
+* VVV now switches to Parallels by default on Arm machines ( #2560 )
+
 ## 3.8.1 ( 2021 November 15th )
 
 ### Enhancements

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -211,6 +211,12 @@ defaults = {}
 defaults['memory'] = 2048
 defaults['cores'] = 1
 defaults['provider'] = 'virtualbox'
+
+# if Arm default to parallels
+if Etc.uname[:version].include? 'ARM64'
+  defaults['provider'] = 'parallels'
+end
+
 # This should rarely be overridden, so it's not included in the config/default-config.yml file.
 defaults['private_network_ip'] = '192.168.56.4'
 


### PR DESCRIPTION
Fixes #2559 

If the machine is an Arm machine, use parallels rather than Virtualbox and the provider default in the config

## Checks

<!--  Have you: -->
* [x] I've updated the changelog.
* [ ] I've tested this PR
* [x] This PR is for the `develop` branch not the `stable` branch.
* [x] This PR is complete and ready for review.
