### PR TITLE
Prevent VM_DIR and VVV_PATH_TO_SITE having trailing slashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ permalink: /docs/en-US/changelog/
 
 * VVV will check if Parallels is installed before defaulting to docker on Arm64/Apple Silicon due to issues with Docker detection ( #2722 )
 * Switched from Rackspace to Starburst services for MariaDB mirrors ( #2728 )
+* Fixed an issue with trailing slashes and site provisioners introduced in an earlier version (#2731)
 
 ## 3.13.2 ( 2024 July 19th )
 

--- a/provision/provision-site.sh
+++ b/provision/provision-site.sh
@@ -17,7 +17,7 @@ SITE=$1
 SITE_ESCAPED="${SITE//./\\.}"
 REPO=$2
 BRANCH=$3
-VM_DIR=$4
+VM_DIR="${4%/}" # No trailing strings
 SKIP_PROVISIONING=$5
 NGINX_UPSTREAM=$6
 VVV_PATH_TO_SITE=${VM_DIR} # used in site templates
@@ -167,7 +167,7 @@ function vvv_provision_site_nginx_config() {
 
   local NCONFIG
   NCONFIG=$(vvv_search_replace_in_file "${SITE_NGINX_FILE}" "{vvv_path_to_folder}" "${DIR}")
-  NCONFIG=$(vvv_search_replace "${NCONFIG}" "{vvv_path_to_site}" "${VM_DIR}/")
+  NCONFIG=$(vvv_search_replace "${NCONFIG}" "{vvv_path_to_site}" "${VM_DIR}")
   NCONFIG=$(vvv_search_replace "${NCONFIG}" "{vvv_site_name}" "${SITE_NAME}")
   NCONFIG=$(vvv_search_replace "${NCONFIG}" "{vvv_hosts}" "${VVV_HOSTS}")
 


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/Varying-Vagrant-Vagrants/VVV/commit/abea1f59de627e5276178d730ce1e61c74f6b10a

Related to https://github.com/Varying-Vagrant-Vagrants/VVV/issues/2729

## Checks

<!--  Have you: -->
* [x] I've updated the changelog.
* [ ] I've tested this PR
* [x] This PR is for the `develop` branch not the `stable` branch.
* [x] This PR is complete and ready for review.
