### PR TITLE
Fixing faulty Vagrant plugin check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ permalink: /docs/en-US/changelog/
 
 ### Bug Fixes
 
-* ....
+* Fixed faulty Vagrant plugin check.
+
 
 ## 3.10.1 ( 2022 September 10th )
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -851,29 +851,26 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # located in the www/ directory and in config/config.yml.
   #
 
-  if Vagrant.has_plugin?('vagrant-goodhosts')
+  if config.vagrant.plugins.include? 'vagrant-goodhosts'
     config.goodhosts.aliases = vvv_config['hosts']
     config.goodhosts.remove_on_suspend = true
-  elsif Vagrant.has_plugin?('vagrant-hostsmanager')
+  elsif config.vagrant.plugins.include? 'vagrant-hostsmanager'
     config.hostmanager.aliases = vvv_config['hosts']
     config.hostmanager.enabled = true
     config.hostmanager.manage_host = true
     config.hostmanager.manage_guest = true
     config.hostmanager.ignore_private_ip = false
     config.hostmanager.include_offline = true
-  elsif Vagrant.has_plugin?('vagrant-hostsupdater')
+  elsif config.vagrant.plugins.include? 'vagrant-hostsupdater'
     # Pass the found host names to the hostsupdater plugin so it can perform magic.
     config.hostsupdater.aliases = vvv_config['hosts']
     config.hostsupdater.remove_on_suspend = true
-  else
-    show_check = true if %w[up halt resume suspend status provision reload].include? ARGV[0]
-    if show_check
-      puts ""
-      puts " X ! There is no hosts file vagrant plugin installed!"
-      puts " X You need the vagrant-goodhosts plugin (or HostManager/ HostsUpdater ) for domains to work in the browser"
-      puts " X Run 'vagrant plugin install --local' to fix this."
-      puts ""
-    end
+  elsif %w[up halt resume suspend status provision reload].include? ARGV[0]
+    puts ""
+    puts " X ! There is no hosts file vagrant plugin installed!"
+    puts " X You need the vagrant-goodhosts plugin (or HostManager/ HostsUpdater ) for domains to work in the browser"
+    puts " X Run 'vagrant plugin install --local' to fix this."
+    puts ""
   end
 
   # Vagrant Triggers


### PR DESCRIPTION
This replaces some `Vagrant.has_plugin?` checks  in the Vagrantfile with `config.vagrant.plugins.include?` as the latter is not available when the `Vagrantfile` is run in version 2.1.4 and newer of Vagrant.

There are other `Vagrant.has_plugin?` calls in the Vagrant file, but they don't seem to affect things in the same way. I can mend that in a separate PR, but I am not sure about the effectiveness, even if `config.vagrant.plugins.include?` seems more reliable.

See also: https://github.com/hashicorp/vagrant/issues/10161

<!-- what does it add/fix/change/remove? Bonus points for screenshots if it's pretty! -->

## Checks

<!--  Have you: -->
* [x] I've updated the changelog.
* [x] I've tested this PR
* [x] This PR is for the `develop` branch not the `stable` branch.
* [x] This PR is complete and ready for review.
