### PR TITLE
Check if docker is present before defaulting to it on Arm64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ permalink: /docs/en-US/changelog/
 
 ## 3.14 ( 2024 TBA )
 
+### Bug Fixes
+
+* VVV will check if Docker is installed before defaulting to it on Arm64/Apple Silicon ( #2715 )
+
 ## 3.13.1 ( 2024 June 16th )
 
 ### Enhancements

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -40,6 +40,21 @@ def sudo_warnings
   # exit
 end
 
+
+def vvv_is_docker_present()
+  VagrantPlugins::DockerProvider::Driver.new.execute("docker", "version")
+  return true
+rescue Vagrant::Errors::CommandUnavailable
+  return false
+end
+
+def vvv_is_parallels_present()
+  VagrantPlugins::DockerProvider::Driver.new.execute("prctl", "version")
+  return true
+rescue Vagrant::Errors::CommandUnavailable
+  return false
+end
+
 vagrant_dir = __dir__
 show_logo = false
 branch_c = "\033[38;5;6m" # 111m"
@@ -214,12 +229,16 @@ vvv_config['general'] = {} unless vvv_config['general'].is_a? Hash
 
 defaults = {}
 defaults['memory'] = 2048
-defaults['cores'] = 1
+defaults['cores'] = 2
 defaults['provider'] = 'virtualbox'
 
-# if Arm default to docker
+# if Arm default to docker then parallels
 if Etc.uname[:version].include? 'ARM64'
-  defaults['provider'] = 'docker'
+  if vvv_is_docker_present()
+    defaults['provider'] = 'docker'
+  elsif vvv_is_parallels_present
+    defaults['provider'] = 'parallels'
+  end
 end
 
 # This should rarely be overridden, so it's not included in the config/default-config.yml file.


### PR DESCRIPTION
Dont just default to docker, check if it is installed first then use parallels if thats present.

This is mainly affecting users on Arm who bought Parallels but never set it in `config.yml` who now updated to `3.13.1` which changed the default to docker on Arm

## Checks

<!--  Have you: -->
* [x] I've updated the changelog.
* [x] I've tested this PR
* [x] This PR is for the `develop` branch not the `stable` branch.
* [x] This PR is complete and ready for review.
