### PR TITLE
Adjust wp cli package updating so it doesn't fail the provisioner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ permalink: /docs/en-US/changelog/
 
 # Changelog
 
+## 3.10 ( 2022 TBD )
+
+### Enhancements
+
+### Bug Fixes
+
+* WP CLI package update failures now fail gracefully instead of stopping a provision ( #2601 )
+
 ## 3.9.1 ( 2022 April 13th )
 
 ### Enhancements

--- a/provision/core/wp-cli/provision.sh
+++ b/provision/core/wp-cli/provision.sh
@@ -49,8 +49,11 @@ function wp_cli_setup() {
 
   if [ "${VVV_DOCKER}" != 1 ]; then
     vvv_info " * [WP-CLI]: Updating packages"
-    noroot wp package update
-    vvv_info " * [WP-CLI]: Package updates completed"
+    if noroot wp package update; then
+      vvv_info " * [WP-CLI]: Package updates completed"
+    else
+      vvv_warn " ! [WP-CLI]: Package update did not complete, wp package update exited with a bad error code ${?}"
+    fi
   fi
 
   vvv_success " * [WP-CLI]: WP CLI setup completed"


### PR DESCRIPTION
Related to #2600, this doesn't fix WP CLI Doctor updating, but it means the provisioner will continue to run so it's a soft failure rather than a hard failure

## Checks

<!--  Have you: -->
* [x] I've updated the changelog.
* [ ] I've tested this PR
* [x] This PR is for the `develop` branch not the `stable` branch.
* [x] This PR is complete and ready for review.
