### PR TITLE
Better PHP warnings and IP6 VM hostfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ permalink: /docs/en-US/changelog/
 * Switched the default PHP to v8.0 ( #2658 )
 * WP Coding standards v3 ( #2688 )
 * VIP Coding standards v3 ( #2688 )
+* Better error messages with links to docs when trying to use a PHP version that isn't installed ( #2689 )
+
+### Bug Fixes
+
+* The host file inside the VM was only adding sites with `127.0.0.1` addresses, now it adds the IPVv6 `::1` too ( #2689 )
 
 ## 3.12 ( 2023 August 3rd )
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ permalink: /docs/en-US/changelog/
 * WP Coding standards v3 ( #2688 )
 * VIP Coding standards v3 ( #2688 )
 * Better error messages with links to docs when trying to use a PHP version that isn't installed ( #2689 )
+* Opted out of Dotnet package telemetry ( #2689 )
 
 ### Bug Fixes
 

--- a/provision/core/env/homedir/.bash_profile
+++ b/provision/core/env/homedir/.bash_profile
@@ -14,6 +14,9 @@ if [ -n "$BASH_VERSION" ]; then
     fi
 fi
 
+# Telemetry opt outs
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+
 export PATH="$PATH:/srv/www/phpcs/bin"
 
 # set variable identifying the chroot you work in (used in the prompt below)

--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -62,10 +62,14 @@ vvv_validate_site_php_version() {
     vvv_warn " ! Warning: PHP version defined is using a wrong format: '${SITE_PHP}' with length '${#SITE_PHP}'"
     vvv_warn "            If you are trying to use a more specific version of PHP such as 7.4.1 or 7.4.0 you"
     vvv_warn "            need to be less specific and use 7.4"
+    vvv_warn " !          https://varyingvagrantvagrants.org/docs/en-US/adding-a-new-site/changing-php-version/"
   fi
 
   if [[ ! -e "/usr/bin/php${SITE_PHP}" ]]; then
-    vvv_warn " ! Warning: Chosen PHP version doesn't exist in this environment: '${SITE_PHP}' looking for '/usr/bin/php${SITE_PHP}'"
+    vvv_warn " ! Warning: The chosen PHP version doesn't exist in this environment: '${SITE_PHP}' looking for '/usr/bin/php${SITE_PHP}'"
+    vvv_warn " !          Did you forget to install it via config/config.yml? Add it to the extensions section as documented in the"
+    vvv_warn " !          changing PHP versions age on the VVV site, and re-provision:"
+    vvv_warn " !          https://varyingvagrantvagrants.org/docs/en-US/adding-a-new-site/changing-php-version/"
   fi
 }
 
@@ -228,7 +232,8 @@ function vvv_provision_hosts_file() {
     while IFS='' read -r line || [ -n "${line}" ]; do
       if [[ "#" != "${line:0:1}" ]]; then
         if [[ -z "$(grep -q "^127.0.0.1 ${line}$" /etc/hosts)" ]]; then
-          echo "127.0.0.1 $line # vvv-auto" >> "/etc/hosts"
+          echo "127.0.0.1 ${line} # vvv-auto" >> "/etc/hosts"
+          echo "::1 ${line} # vvv-auto" >> "/etc/hosts"
           echo "   - Added ${line} from ${HOSTFILE}"
         fi
       fi
@@ -273,6 +278,7 @@ function vvv_process_site_hosts() {
     for line in $hosts; do
       if [[ -z "$(grep -q "^127.0.0.1 ${line}$" /etc/hosts)" ]]; then
         echo "127.0.0.1 ${line} # vvv-auto" >> "/etc/hosts"
+        echo "::1 ${line} # vvv-auto" >> "/etc/hosts"
         echo "   - Added ${line} from ${VVV_CONFIG}"
       fi
     done


### PR DESCRIPTION
When VVV detects the requested PHP version is missing, remind the user they need to install it themselves via config.yml and link out to the PHP changing doc

Also add `::1` too when updating the VMs hosts file


## Checks

<!--  Have you: -->
* [x] I've updated the changelog.
* [ ] I've tested this PR
* [x] This PR is for the `develop` branch not the `stable` branch.
* [ ] This PR is complete and ready for review.
