### PR TITLE
Add Ubuntu 26.04 (Resolute Raccoon) support

### DIFF
--- a/.github/workflows/eol.yml
+++ b/.github/workflows/eol.yml
@@ -20,6 +20,6 @@ jobs:
         uses: sindrel/endoflife-github-action@v1.0.0
         with:
           product: ubuntu
-          version: 24.04
+          version: 26.04
           fail_on_eol: true
           fail_days_left: 90

--- a/.github/workflows/vvv-provisioning.yml
+++ b/.github/workflows/vvv-provisioning.yml
@@ -122,3 +122,102 @@ jobs:
         with:
           name: logs-on-docker
           path: "${{ github.workspace }}/log"
+
+  on-docker-26:
+    name: Ubuntu 26 Docker Provisioner
+    runs-on: ubuntu-latest
+    container: pentatonicfunk/vagrant-ubuntu-base-images:26.04
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create Vagrant Like Environment
+        run: |
+          sudo DEBIAN_FRONTEND=noninteractive apt-get -yq autoclean
+
+          # Create vagrant group if it doesn't exist
+          if ! getent group vagrant >/dev/null; then
+            echo "Creating vagrant group"
+            sudo groupadd -g 2000 vagrant
+          fi
+
+          # Create vagrant user if it doesn't exist
+          if ! id -u vagrant >/dev/null 2>&1; then
+            echo "Creating vagrant user"
+            sudo useradd -u 2000 -g vagrant -m vagrant
+          fi
+
+          # Create /srv if it doesn't exist
+          if [ ! -d "/srv" ]; then
+            echo "Preparing /srv"
+            sudo mkdir -p /srv
+            sudo chown vagrant:vagrant /srv
+          fi
+
+          echo "Copying files.."
+
+          # copy files provided by vagrant
+          sudo cp -f "$GITHUB_WORKSPACE/config/default-config.yml" "$GITHUB_WORKSPACE/config/config.yml"
+          sudo cp -f "$GITHUB_WORKSPACE/version" "/home/vagrant/version"
+
+          sudo mkdir -p /srv/certificates
+          sudo cp -rT "$GITHUB_WORKSPACE/www" /srv/certificates
+          sudo chown -R vagrant:vagrant /srv/certificates
+
+          sudo mkdir -p /srv/www
+          sudo cp -rT "$GITHUB_WORKSPACE/www" /srv/www
+          sudo chown -R vagrant:vagrant /srv/www
+
+          echo "Preparing Symlinks..."
+
+          # vvv_symlink function to sumulate synced folders
+          vvv_symlink() {
+            if [ ! -d "${1}" ]; then
+              sudo mkdir -p "${1}"
+            fi
+            sudo chown -R vagrant:vagrant "${1}"
+            sudo ln -sf "${1}" "${2}"
+          }
+
+          # make folders available
+          vvv_symlink "$GITHUB_WORKSPACE/database/sql" "/srv/database"
+          vvv_symlink "$GITHUB_WORKSPACE/config" "/srv/config"
+          vvv_symlink "$GITHUB_WORKSPACE/provision" "/srv/provision"
+
+      - name: Run provison-pre.sh
+        run: sudo bash -c '. "/srv/provision/tests/provisioners.sh" && pre_hook'
+
+      - name: Run provision.sh
+        run: sudo bash -c '. "/srv/provision/tests/provisioners.sh" && provision_main'
+
+      - name: Run provision-tools.sh
+        run: sudo bash -c '. "/srv/provision/tests/provisioners.sh" && provision_tools'
+
+      - name: Run provison-dashboard.sh
+        run: sudo bash -c '. "/srv/provision/tests/provisioners.sh" && provision_dashboard'
+
+      - name: Run provision-extension-source.sh
+        run: sudo bash -c '. "/srv/provision/tests/provisioners.sh" && provision_extension_sources'
+
+      - name: Run provision-extension.sh
+        run: sudo bash -c '. "/srv/provision/tests/provisioners.sh" && provision_extensions'
+
+      - name: Run provision-site.sh
+        run: sudo bash -c '. "/srv/provision/tests/provisioners.sh" && provision_sites'
+
+      - name: Run provision-post.sh
+        run: sudo bash -c '. "/srv/provision/tests/provisioners.sh" && post_hook'
+
+      - name: Prepare Output
+        if: ${{ always() }}
+        run: |
+          MYUID=$(id -u -n)
+          MYGID=$(id -g -n)
+          sudo chown -R $MYUID:$MYGID "$GITHUB_WORKSPACE/log"
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: logs-on-docker-26
+          path: "${{ github.workspace }}/log"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ permalink: /docs/en-US/changelog/
 
 * Added the `stow`, `tmux`, `neovim`, `fzf`, `httpie`, and `ghostscript` apt packages ( #2771 )
 * Adds the `yq` package ( #2774 )
+* Switched the base box to Ubuntu 26.04 LTS (Resolute Raccoon) for newly created VMs; existing 24.04 VMs are unaffected until destroyed and recreated ( #2796 )
 * Added automated GitHub Actions workflow to check and update GPG keys monthly
 * **Improved provisioning reliability and error handling**
   - Added network retry logic with exponential backoff to handle transient connection issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ permalink: /docs/en-US/changelog/
 ### Maintenance
 
 * Regenerated Sequel Pro/Sequel Ace SPF file. ( #2773 )
+* Replaced ntp/ntpdate with chrony for VM clock sync on all releases (ntp/ntpdate were removed in Ubuntu 26.04); the old packages are purged on reprovision ( #2796 )
 * Modernized GPG key management for PHP, Nginx, and MariaDB
   - Keys downloaded from official sources: Ubuntu keyserver, nginx.org, MariaDB
   - Added comprehensive error handling and validation

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -479,32 +479,32 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # The Parallels Provider uses a different naming scheme.
   config.vm.provider :parallels do |_v, override|
-    override.vm.box = 'bento/ubuntu-24.04'
+    override.vm.box = 'bento/ubuntu-26.04'
 
     # Pin the arm64 version of the box to a specific version we know has an arm build.
     if Etc.uname[:version].include? 'ARM64'
-      override.vm.box_version = "202502.21.0"
+      override.vm.box_version = "202606.01.0"
     end
   end
 
   # The VMware Desktop Provider uses a different naming scheme.
   config.vm.provider :vmware_desktop do |v, override|
-    override.vm.box = 'bento/ubuntu-24.04'
+    override.vm.box = 'bento/ubuntu-26.04'
     v.gui = false
   end
 
   # Hyper-V uses a different base box.
   config.vm.provider :hyperv do |_v, override|
-    # override.vm.box = 'bento/ubuntu-24.04'
-    # At the time of writing no Bento box existed for Ubuntu 2024 with the Hyper-V provider,
-    # so we're using the most popular box available in the box catalog as a temporary measure.
+    # No Bento box ships a Hyper-V build for Ubuntu 24.04 or 26.04, and no
+    # gusztavvargadr 26.04 box exists yet, so Hyper-V stays on 24.04 for now.
+    # Revisit when a 26.04 Hyper-V box becomes available.
     override.vm.box = "gusztavvargadr/ubuntu-server-2404-lts"
     override.vm.box_version = ">=2404.0.2503"
   end
 
   # Docker use image.
   config.vm.provider :docker do |d, override|
-    d.image = 'pentatonicfunk/vagrant-ubuntu-base-images:24.04'
+    d.image = 'pentatonicfunk/vagrant-ubuntu-base-images:26.04'
     d.has_ssh = true
     d.ports =  [ "80:80" ] # HTTP
     d.ports += [ "443:443" ] # HTTPS
@@ -523,7 +523,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # This box is provided by Bento boxes via vagrantcloud.com and is a nicely sized
     # box containing the Ubuntu LTS release. Once this box is downloaded
     # to your host computer, it is cached for future use under the specified box name.
-    override.vm.box = 'bento/ubuntu-24.04'
+    override.vm.box = 'bento/ubuntu-26.04'
 
     # If we're at a contributor day, switch the base box to the prebuilt one
     if defined? vvv_config['vm_config']['wordcamp_contributor_day_box']

--- a/provision/core/git/sources-ubuntu-resolute.list
+++ b/provision/core/git/sources-ubuntu-resolute.list
@@ -1,0 +1,3 @@
+# TODO: switch suite to resolute once git-lfs publishes a resolute (Ubuntu 26.04) suite; using noble until then
+deb [signed-by=/etc/apt/keyrings/github_git-lfs-archive-keyring.gpg] https://packagecloud.io/github/git-lfs/ubuntu/ noble main
+deb-src [signed-by=/etc/apt/keyrings/github_git-lfs-archive-keyring.gpg] https://packagecloud.io/github/git-lfs/ubuntu/ noble main

--- a/provision/core/mariadb/sources-ubuntu-resolute.list
+++ b/provision/core/mariadb/sources-ubuntu-resolute.list
@@ -1,0 +1,7 @@
+# MariaDB 10.11 repository list
+# https://mariadb.org/download/
+# deb.mariadb.org is a dynamic mirror if your preferred mirror goes offline. See https://mariadb.org/mirrorbits/ for details.
+# TODO: switch suite to resolute once MariaDB publishes a resolute (Ubuntu 26.04) suite; using noble until then
+# deb [signed-by=/etc/apt/keyrings/mariadb-keyring.pgp] https://deb.mariadb.org/10.11/ubuntu noble main
+deb [signed-by=/etc/apt/keyrings/mariadb-keyring.pgp] http://mariadb.mirrors.ovh.net/MariaDB/repo/10.11/ubuntu noble main
+# deb-src [signed-by=/etc/apt/keyrings/mariadb-keyring.pgp] http://mariadb.mirrors.ovh.net/MariaDB/repo/10.11/ubuntu noble main

--- a/provision/core/nginx/sources-ubuntu-resolute.list
+++ b/provision/core/nginx/sources-ubuntu-resolute.list
@@ -1,0 +1,3 @@
+# Provides Nginx mainline
+deb [signed-by=/etc/apt/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/mainline/ubuntu/ resolute nginx
+deb-src [signed-by=/etc/apt/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/mainline/ubuntu/ resolute nginx

--- a/provision/core/php/sources-ubuntu-resolute.list
+++ b/provision/core/php/sources-ubuntu-resolute.list
@@ -1,0 +1,3 @@
+# Provides PHP
+# TODO: switch suite to resolute once ondrej/php publishes a resolute (Ubuntu 26.04) suite; using noble until then
+deb [signed-by=/etc/apt/keyrings/php.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu noble main

--- a/provision/core/vvv/provision.sh
+++ b/provision/core/vvv/provision.sh
@@ -90,11 +90,14 @@ function vvv_register_apt_sources() {
 vvv_add_hook register_apt_sources vvv_register_apt_sources 0
 
 function vvv_register_keys() {
-  if ! vvv_apt_keys_has 'Varying Vagrant Vagrants'; then
-    # Apply the VVV signing key
-    vvv_info " * Applying the VVV mirror signing key..."
-    apt-key add /srv/provision/core/vvv/apt-keys/varying-vagrant-vagrants_keyserver_ubuntu.key
-  fi
+  # The VVV mirror this key signs is only enabled on older releases (e.g. bionic),
+  # which still rely on the legacy apt-key trust store. apt-key was removed in
+  # Ubuntu 26.04+, so skip cleanly where it no longer exists.
+  command -v apt-key >/dev/null 2>&1 || return 0
+  # apt-key add is idempotent, so re-importing on each run is harmless and lets
+  # VVV core avoid depending on the legacy vvv_apt_keys_has() lookup.
+  vvv_info " * Applying the VVV mirror signing key..."
+  apt-key add /srv/provision/core/vvv/apt-keys/varying-vagrant-vagrants_keyserver_ubuntu.key
 }
 vvv_add_hook register_apt_sources vvv_register_keys 0
 

--- a/provision/core/vvv/provision.sh
+++ b/provision/core/vvv/provision.sh
@@ -65,15 +65,11 @@ function vvv_register_packages() {
     stow
     fzf
     tmux
-  )
 
-  # Time sync: ntp/ntpdate were removed in Ubuntu 26.04. Use chrony there
-  # (the modern NTP daemon, in main), and the classic packages on older releases.
-  if dpkg --compare-versions "$(lsb_release -sr)" ge "26.04"; then
-    VVV_PACKAGE_LIST+=( chrony )
-  else
-    VVV_PACKAGE_LIST+=( ntp ntpdate )
-  fi
+    # chrony keeps the VM clock current (replaces the older ntp/ntpdate,
+    # which were removed in Ubuntu 26.04)
+    chrony
+  )
 }
 vvv_add_hook register_apt_packages vvv_register_packages 0
 
@@ -116,6 +112,16 @@ function vvv_before_packages() {
 }
 vvv_add_hook before_packages vvv_before_packages 0
 
+function vvv_remove_legacy_ntp() {
+  # chrony now keeps the clock current on every release. Remove ntp/ntpdate if a
+  # previous provision installed them, so two NTP daemons don't contend for UDP/123.
+  if vvv_is_apt_pkg_installed "ntp" || vvv_is_apt_pkg_installed "ntpdate"; then
+    vvv_info " * Removing legacy ntp/ntpdate packages (replaced by chrony)"
+    apt-get --yes purge ntp ntpdate
+  fi
+}
+vvv_add_hook before_packages vvv_remove_legacy_ntp 0
+
 function shyaml_setup() {
   # Shyaml
   #
@@ -144,18 +150,13 @@ export -f shyaml_setup
 
 vvv_add_hook after_packages shyaml_setup 0
 
-function vvv_ntp_restart() {
+function vvv_chrony_restart() {
   if [ ! -f /.dockerenv ]; then
-    # ntp was replaced by chrony on Ubuntu 26.04+
-    if dpkg --compare-versions "$(lsb_release -sr)" ge "26.04"; then
-      service chrony restart
-    else
-      service ntp restart
-    fi
+    service chrony restart
   fi
 }
 
-vvv_add_hook services_restart vvv_ntp_restart
+vvv_add_hook services_restart vvv_chrony_restart
 
 function cleanup_vvv(){
   if test -f "/tmp/hosts"; then

--- a/provision/core/vvv/provision.sh
+++ b/provision/core/vvv/provision.sh
@@ -49,10 +49,6 @@ function vvv_register_packages() {
     neovim
     nano
 
-    # ntp service to keep clock current
-    ntp
-    ntpdate
-
     # Required for i18n tools
     gettext
 
@@ -70,6 +66,14 @@ function vvv_register_packages() {
     fzf
     tmux
   )
+
+  # Time sync: ntp/ntpdate were removed in Ubuntu 26.04. Use chrony there
+  # (the modern NTP daemon, in main), and the classic packages on older releases.
+  if dpkg --compare-versions "$(lsb_release -sr)" ge "26.04"; then
+    VVV_PACKAGE_LIST+=( chrony )
+  else
+    VVV_PACKAGE_LIST+=( ntp ntpdate )
+  fi
 }
 vvv_add_hook register_apt_packages vvv_register_packages 0
 
@@ -142,7 +146,12 @@ vvv_add_hook after_packages shyaml_setup 0
 
 function vvv_ntp_restart() {
   if [ ! -f /.dockerenv ]; then
-    service ntp restart
+    # ntp was replaced by chrony on Ubuntu 26.04+
+    if dpkg --compare-versions "$(lsb_release -sr)" ge "26.04"; then
+      service chrony restart
+    else
+      service ntp restart
+    fi
   fi
 }
 

--- a/provision/core/vvv/sources-ubuntu-resolute.list
+++ b/provision/core/vvv/sources-ubuntu-resolute.list
@@ -1,0 +1,3 @@
+# VVV mirror packages
+# deb https://ppa.launchpadcontent.net/varying-vagrant-vagrants/php/ubuntu resolute main
+# deb-src https://ppa.launchpadcontent.net/varying-vagrant-vagrants/php/ubuntu resolute main

--- a/provision/provision-helpers.sh
+++ b/provision/provision-helpers.sh
@@ -325,6 +325,8 @@ export -f noroot
 #
 # @arg $1 string a key string to test
 function vvv_apt_keys_has() {
+  # apt-key was removed in Ubuntu 26.04+; treat keys as not-present when it is gone.
+  command -v apt-key >/dev/null 2>&1 || return 1
   local keys=$( apt-key list )
   if [[ ! $( echo "${keys}" | grep "$1") ]]; then
     return 1
@@ -683,9 +685,12 @@ vvv_apt_update() {
   fi
 
   vvv_info " * Updating apt keys"
-  if ! apt-key update -y; then
-    vvv_error " * Updating apt keys failed"
-    return 1
+  # apt-key was removed in Ubuntu 26.04+; only refresh the legacy keyring where it exists.
+  if command -v apt-key >/dev/null 2>&1; then
+    if ! apt-key update -y; then
+      vvv_error " * Updating apt keys failed"
+      return 1
+    fi
   fi
 
   # Update all of the package references before installing anything


### PR DESCRIPTION
## What

Moves newly created VVV VMs to **Ubuntu 26.04 LTS (Resolute Raccoon)** while keeping existing 24.04 (`noble`) VMs provisioning unchanged.

### Box selection (Vagrantfile)
- VirtualBox, VMware, Parallels → `bento/ubuntu-26.04` (Parallels arm64 pin → `202606.01.0`, verified to ship an arm64 build)
- Docker → `pentatonicfunk/vagrant-ubuntu-base-images:26.04`
- **Hyper-V stays on 24.04** — no bento Hyper-V build and no `gusztavvargadr` 2604 box exists yet; comment updated. A reprovisioned Hyper-V VM stays on the fully-supported noble path.

### Provisioner (additive — nothing removed)
- New `sources-ubuntu-resolute.list` for `vvv`, `php`, `nginx`, `git`, `mariadb`.
- Upstream `resolute` suites were probed: **nginx** publishes one (used); **ondrej PHP, git-lfs, MariaDB 10.11** do not yet (404), so those use the `noble` suite with a `TODO` until they do. noble-built `.deb`s run on 26.04.
- All existing `noble`/`jammy`/`focal`/`bionic` source files are untouched, so reprovisioning an existing VM keeps working.

### CI / workflows
- `eol.yml` now tracks `26.04`.
- Added a **non-blocking** `on-docker-26` provisioning job (`continue-on-error: true`, `:26.04` image) alongside the existing 24.04 job, as the real-run signal for resolute. May be red while the 26.04 Docker image is unverified (#2795).

## Why "replace box, add provisioner support"

Reprovisioning does not re-image in place — only `destroy` + recreate pulls the new box. So the provisioner must run on both noble and resolute; only the box strings move.

## MongoDB

MongoDB lives in the separate **vvv-utilities** repo and has its own PR: Varying-Vagrant-Vagrants/vvv-utilities#118 (adds `resolute` to the codename map).

## Testing
- `ruby -c Vagrantfile` → Syntax OK; both workflow YAMLs valid.
- No older-codename source files modified or deleted; `ge "24.04"` provisioner guard intact.
- Full resolute run pending via the new CI job.

Related: #2795