### PR TITLE
Disable gcrypt hardware optimization as we are a VM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ permalink: /docs/en-US/changelog/
 
 * WP CLI package update failures now fail gracefully instead of stopping a provision ( #2601 )
 * Fixed an edge case updating NVM via git ( #2604 )
+* Disable hardware support for gcrypt to avoid bad VirtualBox implementations ( #2609 )
 
 ## 3.9.1 ( 2022 April 13th )
 

--- a/provision/core/vvv/provision.sh
+++ b/provision/core/vvv/provision.sh
@@ -133,6 +133,8 @@ function apt_hash_missmatch_fix() {
     vvv_info " * Copying /srv/provision/core/vvv/apt-conf-d/99hashmismatch to /etc/apt/apt.conf.d/99hashmismatch"
     cp -f "/srv/provision/core/vvv/apt-conf-d/99hashmismatch" "/etc/apt/apt.conf.d/99hashmismatch"
   fi
+
+  # Avoid bad hardware implementations that interfere with gcrypt by disabling hardware support
   # reference https://askubuntu.com/a/1242739
   mkdir /etc/gcrypt
   echo all >> /etc/gcrypt/hwf.deny

--- a/provision/core/vvv/provision.sh
+++ b/provision/core/vvv/provision.sh
@@ -133,6 +133,9 @@ function apt_hash_missmatch_fix() {
     vvv_info " * Copying /srv/provision/core/vvv/apt-conf-d/99hashmismatch to /etc/apt/apt.conf.d/99hashmismatch"
     cp -f "/srv/provision/core/vvv/apt-conf-d/99hashmismatch" "/etc/apt/apt.conf.d/99hashmismatch"
   fi
+  # reference https://askubuntu.com/a/1242739
+  mkdir /etc/gcrypt
+  echo all >> /etc/gcrypt/hwf.deny
 }
 export -f apt_hash_missmatch_fix
 vvv_add_hook init apt_hash_missmatch_fix


### PR DESCRIPTION
This fix an issue with hash mismatch as disable the hardware optimization for hash calculation and use the software version that works always.

<!-- what does it add/fix/change/remove? Bonus points for screenshots if it's pretty! -->

## Checks

<!--  Have you: -->
* [x] I've updated the changelog.
* [x] I've tested this PR
* [x] This PR is for the `develop` branch not the `stable` branch.
* [x] This PR is complete and ready for review.
