### PR TITLE
Missing dashboard message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ permalink: /docs/en-US/changelog/
 
 ## 3.14 ( 2024 TBA )
 
+### Enhancements
+
+* VVV now shows a missing dashboard page with help when `www/default/index.php` is accidentally deleted instead of a HTTP forbidden error ( #2714 )
+
 ## 3.13.1 ( 2024 June 16th )
 
 ### Enhancements

--- a/provision/core/nginx/config/sites/default.conf
+++ b/provision/core/nginx/config/sites/default.conf
@@ -32,10 +32,17 @@ server {
         root /usr/share/nginx/html;
     }
 
+    location = /nodashboard.html {
+        ssi on;
+        internal;
+        auth_basic off;
+        root /usr/share/nginx/html;
+    }
+
     include /etc/nginx/custom-dashboard-extensions/*.conf;
 
     location / {
-        index index.php;
+        index index.php /nodashboard.html;
         try_files $uri $uri/ /index.php$is_args$args;
     }
 

--- a/provision/core/nginx/default-pages/nodashboard.html
+++ b/provision/core/nginx/default-pages/nodashboard.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<title>Dashboard file missings</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<style>
+			html, body {
+				height: 100%;
+			}
+			body {
+				width: 90%;
+				margin: 0 auto;
+				font-family: Tahoma, Verdana, Arial, sans-serif;
+				background-color: #2b303b;
+				display: flex;
+				justify-content: center;
+				align-items: center;
+				align-content : center;
+				color: #c0c5ce;
+				height:100%;
+			}
+			pre, code {
+				background: #2b303b;
+				border-radius: 4px;
+				border: 1px solid #4f5b66;
+			}
+			code {
+				color: #a3be8c;
+				padding: .1em .2em;
+			}
+			main {
+				display: flex;
+				border-radius: 4px;
+				padding: 1.5em;
+				box-sizing: border-box;
+				margin: 1em 20px;
+				max-width: 800px;
+			}
+			.right {
+				align-self: center;
+				font-size:120px;
+				padding-left:60px;
+			}
+			h1 {
+				color:white;
+			}
+			a {
+				color: #ebcb8b;
+				background: #ebcb8b11;
+			}
+			a:hover {
+				background: #ebcb8b;
+				color: #ebcb8b11;
+			}
+			a:focus, a:active {
+				color: magenta;
+			}
+			@media only screen and (max-width: 601px) {
+				main {
+					flex-direction: column;
+					margin: 1em 0;
+					padding: 0;
+				}
+				.right {
+					order: 0;
+					padding-left: 0;
+				}
+				.left {
+					order: 1;
+				}
+			}
+		</style>
+	</head>
+<body>
+	<main>
+		<div class="left">
+			<h1>The Dashboard Loader file is missing!</h1>
+			<p>It looks like <code>www/default/index.php</code> is missing!</p>
+      <p>This file and the <code>www/default</code> folder are needed for dashboard and other parts of VVV to function. This includes tools such as xdebug info/phpmyadmin/etc.</p>
+      <p><strong>You can fix this and restore the <code>www/default</code> folder with <code>git checkout www/default</code>.</strong></p>
+		</div>
+		<div class="right">
+			🚩
+		</div>
+	</main>
+</body>
+</html>

--- a/provision/provision-dashboard.sh
+++ b/provision/provision-dashboard.sh
@@ -6,6 +6,11 @@ REPO=$1
 BRANCH=${2:-master}
 DIR="/srv/www/default/dashboard"
 
+if [[ ! -f /srv/www/default/index.php ]]; then
+  vvv_warn " ! The dashboard loader index.hp file is missing!"
+  vvv_warn " Without this neither the default or custom dashboard will load, and you will get a HTTP 401 forbidden message. If you deleted your www folder, restore the www/default folder to fix this, 'git checkout www/default' might fix this for you."
+fi
+
 if [[ false != "dashboard" && false != "${REPO}" ]]; then
   noroot mkdir -p "${DIR}"
   # Clone or pull the resources repository


### PR DESCRIPTION
If a user deletes the entire `www` folder and the dashboard with it there'll be no `www/default/index.php` loader file and Nginx will show a forbidden HTTP error when visiting `vvv.test`.

Instead it now shows this:

![Screenshot 2024-06-18 at 15 18 03](https://github.com/Varying-Vagrant-Vagrants/VVV/assets/58855/75d5a125-c536-40d3-aa7a-bb51108bcf7e)

Making it clear what happened and suggesting a solution.

## Checks

<!--  Have you: -->
* [x] I've updated the changelog.
* [x] I've tested this PR
* [x] This PR is for the `develop` branch not the `stable` branch.
* [x] This PR is complete and ready for review.
