### PR TITLE
Fix setting git rebase pull config value for non-root users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ permalink: /docs/en-US/changelog/
 * Sites that do not have a provisioner set will have a logs folder created for Nginx logs,and a public_html folder with Nginx rules for WordPress or other PHP applications. The user is responsible for creating a database and installing/placing a site.
 * Simplified PHPCS installation bin dir setting ( #2648 )
 * Virtualbox users running `sudo vagrant` commands now get a warning
+* Fixed setting of git rebase config for the vagrant nonroot user ( #2658 )
 
 ### Bug Fixes
 

--- a/provision/core/git/provision.sh
+++ b/provision/core/git/provision.sh
@@ -54,5 +54,9 @@ function git_after_packages() {
     vvv_info " * Git hasn't been told how to merge branches, setting pull.rebase false for the merge strategy"
     git config --global pull.rebase false
   fi
+  if ! noroot git config --global pull.rebase; then
+    vvv_info " * Git hasn't been told how to merge branches, setting pull.rebase false for the merge strategy"
+    noroot git config --global pull.rebase false
+  fi
 }
 vvv_add_hook after_packages git_after_packages


### PR DESCRIPTION
I had switched to another branch for extension testing and realised we handle git asking how to merge for root but not nonroot, and it halted provisioning

## Checks

<!--  Have you: -->
* [x] I've updated the changelog.
* [x] I've tested this PR
* [x] This PR is for the `develop` branch not the `stable` branch.
* [x] This PR is complete and ready for review.
