### PR TITLE
Fixed a typo preventing composer create-project working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ permalink: /docs/en-US/changelog/
 * VVV now switches to Parallels by default on Arm machines ( #2560 )
 * Adds default Nginx pages for 40x and 50x errors to help on troubleshooting ( #2345 )
 
+### Bug Fixes
+
+* Fixed an issue with `composer create-project` not running when specified in `config.yml` ( #2565 )
 
 ## 3.8.1 ( 2021 November 15th )
 

--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -361,8 +361,7 @@ function vvv_custom_folder_composer() {
             vvv_info " * Running composer update in ${folder}"
             noroot composer update
           fi
-        elif [[ "
-        project" == "${key}" ]]; then
+        elif [[ "create-project" == "${key}" ]]; then
           vvv_info " * Running composer create-project ${value} in ${folder}"
           noroot composer create-project "${value}" .
         else


### PR DESCRIPTION
As it says on the tin; it appears there is a typo in the `provision-site.sh` to enable composer create-project to work properly when specified in the `config/config.yml`.

I noticed this issue experimenting with VVV as a development environment for [Grav](https://getgrav.org/) after using the [Drupal setup in the documentation](https://varyingvagrantvagrants.org/docs/en-US/adding-a-new-site/#drupal) as a template.
```yaml
sites:
  # Grav Vanilla Site
  vanillagrav:
    skip_provisioning: false
    description: "Grav Site"
    repo: https://github.com/Varying-Vagrant-Vagrants/custom-site-template.git
    nginx_upstream: php74
    folders:
      public_html:
        composer:
          create-project: getgrav/grav
    hosts:
      - grav.test
    custom:
      wp_type: none
```

I didn't update the changelog to ensure I didn't cause an unnecessary merge conflict.

## Checks

<!--  Have you: -->
* [x] I've updated the changelog.
* [x] I've tested this PR with **Vagrant v2.2.19** and **VirtualBox v6.1.30r148432** on **Ubuntu 20.04.3 LTS**
* [x] This PR is for the `develop` branch not the `stable` branch.
* [x] This PR is complete and ready for review.
