### PR TITLE
Use ubuntu 20 for workflows

### DIFF
--- a/.github/workflows/vvv-provisioning.yml
+++ b/.github/workflows/vvv-provisioning.yml
@@ -15,7 +15,7 @@ jobs:
   on-docker:
     name: Docker Provisioner
     # The type of runner that the job will run on
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -113,7 +113,7 @@ jobs:
   on-stable:
     name: Stable Reprovision
     # The type of runner that the job will run on
-    runs-on: macos-10.15
+    runs-on: macos-11
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -147,7 +147,7 @@ jobs:
   on-develop:
     name: Develop Reprovision
     # The type of runner that the job will run on
-    runs-on: macos-10.15
+    runs-on: macos-11
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -181,7 +181,7 @@ jobs:
   on-clean:
     name: Clean Provision
     # The type of runner that the job will run on
-    runs-on: macos-10.15
+    runs-on: macos-11
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/vvv-provisioning.yml
+++ b/.github/workflows/vvv-provisioning.yml
@@ -14,7 +14,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   on-docker:
-    name: Docker Provisioner
+    name: Ubuntu 20 Docker Provisioner
     # The type of runner that the job will run on
     runs-on: ubuntu-20.04
 
@@ -112,7 +112,7 @@ jobs:
 
   # This workflow contains a single job called "build"
   on-stable:
-    name: Stable Reprovision
+    name: MacOS 10.15 Stable Reprovision
     # The type of runner that the job will run on
     runs-on: macos-10.15
 
@@ -154,7 +154,7 @@ jobs:
           path: "${{ github.workspace }}/log"
 
   on-develop:
-    name: Develop Reprovision
+    name: MacOS 10.15 Develop Reprovision
     # The type of runner that the job will run on
     runs-on: macos-10.15
 
@@ -197,7 +197,7 @@ jobs:
           path: "${{ github.workspace }}/log"
 
   on-clean:
-    name: Clean Provision
+    name: MacOS 10.15 Clean Provision
     # The type of runner that the job will run on
     runs-on: macos-10.15
 

--- a/.github/workflows/vvv-provisioning.yml
+++ b/.github/workflows/vvv-provisioning.yml
@@ -1,14 +1,15 @@
-# This is a basic workflow to help you get started with Actions
-
 name: VVV Provisioning
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the develop branch
 on:
   push:
-    branches: [ develop ]
+    branches:
+      - develop
   pull_request:
-    branches: [ develop, stable ]
+    branches:
+      - develop
+      - stable
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -113,7 +114,7 @@ jobs:
   on-stable:
     name: Stable Reprovision
     # The type of runner that the job will run on
-    runs-on: macos-11
+    runs-on: macos-10.15
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -121,6 +122,14 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: stable
+
+      - name: Cache Vagrant boxes
+        uses: actions/cache@v2
+        with:
+          path: ~/.vagrant.d/boxes
+          key: ${{ runner.os }}-vagrant-${{ hashFiles('Vagrantfile') }}
+          restore-keys: |
+            ${{ runner.os }}-vagrant-
 
       - name: install goodhosts
         run: vagrant plugin install --local
@@ -147,7 +156,7 @@ jobs:
   on-develop:
     name: Develop Reprovision
     # The type of runner that the job will run on
-    runs-on: macos-11
+    runs-on: macos-10.15
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -155,6 +164,15 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: develop
+
+      - name: Cache Vagrant boxes
+        uses: actions/cache@v2
+        with:
+          path: ~/.vagrant.d/boxes
+          key: ${{ runner.os }}-vagrant-${{ hashFiles('Vagrantfile') }}
+          restore-keys: |
+            ${{ runner.os }}-vagrant-
+
 
       - name: install goodhosts
         run: vagrant plugin install --local
@@ -181,12 +199,20 @@ jobs:
   on-clean:
     name: Clean Provision
     # The type of runner that the job will run on
-    runs-on: macos-11
+    runs-on: macos-10.15
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+
+      - name: Cache Vagrant boxes
+        uses: actions/cache@v2
+        with:
+          path: ~/.vagrant.d/boxes
+          key: ${{ runner.os }}-vagrant-${{ hashFiles('Vagrantfile') }}
+          restore-keys: |
+            ${{ runner.os }}-vagrant-
 
       - name: install goodhosts
         run: vagrant plugin install --local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ permalink: /docs/en-US/changelog/
 ### Bug Fixes
 
 * Fixed a vagrantfile error on Arm when the vagrant-parallels plugin is missing ( #2670 )
+* Github action fixes for composer and an upgrade to Ubuntu 20 ( #2677 )
 
 ## 3.11.2 ( 2023 May 8th )
 

--- a/provision/core/composer/provision.sh
+++ b/provision/core/composer/provision.sh
@@ -37,7 +37,7 @@ function composer_setup() {
       return 1
     fi
   else
-    vvv_info " * [Composer]: Already installed"
+    vvv_info " * [Composer]: Already installed: $(composer --version)"
   fi
 
   vvv_info " * [Composer]: Making sure the Composer cache is not owned by root"
@@ -46,6 +46,11 @@ function composer_setup() {
   mkdir -p /root/.local/share/composer
   chown -R vagrant:www-data "${COMPOSER_DATA_DIR}"
   chown -R vagrant:www-data /root/.local/share/composer
+
+  # Github runner fixes
+  if [ -d "/home/runner/.config/composer/" ]; then
+    chown -R vagrant:www-data /home/runner/.config/composer/
+  fi
 
   vvv_info " * [Composer]: Checking for GitHub tokens"
   if github_token=$(shyaml get-value -q "general.github_token" < "${VVV_CONFIG}"); then

--- a/provision/core/phpcs/provision.sh
+++ b/provision/core/phpcs/provision.sh
@@ -6,6 +6,7 @@ set -eo pipefail
 function php_codesniff_setup() {
   export COMPOSER_ALLOW_SUPERUSER=1
   export COMPOSER_NO_INTERACTION=1
+  export COMPOSER_RUNTIME_ENV="vagrant"
 
   if [[ -f "/srv/www/phpcs/CodeSniffer.conf" ]]; then
     vvv_info " * [PHPCS]: Removing the old PHPCS setup"


### PR DESCRIPTION
Ubuntu 18 is deprecated and gives warnings, also cache vagrant boxes

## Checks

<!--  Have you: -->
* [x] I've updated the changelog.
* [ ] I've tested this PR
* [x] This PR is for the `develop` branch not the `stable` branch.
* [x] This PR is complete and ready for review.
