### PR TITLE
Migrate PHP packages to the unified packages.sury.org repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ permalink: /docs/en-US/changelog/
 ### Maintenance
 
 * Regenerated Sequel Pro/Sequel Ace SPF file. ( #2773 )
+* Migrated PHP packages for supported releases (jammy/noble/resolute) from the Launchpad PPA to the unified packages.sury.org repository, ahead of the PPA being retired ( #2797 )
 * Modernized GPG key management for PHP, Nginx, and MariaDB
   - Keys downloaded from official sources: Ubuntu keyserver, nginx.org, MariaDB
   - Added comprehensive error handling and validation

--- a/provision/core/php/ondrej-ppa-pin
+++ b/provision/core/php/ondrej-ppa-pin
@@ -1,4 +1,8 @@
 Package: *
+Pin: release o=deb.sury.org
+Pin-Priority: 1001
+
+Package: *
 Pin: release o=LP-PPA-ondrej-php
 Pin-Priority: 1001
 

--- a/provision/core/php/provision.sh
+++ b/provision/core/php/provision.sh
@@ -67,14 +67,51 @@ function php_register_apt_packages() {
 vvv_add_hook register_apt_packages php_register_apt_packages
 
 
-function php_register_apt_keys() {
-  # Modern approach: copy GPG key to keyrings directory
-  # This replaces the deprecated apt-key add method
-  # IMPORTANT: Keys must be installed BEFORE sources are registered
-  #
-  # NOTE: We use Launchpad PPA keys because packages.sury.org blocks VM/automated access
-  # with HTTP 418. The Launchpad PPA mirrors the same packages with different signing keys.
+# @description Install the deb.sury.org archive keyring used by the unified
+# packages.sury.org PHP repository. Used on supported Ubuntu releases (jammy,
+# noble, resolute); see https://github.com/Varying-Vagrant-Vagrants/VVV/issues/2797
+function php_install_sury_keyring() {
+  local KEYRING="/usr/share/keyrings/debsuryorg-archive-keyring.gpg"
+  if [ -f "${KEYRING}" ]; then
+    vvv_info " * deb.sury.org archive keyring already installed"
+    return 0
+  fi
 
+  vvv_info " * Installing the deb.sury.org archive keyring"
+  local TMP_DEB
+  TMP_DEB=$(mktemp --suffix=.deb) || {
+    vvv_error " ! Failed to create a temporary file for the sury keyring"
+    return 1
+  }
+  if curl -fsSL "https://packages.sury.org/debsuryorg-archive-keyring.deb" -o "${TMP_DEB}"; then
+    if dpkg -i "${TMP_DEB}"; then
+      rm -f "${TMP_DEB}"
+      vvv_success " * deb.sury.org archive keyring installed"
+    else
+      rm -f "${TMP_DEB}"
+      vvv_error " ! Failed to install the deb.sury.org archive keyring"
+      return 1
+    fi
+  else
+    rm -f "${TMP_DEB}"
+    vvv_error " ! Failed to download the deb.sury.org archive keyring"
+    return 1
+  fi
+}
+
+function php_register_apt_keys() {
+  # Supported Ubuntu releases use the unified packages.sury.org repository, which
+  # ships its own archive keyring. Older (EOL) releases fall through to the legacy
+  # Launchpad PPA key handling below.
+  # IMPORTANT: Keys must be installed BEFORE sources are registered
+  case "$(lsb_release -sc)" in
+    jammy|noble|resolute)
+      php_install_sury_keyring
+      return $?
+      ;;
+  esac
+
+  # --- Legacy Launchpad PPA key handling (EOL releases only) ---
   local DEST_KEY="/etc/apt/keyrings/php.gpg"
   local SOURCE_KEY="/srv/provision/core/php/apt-keys/php.gpg"
   local NEEDS_UPDATE=0

--- a/provision/core/php/sources-ubuntu-jammy.list
+++ b/provision/core/php/sources-ubuntu-jammy.list
@@ -1,2 +1,2 @@
-# Provides PHP
-deb [signed-by=/etc/apt/keyrings/php.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu jammy main
+# Provides PHP (unified deb.sury.org repository)
+deb [signed-by=/usr/share/keyrings/debsuryorg-archive-keyring.gpg] https://packages.sury.org/php/ jammy main

--- a/provision/core/php/sources-ubuntu-noble.list
+++ b/provision/core/php/sources-ubuntu-noble.list
@@ -1,2 +1,2 @@
-# Provides PHP
-deb [signed-by=/etc/apt/keyrings/php.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu noble main
+# Provides PHP (unified deb.sury.org repository)
+deb [signed-by=/usr/share/keyrings/debsuryorg-archive-keyring.gpg] https://packages.sury.org/php/ noble main


### PR DESCRIPTION
Draft — migrates PHP sourcing for currently-supported Ubuntu releases from the Launchpad `ppa:ondrej/php` to the unified **packages.sury.org** repo, ahead of the PPA being retired.

Closes #2797 (tracking).

## Why
The ondrej Launchpad PPA is being sunset (accelerated by the Launchpad DDoS); the maintainer is consolidating on `packages.sury.org`. See oerdnj/deb.sury.org#73.

## Scope: supported releases only
The unified repo serves **jammy (22.04), noble (24.04), resolute (26.04)** — confirmed via `dists/<codename>/Release`. It does **not** serve focal/bionic, because ondrej deletes packages once an Ubuntu release reaches EOL (true of the PPA too) — so those are already dead upstream and are left untouched here.

## Changes
- `sources-ubuntu-{jammy,noble}.list` → `deb [signed-by=/usr/share/keyrings/debsuryorg-archive-keyring.gpg] https://packages.sury.org/php/ <codename> main`
- `php_register_apt_keys` routes by codename: installs the official **deb.sury.org archive keyring** (`debsuryorg-archive-keyring.deb`) on jammy/noble/resolute; EOL releases fall through to the existing Launchpad key logic
- `ondrej-ppa-pin` pins the `deb.sury.org` origin alongside the legacy PPA origin
- Removed the stale "packages.sury.org blocks VMs with HTTP 418" comment (long obsolete; apt access to the repo returns 200)

## Validation
- The **Ubuntu 24 (noble) CI job is the real test** — it proves noble PHP installs cleanly from sury, and that GitHub Actions datacenter IPs aren't blocked.
- resolute's source file is handled in the Ubuntu 26 branch (#2796), which rebases onto this once merged.

## Notes / possible follow-ups
- The sury keyring is installed via the official `.deb` (downloaded at provision time). A shipped offline fallback key (as done for nginx/mariadb) could be added if desired.
- `network_check` in `provision-helpers.sh` still probes `ppa.launchpadcontent.net`; could add `packages.sury.org` as the supported-release critical host.