### PR TITLE
Check for parallels instead of docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ permalink: /docs/en-US/changelog/
 
 ## 3.14 ( 2024 ETA )
 
+### Bug Fixes
+
+* VVV will check if Parallels is installed before defaulting to docker on Arm64/Apple Silicon due to issues with Docker detection ( #2722 )
 
 ## 3.13.2 ( 2024 July 19th )
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,6 +45,7 @@ def vvv_is_docker_present()
   if `docker version`
     return true
   end
+  return false
 end
 
 def vvv_is_parallels_present()
@@ -230,10 +231,10 @@ defaults['provider'] = 'virtualbox'
 
 # if Arm default to docker then parallels
 if Etc.uname[:version].include? 'ARM64'
-  if vvv_is_docker_present()
-    defaults['provider'] = 'docker'
-  else
+  if vvv_is_parallels_present()
     defaults['provider'] = 'parallels'
+  else
+    defaults['provider'] = 'docker'
   end
 end
 


### PR DESCRIPTION
So it turns out if you do:

```
`command goes here`
```

And the command doesn't exist, then it will generate a syntax error rather than reporting a failure.

It also turns out that if we use `system()` to bypass this it works but the output is dumped into the terminal and the only way to avoid it is to pipe to dev/null which isn't an option on Windows.

So instead we ask vagrant if parallels is installed

## Checks

<!--  Have you: -->
* [ ] I've updated the changelog.
* [x] I've tested this PR
* [x] This PR is for the `develop` branch not the `stable` branch.
* [x] This PR is complete and ready for review.
