### PR TITLE
Fix #2634 - adding full path to vvv_restore_php_default in provision-site.sh

### DIFF
--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -575,6 +575,6 @@ if [ "${SUCCESS}" -ne "0" ]; then
   exit 1
 fi
 
-vvv_restore_php_default
+/srv/config/homebin/vvv_restore_php_default
 
 provisioner_success


### PR DESCRIPTION
This PR adds the full path to the vvv_restore_php_default script because it is not in the path when the script is executed.

## Checks

* [ ] I've updated the changelog.
* [X] I've tested this PR
* [X] This PR is for the `develop` branch not the `stable` branch.
* [X] This PR is complete and ready for review.
