### PR TITLE
Improve db scripts

### DIFF
--- a/config/homebin/db_backup
+++ b/config/homebin/db_backup
@@ -53,7 +53,7 @@ ext=".sql"
 if [[ "${gzip}" == "True" ]]; then
     ext=".sql.gz"
 fi
-count=0
+count=1
 for db in "${databases[@]}"
 do
     OUTPUT=$(printf "<info>   - %2s/%s Backing up </info><b>%-23s</b><info> to </info><b>'database/backups/%s${ext}'</b>" "${count}" "${#databases[@]}" "'${db}'" "${db}")

--- a/config/homebin/db_backup
+++ b/config/homebin/db_backup
@@ -4,6 +4,7 @@
 # are imported automatically during an initial provision if
 # the databases exist per the import-sql.sh process.
 set -eo pipefail
+set -u
 
 trap 'rm -rf $TMPFIFODIR' EXIT; TMPFIFODIR=$(mktemp -d); mkfifo $TMPFIFODIR/dbnames
 

--- a/config/homebin/db_backup
+++ b/config/homebin/db_backup
@@ -35,7 +35,7 @@ while read db_name; do
     done
 
     if [ ${skip} == "true" ]; then
-        vvv_info "   - skipped <b>${db_name}</b>" && continue;
+        vvv_info "   - excluded <b>${db_name}</b>" && continue;
     fi
 
     # don't back up databases with no tables

--- a/config/homebin/db_backup
+++ b/config/homebin/db_backup
@@ -24,6 +24,7 @@ do
     [ "${db_name}" == "mysql" ] && vvv_info "   - skipped <b>${db_name}</b>" && continue;
     [ "${db_name}" == "information_schema" ] && vvv_info "   - skipped <b>${db_name}</b>" && continue;
     [ "${db_name}" == "performance_schema" ] && vvv_info "   - skipped <b>${db_name}</b>" && continue;
+    [ "${db_name}" == "sys" ] && vvv_info "   - skipped <b>${db_name}</b>" && continue;
     [ "${db_name}" == "test" ] && vvv_info "   - skipped ${db_name}" && continue;
     [ "${db_name}" == "wordpress_unit_tests" ] && vvv_info "   - skipped <b>${db_name}</b>" && continue;
 

--- a/config/homebin/db_backup
+++ b/config/homebin/db_backup
@@ -16,10 +16,8 @@ gzip=$(get_config_value "general.db_backup.gzip")
 exclude_list=$(get_config_values "general.db_backup.exclude")
 
 vvv_info " * Fetching Database names"
-mysql --user="root" --password="root" -e 'show databases' | \
-grep -v -F "Database" > $TMPFIFODIR/dbnames &
-while read db_name
-do
+mysql -e 'show databases' | grep -v -F "Database" > $TMPFIFODIR/dbnames &
+while read db_name; do
     # skip these databases
     [ "${db_name}" == "mysql" ] && vvv_info "   - skipped <b>${db_name}</b>" && continue;
     [ "${db_name}" == "information_schema" ] && vvv_info "   - skipped <b>${db_name}</b>" && continue;
@@ -41,7 +39,7 @@ do
 
     # don't back up databases with no tables
     mysql_cmd="SHOW TABLES FROM \`${db_name}\`" # Required to support hyphens in database names
-    db_exist=$(mysql -u root -proot --skip-column-names -e "${mysql_cmd}")
+    db_exist=$(mysql --skip-column-names -e "${mysql_cmd}")
     if [ "$?" == "0" ]; then
         if [ "" == "${db_exist}" ]; then
             vvv_info "   - skipped <b>${db_name}</b><info>, no tables in database to back up</info>" && continue;
@@ -60,9 +58,9 @@ do
     OUTPUT=$(printf "<info>   - %2s/%s Backing up </info><b>%-23s</b><info> to </info><b>'database/backups/%s${ext}'</b>" "${count}" "${#databases[@]}" "'${db}'" "${db}")
     vvv_output "${OUTPUT}"
     if [[ "${gzip}" == "True" ]]; then
-      mysqldump -uroot -proot "${db}" | gzip > "/srv/database/backups/${db}.sql.gz"
+      mysqldump "${db}" | gzip > "/srv/database/backups/${db}.sql.gz"
     else
-      mysqldump -uroot -proot "${db}" > "/srv/database/backups/${db}.sql";
+      mysqldump "${db}" > "/srv/database/backups/${db}.sql";
     fi
     let "count=count+1"
 done

--- a/config/homebin/db_restore
+++ b/config/homebin/db_restore
@@ -1,4 +1,4 @@
 #!/bin/bash
 #
 # Restore individual SQL files for each database.
-/srv/database/import-sql.sh
+. /srv/database/import-sql.sh

--- a/database/sql/import-sql.sh
+++ b/database/sql/import-sql.sh
@@ -17,6 +17,8 @@
 # through {vvv-dir}/database/data
 #
 # Let's begin...
+set -eo pipefail
+set -u
 
 source /srv/provision/provision-helpers.sh
 

--- a/database/sql/import-sql.sh
+++ b/database/sql/import-sql.sh
@@ -123,8 +123,8 @@ then
 			fi
 		done
 
