### PR TITLE
PHPCS composer plugin allow

### DIFF
--- a/provision/core/phpcs/composer.json
+++ b/provision/core/phpcs/composer.json
@@ -12,9 +12,14 @@
     "issues": "https://github.com/Varying-Vagrant-Vagrants/VVV/issues/"
   },
   "require": {
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",
     "automattic/vipwpcs": "^2.3.3",
     "phpcompatibility/php-compatibility": "^9.3.5",
     "phpcompatibility/phpcompatibility-wp": "^2.1.3"
+  },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   }
 }


### PR DESCRIPTION
fix an allow plugins issue in PHPCS provisioning that will cause issues in July

<!-- what does it add/fix/change/remove? Bonus points for screenshots if it's pretty! -->

## Checks

<!--  Have you: -->
* [ ] I've updated the changelog.
* [ ] I've tested this PR
* [x] This PR is for the `develop` branch not the `stable` branch.
* [ ] This PR is complete and ready for review.
