### PR TITLE
VVV specific dockerfile, gets built on provision

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,60 @@
+FROM ubuntu:20.04
+
+LABEL maintainer="vvv@tomjn.com"
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# install common dependencies
+# ca-certificates usually needed by vagrant to download stuff
+# some others are just attempt to speed the provision up
+RUN apt-get update && apt-get install -y \
+    locales \
+    curl \
+    lsb-release \
+    openssh-server \
+    sudo \
+    python \
+    ca-certificates \
+    gnupg2 \
+    software-properties-common \
+    apt-utils \
+    iputils-ping \
+    net-tools \
+    nano \
+    less
+
+## in case ca-cert already installed, force upgrade ( to get latest chain )
+RUN apt-get upgrade -y ca-certificates
+
+# ensure we have the en_US.UTF-8 locale available
+RUN locale-gen en_US.UTF-8
+
+# setup the vagrant user
+RUN if ! getent passwd vagrant; then useradd -d /home/vagrant -m -s /bin/bash vagrant; fi \
+    && echo vagrant:vagrant | chpasswd \
+    && echo 'vagrant ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
+    && mkdir -p /etc/sudoers.d \
+    && echo 'vagrant ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/vagrant \
+    && chmod 0440 /etc/sudoers.d/vagrant
+
+# add the vagrant insecure public key
+RUN mkdir -p /home/vagrant/.ssh \
+    && chmod 0700 /home/vagrant/.ssh \
+    && wget --no-check-certificate \
+      https://raw.githubusercontent.com/hashicorp/vagrant/main/keys/vagrant.pub \
+      -O /home/vagrant/.ssh/authorized_keys \
+    && chmod 0600 /home/vagrant/.ssh/authorized_keys \
+    && chown -R vagrant /home/vagrant/.ssh
+
+# don't clean packages, we might be using vagrant-cachier
+RUN rm /etc/apt/apt.conf.d/docker-clean
+
+# create the privilege separation directory for sshd
+RUN mkdir -p /run/sshd
+
+# run sshd in the foreground
+CMD /usr/sbin/sshd -D \
+    -o UseDNS=no\
+    -o UsePAM=no\
+    -o PasswordAuthentication=yes\
+    -o PidFile=/tmp/sshd.pid

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -464,7 +464,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Docker use image.
   config.vm.provider :docker do |d, override|
-    d.image = 'pentatonicfunk/vagrant-ubuntu-base-images:20.04'
+    d.build_dir = "."
+    #d.image = 'vvvlocal/vvv-ubuntu-base:20.04'
     d.has_ssh = true
     d.ports =  [ "80:80" ] # HTTP
     d.ports += [ "443:443" ] # HTTPS


### PR DESCRIPTION
Moves the dockerfile from pentatonic funk over to VVV, this does centralise things here, though ideally we build this and put it up as an image with a VVV name. I also used `vvv@tomjn.com` but that's only slightly less problematic ( is it optional? ).

The other Q is, what can we put in here to save time during the main VVV provisioner that only docker can do? Do we need a compose file to setup Nginx/MariaDB containers and would that mean changing other parts of VVV to make that work? Would all `wp-config.php` files need to change on docker based setups?

## Checks

<!--  Have you: -->
* [ ] I've updated the changelog.
* [ ] I've tested this PR
* [ ] This PR is for the `develop` branch not the `stable` branch.
* [ ] This PR is complete and ready for review.