-		mysql -u root --password=root -e "CREATE DATABASE IF NOT EXISTS \`${db_name}\`"
-		mysql -u root --password=root -e "GRANT ALL PRIVILEGES ON \`${db_name}\`.* TO wp@localhost IDENTIFIED BY 'wp';"
+		mysql -e "CREATE DATABASE IF NOT EXISTS \`${db_name}\`"
+		mysql -e "GRANT ALL PRIVILEGES ON \`${db_name}\`.* TO wp@localhost IDENTIFIED BY 'wp';"
 
 		[ "${db_name}" == "wordpress_unit_tests" ] && continue;
 
@@ -133,7 +133,7 @@ then
 		fi
 
 		mysql_cmd="SHOW TABLES FROM \`${db_name}\`" # Required to support hyphens in database names
-		db_exist=$(mysql -u root -proot --skip-column-names -e "${mysql_cmd}")
+		db_exist=$(mysql --skip-column-names -e "${mysql_cmd}")
 		if [ "$?" != "0" ]
 		then
 			vvv_error " * Error - Create the <b>${db_name}</b><error> database via init-custom.sql before attempting import"
@@ -141,9 +141,9 @@ then
 			if [ "" == "${db_exist}" ]; then
 				vvv_info " * Importing <b>${db_name}</b><info> from <b>${file}</b>"
 				if [ "${file: -3}" == ".gz" ]; then
-					gunzip < "${file}" | mysql -u root -proot "${db_name}"
+					gunzip < "${file}" | mysql "${db_name}"
 				else
-					mysql -u root -proot "${db_name}" < "${file}"
+					mysql "${db_name}" < "${file}"
 				fi
 				vvv_success " * Import of <b>'${db_name}'</b><success> successful</success>"
 			else

--- a/database/sql/import-sql.sh
+++ b/database/sql/import-sql.sh
@@ -96,6 +96,7 @@ then
 		[ "${db_name}" == "mysql" ] && continue;
 		[ "${db_name}" == "information_schema" ] && continue;
 		[ "${db_name}" == "performance_schema" ] && continue;
+		[ "${db_name}" == "sys" ] && continue;
 		[ "${db_name}" == "test" ] && continue;
 
 		if [ "1" == "${FORCE_RESTORE}" ]; then

--- a/provision/core/mariadb/provision.sh
+++ b/provision/core/mariadb/provision.sh
@@ -106,6 +106,10 @@ function mysql_setup() {
   cp -f "/srv/provision/core/mariadb/config/my.cnf" "/etc/mysql/my.cnf"
   vvv_info " * Copied /srv/provision/core/mariadb/config/my.cnf               to /etc/mysql/my.cnf"
 
+  cp -f  "/srv/provision/core/mariadb/config/root-my.cnf" "/root/.my.cnf"
+  chmod 0644 "/root/.my.cnf"
+  vvv_info " * Copied /srv/provision/core/mariadb/config/root-my.cnf          to /root/.my.cnf"
+
   cp -f  "/srv/provision/core/mariadb/config/root-my.cnf" "/home/vagrant/.my.cnf"
   chmod 0644 "/home/vagrant/.my.cnf"
   vvv_info " * Copied /srv/provision/core/mariadb/config/root-my.cnf          to /home/vagrant/.my.cnf"

--- a/provision/core/mariadb/provision.sh
+++ b/provision/core/mariadb/provision.sh
@@ -73,7 +73,7 @@ function check_mysql_root_password() {
       plugin='mysql_native_password';
 SQL
 )
-  root_matches=$(mysql -u root --password=root -s -N -e "${sql}")
+  root_matches=$(mysql -u root -proot -s -N -e "${sql}")
   if [[ $? -eq 0 && $root_matches == "1" ]]; then
     # mysql connected and the SQL above matched
     vvv_success " * The database root password is the expected value"


### PR DESCRIPTION
This is a _backport from the port_ I've made of this scripts from VVV into a docker solution we're currently using (and I intend to slowly port back to VVV).

Basically allows to:

### Allow to restore specific databases with `db_restore`

By running `db_restore db_name_1 db_name_2` you can only restore specific databases only.

### Force restoration when running `db_restore`

This allows to run `db_restore --force` or `db_restore -f` to delete all databases being restored before restoring them. Allows to easily force restore to a dump. Most useful in conjunction with specific databases usage

### Minor other improvements

* Skip `sys` database when backing up or restoring.
* Root user now also has .my.cnf file in their home dir which grants mysql default user password (root / root).
* Due to the above, all mysql commands run in provisioners do not require user and password. Removed.
* When backing up, count should start at 1 (not 0)
* Normalized wording of exclude/skip on the restore script.

Didn't test this myself on VVV (because i cannot run it right now). Will see how the provisioner goes, but none of these changes should be breaking.

Once we agree if this is to be merged, I'll update the CHANGELOG.md file.

## Checks

<!--  Have you: -->
* [ ] I've updated the changelog.
* [ ] I've tested this PR
* [ ] This PR is for the `develop` branch not the `stable` branch.
* [ ] This PR is complete and ready for review.
