### PR TITLE
Adds an issue autolabelling workflow

### DIFF
--- a/.github/issue-labels.yml
+++ b/.github/issue-labels.yml
@@ -1,0 +1,19 @@
+# .github/issues.yml
+"type:bug":
+  match:
+    - "error"
+    - "fail"
+    - "bug"
+    - "crash"
+  description: "Indicates a bug or error in the system."
+
+"provider:parallels":
+  match:
+    - "parallels"
+  description: "Parallels provider"
+
+"provider:virtualbox":
+  match:
+    - "virtualbox"
+    - "oracle"
+  description: "Virtualbox provider"

--- a/.github/workflows/autolabel.yml
+++ b/.github/workflows/autolabel.yml
@@ -1,0 +1,16 @@
+name: Auto Labelling Checks
+on:
+  [pull_request]
+
+jobs:
+  build:
+    name: AutoLabelling
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply Labels on Issues
+        if: github.event_name == 'issues'
+        uses: offensive-vk/auto-label@v8
+        with:
+          create-labels: true # Optional, defaults to true
+          auth-token: ${{ github.token }} # Optional, defaults to ${{ secrets.GITHUB_TOKEN }}
+          issue-config: .github/issue-labels.yml # Required, path to the issue configuration file.

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,7 +1,7 @@
 name: Syntax Checking and Linting
 on:
   [pull_request]
-    
+
 jobs:
   build:
     name: Linting


### PR DESCRIPTION
Some basic issue auto-labelling, e.g. to auto-tag the parallels provider

## Checks

<!--  Have you: -->
* [ ] I've updated the changelog.
* [ ] I've tested this PR
* [ ] This PR is for the `develop` branch not the `stable` branch.
* [ ] This PR is complete and ready for review.
