### PR TITLE
Switch to Node 20 to match WP core defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ permalink: /docs/en-US/changelog/
 
 ### Enhancements
 
-* Switched the default PHP from v7.4 to v8.2 and default Node from v14 to v16 ( #2690 )
+* Switched the default PHP from v7.4 to v8.2 and ~default Node from v14 to v16~ ( #2690 )
+* Use Node 20 as the default version to match WP and Gutenberg ( #2696 )
 * WP Coding standards v3 ( #2688 )
 * VIP Coding standards v3 ( #2688 )
 * Better error messages with links to docs when trying to use a PHP version that isn't installed ( #2689 )

--- a/provision/core/node-nvm/provision.sh
+++ b/provision/core/node-nvm/provision.sh
@@ -53,9 +53,9 @@ function vvv_nvm_setup() {
 
   fi
 
-  vvv_info " - Installing Node 16 via nvm"
-  nvm install 16
-  nvm use 16
+  vvv_info " - Installing Node 20 via nvm"
+  nvm install 20
+  nvm use 20
 
   vvv_info " - Ensuring vagrant user owns its own nvm folder"
   chown -R vagrant:vagrant /home/vagrant/.nvm/


### PR DESCRIPTION
WP Core and Gutenberg use Node 20, and have nvm rc files if that changes:

 - https://github.com/WordPress/gutenberg/blob/trunk/.nvmrc
 - https://github.com/WordPress/wordpress-develop/blob/trunk/.nvmrc

## Checks

<!--  Have you: -->
* [x] I've updated the changelog.
* [ ] I've tested this PR
* [x] This PR is for the `develop` branch not the `stable` branch.
* [x] This PR is complete and ready for review.
