### PR TITLE
MariaDB APT fix

### DIFF
--- a/provision/core/vvv/provision.sh
+++ b/provision/core/vvv/provision.sh
@@ -8,9 +8,6 @@ function vvv_register_packages() {
     python-pip
     python-setuptools
 
-    # remove mysql-common to ensure mariadb installation works
-    mysql-common
-
     # remove nodesource js etc we have nvm for that
     nodejs
   )


### PR DESCRIPTION
Ref: https://github.com/Varying-Vagrant-Vagrants/VVV/issues/2525

So the pinning of mariadb packages wasn't fixing the problem and investigating a bit is that we remove mysql-common but is required by mariadb to put aliases for mysql (and it is in the mariadb repository).
Removing that line let everything works with no problem.

## Checks

<!--  Have you: -->
* [ ] I've updated the changelog.
* [x] I've tested this PR
* [x] This PR is for the `develop` branch not the `stable` branch.
* [x] This PR is complete and ready for review.
